### PR TITLE
Fix MFDtemplate and AscentMFD for x86 and x64 compatibility

### DIFF
--- a/Orbitersdk/samples/AscentMFD/AscentMFD.cpp
+++ b/Orbitersdk/samples/AscentMFD/AscentMFD.cpp
@@ -167,12 +167,12 @@ void AscentMFD::InitReferences (void)
 }
 
 // message parser
-int AscentMFD::MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
+OAPI_MSGTYPE AscentMFD::MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
 {
 	switch (msg) {
 	case OAPI_MSG_MFD_OPENEDEX: {
 		MFDMODEOPENSPEC *ospec = (MFDMODEOPENSPEC*)wparam;
-		return (int)(new AscentMFD (ospec->w, ospec->h, (VESSEL*)lparam));
+		return (OAPI_MSGTYPE)(new AscentMFD (ospec->w, ospec->h, (VESSEL*)lparam));
 		}
 	}
 	return 0;

--- a/Orbitersdk/samples/AscentMFD/AscentMFD.h
+++ b/Orbitersdk/samples/AscentMFD/AscentMFD.h
@@ -20,7 +20,7 @@ public:
 	void ReadStatus (FILEHANDLE scn);
 	void StoreStatus (void) const;
 	void RecallStatus (void);
-	static int MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
+	static OAPI_MSGTYPE MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
 
 private:
 	void InitReferences (void);

--- a/Orbitersdk/samples/MFDTemplate/MFDTemplate.cpp
+++ b/Orbitersdk/samples/MFDTemplate/MFDTemplate.cpp
@@ -104,13 +104,13 @@ bool MFDTemplate::Update (oapi::Sketchpad *skp)
 }
 
 // MFD message parser
-int MFDTemplate::MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
+OAPI_MSGTYPE MFDTemplate::MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
 {
 	switch (msg) {
 	case OAPI_MSG_MFD_OPENED:
 		// Our new MFD mode has been selected, so we create the MFD and
 		// return a pointer to it.
-		return (int)(new MFDTemplate (LOWORD(wparam), HIWORD(wparam), (VESSEL*)lparam));
+		return (OAPI_MSGTYPE)(new MFDTemplate (LOWORD(wparam), HIWORD(wparam), (VESSEL*)lparam));
 	}
 	return 0;
 }

--- a/Orbitersdk/samples/MFDTemplate/MFDTemplate.h
+++ b/Orbitersdk/samples/MFDTemplate/MFDTemplate.h
@@ -23,7 +23,7 @@ public:
 	char *ButtonLabel (int bt);
 	int ButtonMenu (const MFDBUTTONMENU **menu) const;
 	bool Update (oapi::Sketchpad *skp);
-	static int MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
+	static OAPI_MSGTYPE MsgProc (UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
 
 protected:
 	oapi::Font *font;


### PR DESCRIPTION
Fix MsgProc return type in examples to compile for both x86 and x64 platforms without breaking compatibility.

Mentioned in forum: https://www.orbiter-forum.com/threads/x64-development.40026/post-585380