### PR TITLE
#37: use _execv in Orbiter_ng wrapper to pass command line arguments …

### DIFF
--- a/Src/Orbiter_ng/Orbiter_ng.cpp
+++ b/Src/Orbiter_ng/Orbiter_ng.cpp
@@ -6,8 +6,6 @@
 
 INT WINAPI WinMain (HINSTANCE hInstance, HINSTANCE, LPSTR strCmdLine, INT nCmdShow)
 {
-	const char *cmd = "modules\\server\\orbiter.exe";
-	char *args[1] = {NULL};
-	_execl(cmd, cmd, NULL);
-	return 0;
+	const char *cmd = "Modules\\Server\\Orbiter.exe";
+	return _execv(cmd, __argv);
 }


### PR DESCRIPTION
…through to orbiter server. Now also returns the server exit value.
closes #37