### PR TITLE
#89: Ographics/D3D7Client::clbkVisEvent and VObject::clbkEvent: 

### DIFF
--- a/OVP/D3D7Client/D3D7Client.cpp
+++ b/OVP/D3D7Client/D3D7Client.cpp
@@ -762,7 +762,7 @@ bool D3D7Client::clbkGetRenderParam (DWORD prm, DWORD *value) const
 // ==============================================================
 // Responds to visual events
 
-int D3D7Client::clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, UINT context)
+int D3D7Client::clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, DWORD_PTR context)
 {
 	VisObject *vo = (VisObject*)vis;
 	vo->clbkEvent (msg, context);

--- a/OVP/D3D7Client/D3D7Client.h
+++ b/OVP/D3D7Client/D3D7Client.h
@@ -134,7 +134,7 @@ public:
 	 *   from the orbiter core and distributes them to the appropriate
 	 *   visual object.
 	 */
-	int clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, UINT context);
+	int clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, DWORD_PTR context);
 
 	/**
 	 * \brief Return a mesh handle for a visual, defined by its index
@@ -721,7 +721,7 @@ public:
 	 *   of certain events (e.g. adding and deleting meshes)
 	 * \note For currently supported event types, see \ref visevent.
 	 */
-	virtual void clbkEvent (DWORD event, UINT context) {}
+	virtual void clbkEvent (DWORD event, DWORD_PTR context) {}
 
 protected:
 	OBJHANDLE hObject;

--- a/OVP/D3D7Client/VVessel.cpp
+++ b/OVP/D3D7Client/VVessel.cpp
@@ -70,14 +70,14 @@ void vVessel::GlobalExit ()
 	}
 }
 
-void vVessel::clbkEvent (DWORD event, UINT context)
+void vVessel::clbkEvent (DWORD event, DWORD_PTR context)
 {
 	switch (event) {
 	case EVENT_VESSEL_INSMESH:
-		InsertMesh (context);
+		InsertMesh ((UINT)context);
 		break;
 	case EVENT_VESSEL_DELMESH:
-		DelMesh (context);
+		DelMesh ((UINT)context);
 		break;
 	case EVENT_VESSEL_MESHVISMODE:
 		// todo

--- a/OVP/D3D7Client/VVessel.h
+++ b/OVP/D3D7Client/VVessel.h
@@ -48,7 +48,7 @@ public:
 	static void GlobalInit (oapi::D3D7Client *gc);
 	static void GlobalExit ();
 
-	void clbkEvent (DWORD event, UINT context);
+	void clbkEvent (DWORD event, DWORD_PTR context);
 
 	virtual MESHHANDLE GetMesh (UINT idx);
 

--- a/Src/Orbiter/OGraphics.cpp
+++ b/Src/Orbiter/OGraphics.cpp
@@ -800,7 +800,7 @@ bool OrbiterGraphics::clbkGetRenderParam (DWORD prm, DWORD *value) const
 
 // =======================================================================
 
-int OrbiterGraphics::clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, UINT context)
+int OrbiterGraphics::clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, DWORD_PTR context)
 {
 	VObject *vo = (VObject*)vis;
 	vo->clbkEvent (msg, context);

--- a/Src/Orbiter/OGraphics.h
+++ b/Src/Orbiter/OGraphics.h
@@ -81,7 +81,7 @@ public:
 	LRESULT RenderWndProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	INT_PTR LaunchpadVideoWndProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-	int clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, UINT context);
+	int clbkVisEvent (OBJHANDLE hObj, VISHANDLE vis, DWORD msg, DWORD_PTR context);
 	MESHHANDLE clbkGetMesh (VISHANDLE vis, UINT idx);
 	int clbkGetMeshGroup (DEVMESHHANDLE hMesh, DWORD grpidx, GROUPREQUESTSPEC *grs);
 	int clbkEditMeshGroup (DEVMESHHANDLE hMesh, DWORD grpidx, GROUPEDITSPEC *ges);

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -3221,7 +3221,7 @@ void Vessel::ClearMeshes (bool retain_anim)
 	nmesh = 0;
 	mesh_crc = 0;
 	ScanMeshCaps();
-	BroadcastVisMsg (EVENT_VESSEL_DELMESH, (UINT)-1); // notify visual
+	BroadcastVisMsg (EVENT_VESSEL_DELMESH, (DWORD_PTR)((UINT)-1)); // notify visual
 }
 
 bool Vessel::ShiftMesh (UINT idx, const VECTOR3 &ofs)

--- a/Src/Orbiter/Vobject.h
+++ b/Src/Orbiter/Vobject.h
@@ -74,7 +74,7 @@ public:
 
 	inline const D3DMATRIX &MWorld() const { return mWorld; }
 
-	virtual void clbkEvent (DWORD msg, UINT content) {}
+	virtual void clbkEvent (DWORD msg, DWORD_PTR content) {}
 	// Notification of visual event (e.g. mesh addition/deletion)
 
 protected:

--- a/Src/Orbiter/Vvessel.cpp
+++ b/Src/Orbiter/Vvessel.cpp
@@ -107,13 +107,13 @@ void VVessel::DestroyDeviceObjects ()
 	}
 }
 
-void VVessel::clbkEvent (DWORD msg, UINT content)
+void VVessel::clbkEvent (DWORD msg, DWORD_PTR content)
 {
 	switch (msg) {
 	case EVENT_VESSEL_INSMESH: // insert mesh
-		InsertMesh (content);
-		ResetAnimations (content);
-		UpdateAnimations (content);
+		InsertMesh ((UINT)content);
+		ResetAnimations ((UINT)content);
+		UpdateAnimations ((UINT)content);
 		break;
 	case EVENT_VESSEL_DELMESH: // mesh deleted
 		if (content == (UINT)-1) { // clear all meshes

--- a/Src/Orbiter/Vvessel.h
+++ b/Src/Orbiter/Vvessel.h
@@ -30,7 +30,7 @@ public:
 	DWORD GetCaps () const { return VOCAPS_HASENGINES; }
 	const Vessel *GetVessel() const { return vessel; }
 
-	void clbkEvent (DWORD msg, UINT content);
+	void clbkEvent (DWORD msg, DWORD_PTR content);
 	void RegisterMeshes ();
 	void InsertMesh (UINT idx);
 	void DelMesh (UINT idx);


### PR DESCRIPTION
modified context pointer from UINT to DWORD_PTR to reflect interface change in GraphicsClient.
closes #89