### PR TITLE
Check install in CI regardless of branch/bitness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,6 @@ jobs:
       working-directory: ${{ github.workspace }}/out/build
 
     - name: Install
-      if: ${{ github.ref == 'refs/heads/main' && matrix.architecture == 'x64' }}
       run: 'cmake --install . --prefix "${{ github.workspace }}\out\install"'
       working-directory: ${{ github.workspace }}/out/build
 


### PR DESCRIPTION
Check 'install' in addition to 'build' in PRs (to make sure situations like [this](https://github.com/orbitersim/orbiter/runs/3242215571) do not repeat)