### PR TITLE
Break into debugger on fatal assertion failures if running under debugger

### DIFF
--- a/OVP/D3D7Client/Log.h
+++ b/OVP/D3D7Client/Log.h
@@ -43,12 +43,12 @@ void LogOut_Obsolete (char *func, char *msg = 0);      // Write obsolete-functio
 void LogOut_Warning (const char *msg, ...);            // Write general warning to log file
 
 #ifdef _DEBUG
-#define dVERIFY(test) { if (FAILED(test)) { LogOut_Error (__FUNCTION__, __FILE__, __LINE__, "Assertion failure"); exit(1); }}
+#define dVERIFY(test) { if (FAILED(test)) { LogOut_Error (__FUNCTION__, __FILE__, __LINE__, "Assertion failure"); DebugBreak(); exit(1); }}
 #else
 #define dVERIFY(test) (test)
 #endif
 
-#define ASSERT(test) { if (!(test)) { LogOut_Error (__FUNCTION__, __FILE__, __LINE__, "Assertion failure"); exit(1); }}
+#define ASSERT(test) { if (!(test)) { LogOut_Error (__FUNCTION__, __FILE__, __LINE__, "Assertion failure"); DebugBreak(); exit(1); }}
 
 #define CHECKCWD(cwd,name) { char c[512]; _getcwd(c,512); if(strcmp(c,cwd)) { _chdir(cwd); sprintf (c,"CWD modified by module %s - Fixing.",name); LogOut_Warning(c); } }
 

--- a/Src/Orbiter/Log.h
+++ b/Src/Orbiter/Log.h
@@ -75,6 +75,7 @@ void LogOut_Location(const char* func, const char* file, int line);
 		LogOut_Error_End(); \
 		if(fatal) { \
 			LogOut(">>> TERMINATING <<<"); \
+			DebugBreak(); \
 			exit(1); \
 		} \
 	} \


### PR DESCRIPTION
If Orbiter is running under a debugger, a fatal assertion failure will break into the debugger so the developer can snoop around and debug why the assertion failure occurred.