### PR TITLE
#90: fixed uninitialised 'locked' parameter for module list entries.

### DIFF
--- a/Src/Orbiter/TabModule.cpp
+++ b/Src/Orbiter/TabModule.cpp
@@ -171,6 +171,7 @@ void ModuleTab::RefreshLists ()
 		rec->name[len] = '\0';
 		rec->info = 0;
 		rec->active = false;
+		rec->locked = false;
 
 		// check if module is set active in config
 		for (idx = pCfg->nactmod-1; idx >= 0; idx--)


### PR DESCRIPTION
closes #90 