### PR TITLE
93 console mode dialogs

### DIFF
--- a/Src/Orbiter/CMakeLists.txt
+++ b/Src/Orbiter/CMakeLists.txt
@@ -11,6 +11,7 @@ set(common_src
 	Camera.cpp
 	cmdline.cpp
 	Config.cpp
+	console_ng.cpp
 	ddeserver.cpp
 	Element.cpp
 	elevmgr.cpp

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -799,7 +799,7 @@ void Orbiter::FRecorder_Activate (bool active, const char *fname, bool append)
 	} else {
 		bRecord = false;
 	}
-	if (g_pane->MIBar()) g_pane->MIBar()->SetRecording(bRecord);
+	if (g_pane && g_pane->MIBar()) g_pane->MIBar()->SetRecording(bRecord);
 }
 
 // Save a system event

--- a/Src/Orbiter/Log.h
+++ b/Src/Orbiter/Log.h
@@ -9,11 +9,12 @@
 // comment the following line to suppress log file output
 #define GENERATE_LOG
 
+typedef void (*LogOutFunc)(const char* msg);
+
 // The following routines are for message output into a log file
 void InitLog (char *logfile, bool append);   // Set log file name and clear if exists
 void SetLogVerbosity (bool verbose);
-void SetConsole (bool active);        // Activate/deactivate console output
-void ConsoleOut (const char *msg);    // Write a message to the console
+void SetLogOutFunc(LogOutFunc func); // clone log output to a function
 void LogOut (const char *msg, ...);   // Write a message to the log file
 void LogOutVA(const char *format, va_list ap);
 void LogOutFine (const char *msg, ...);   // Write a message to the log file if fine-grain output enabled

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -855,6 +855,9 @@ HWND Orbiter::CreateRenderWindow (HWND parentWnd, Config *pCfg, const char *scen
 		Pause (TRUE);
 	}
 
+	if (m_pConsole)
+		m_pConsole->EchoIntro();
+
 	return hRenderWnd;
 }
 

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -23,6 +23,7 @@
 #include "D3d7util.h"
 #include "D3dmath.h"
 #include "Log.h"
+#include "console_ng.h"
 #include "State.h"
 #include "Astro.h"
 #include "Camera.h"
@@ -57,8 +58,7 @@
 #include "CSphereMgr.h"
 #include "VVessel.h"
 #include "ScreenNote.h"
-
-TextureManager  *g_texmanager = 0;
+TextureManager* g_texmanager = 0;
 #endif // INLINEGRAPHICS
 
 using namespace std;
@@ -87,7 +87,6 @@ TCHAR* CurrentScenario = "(Current state)";
 char ScenarioName[256] = "\0";
 // some global string resources
 
-char cConsoleCmd[1024] = "\0";
 char cwd[512];
 
 // =======================================================================
@@ -167,8 +166,6 @@ HRESULT ConfirmDevice (DDCAPS*, D3DDEVICEDESC7*);
 //LRESULT CALLBACK WndProc3D (HWND, UINT, WPARAM, LPARAM);
 INT_PTR CALLBACK BkMsgProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK CloseMsgProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-INT_PTR CALLBACK ServerDlgProc (HWND, UINT, WPARAM, LPARAM);
-DWORD WINAPI ConsoleInputProc (LPVOID);
 
 VOID    DestroyWorld ();
 bool    Select_Main (Select &sel);
@@ -317,6 +314,7 @@ Orbiter::Orbiter ()
 	pState          = NULL;
 	pMainDlg        = NULL;
 	pDlgMgr         = NULL;
+	m_pConsole      = NULL;
 	ddeserver       = NULL;
 	bFullscreen     = false;
 	viewW = viewH = viewBPP = 0;
@@ -330,10 +328,7 @@ Orbiter::Orbiter ()
 	NetClient       = NULL;
 #endif // NETCONNECT
 	hRenderWnd      = NULL;
-	hConsoleWnd     = NULL;
-	hServerWnd      = NULL;
 	hBk             = NULL;
-	hConsoleTh      = NULL;
 	hScnInterp      = NULL;
 	snote_playback  = NULL;
 	nsnote          = 0;
@@ -511,7 +506,6 @@ VOID Orbiter::CloseApp (bool fast_shutdown)
 		if (memstat) delete memstat;
 		if (pConfig)  delete pConfig;
 		if (pMainDlg) delete pMainDlg;
-		if (hServerWnd) DestroyWindow (hServerWnd);
 		if (hBk) DestroyWindow (hBk);
 		if (pState)   delete pState;
 		if (ddeserver) delete ddeserver;
@@ -692,14 +686,7 @@ HWND Orbiter::CreateRenderWindow (HWND parentWnd, Config *pCfg, const char *scen
 		GetRenderParameters ();
 	} else {
 		hRenderWnd = NULL;
-		if (AllocConsole() == TRUE) {
-			SetConsoleTitle("Orbiter Server Console");
-			Sleep(40);
-			hConsoleWnd = FindWindow(NULL, "Orbiter Server Console");
-			DWORD id;
-			hConsoleTh = CreateThread (NULL, 4096, ConsoleInputProc, this, 0, &id);
-			SetConsole(true);
-		}
+		m_pConsole = new orbiter::ConsoleNG(this);
 	}
 
 	if (hRenderWnd) {
@@ -787,7 +774,7 @@ HWND Orbiter::CreateRenderWindow (HWND parentWnd, Config *pCfg, const char *scen
 		snote_playback = gclient->clbkCreateAnnotation ();
 	}
 	else {
-		pDlgMgr = new DialogManager(this, hConsoleWnd);
+		pDlgMgr = new DialogManager(this, m_pConsole->WindowHandle());
 	}
 
 #ifdef INLINEGRAPHICS
@@ -844,11 +831,6 @@ HWND Orbiter::CreateRenderWindow (HWND parentWnd, Config *pCfg, const char *scen
 	// make sure render window has focus on start
 
 	LOGOUT ("Finished setting up render state");
-	if (hConsoleTh) {
-		ConsoleOut ("-----------------\nOrbiter NG (no graphics)");
-		ConsoleOut ("Running in server mode (no graphics client attached).");
-		ConsoleOut ("Type \"help\" for a list of commands.");
-	}
 
 	const char *scriptcmd = pState->Script();
 	hScnInterp = (scriptcmd ? script->RunInterpreter (scriptcmd) : NULL);
@@ -899,14 +881,13 @@ void Orbiter::CloseSession ()
 	else if (bPlayback) EndPlayback();
 	char *desc = "Current scenario state\n\n\nContains the latest simulation state.";
 	SaveScenario (CurrentScenario, desc);
-	DestroyServerGuiDlg();
 	if (hScnInterp) {
 		script->DelInterpreter (hScnInterp);
 		hScnInterp = NULL;
 	}
-	if (hConsoleTh) {
-		TerminateThread (hConsoleTh, 0);
-		FreeConsole();
+	if (m_pConsole) {
+		delete m_pConsole;
+		m_pConsole = NULL;
 	}
 	if (ddeserver) {
 		delete ddeserver;
@@ -1082,7 +1063,8 @@ INT Orbiter::Run ()
 						CaptureVideoFrame ();
 					}
 				}
-				if (hConsoleTh) ParseConsoleCmd();
+				if (m_pConsole)
+					m_pConsole->ParseCmd();
 			}
         }
 		if (bRenderOnce && bVisible) {
@@ -1151,160 +1133,6 @@ void Orbiter::UpdateServerWnd (HWND hWnd)
 	SetWindowText (GetDlgItem (hWnd, IDC_STATIC7), cbuf);
 }
 
-bool Orbiter::ParseConsoleCmd ()
-{
-	if (!cConsoleCmd[0]) return false;
-	char cmd[1024], cbuf[256], *pc, *ppc;
-
-	WaitForSingleObject (hConsoleMutex, 1000);
-	strcpy (cmd, cConsoleCmd+1);
-	cConsoleCmd[0] = '\0';
-	ReleaseMutex (hConsoleMutex);
-
-	DWORD i;
-	if (!_strnicmp (cmd, "help", 4)) {
-		pc = trim_string (cmd+4);
-		if (!_strnicmp (pc, "help", 4)) {
-			ConsoleOut ("Brief onscreen help for console commands.");
-			ConsoleOut ("Type \"help\" followed by a top-level command to get information for this command.");
-		} else if (!_strnicmp (pc, "exit", 4)) {
-			ConsoleOut ("Exits the simulation session and returns to the Launchpad dialog.");
-		} else if (!_strnicmp (pc, "vessel", 6)) {
-			ppc = trim_string (pc+6);
-			if (!_strnicmp (ppc, "list", 4)) {
-				ConsoleOut ("Lists all vessels in the current session.");
-			} else if (!_strnicmp (ppc, "count", 5)) {
-				ConsoleOut ("Prints the number of vessels in the current session.");
-			} else if (!_strnicmp (ppc, "focus", 5)) {
-				ConsoleOut ("Prints the name of the current focus vessel.");
-			} else if (!_strnicmp (ppc, "del", 3)) {
-				ConsoleOut ("vessel del <name> -- Destroy vessel <name>.");
-			} else {
-				ConsoleOut ("Vessel-specific commands. The following sub-commands are recognized:\n");
-				ConsoleOut ("list count focus del\n");
-				ConsoleOut ("Type \"help vessel <subcommand>\" to get information for a command.");
-			}
-		} else if (!_strnicmp (pc, "time", 4)) {
-			ConsoleOut ("Output current simulation time.");
-			ConsoleOut ("time syst  --  Session up time (seconds)");
-			ConsoleOut ("time simt  --  Simulation time (seconds)");
-			ConsoleOut ("time mjd   --  Absolute simulation time (MJD format)");
-			ConsoleOut ("time ut    --  Absolute simulation time (UT format)");
-			ConsoleOut ("Without arguments, all 4 time values are displayed.");
-		} else if (!_strnicmp (pc, "tacc", 4)) {
-			ConsoleOut ("Display or set time acceleration factor.");
-			ConsoleOut ("tacc <x>  --  Set new time acceleration factor x.");
-			ConsoleOut ("Without argument, prints the current time acceleration factor.");
-		} else if (!_strnicmp (pc, "pause", 5)) {
-			ConsoleOut ("Pause/resume simulation session.");
-			ConsoleOut ("pause on      --  pause simulation");
-			ConsoleOut ("pause off     --  resume simulation");
-			ConsoleOut ("pause toggle  --  toggle pause/resume state");
-			ConsoleOut ("Without arguments, the current simulation state is displayed.");
-		} else if (!_strnicmp (pc, "step", 4)) {
-			ConsoleOut ("Display momentary simulation step length and steps per second.");
-		}
-		else if (!_strnicmp(pc, "dlg", 3)) {
-			ppc = trim_string(pc + 3);
-			if (!_strnicmp(ppc, "focus", 5)) {
-				ConsoleOut("Open the vessel selection dialog.");
-			}
-			else if (!_strnicmp(ppc, "map", 3)) {
-				ConsoleOut("Open the map window.");
-			}
-			else if (!_strnicmp(ppc, "info", 4)) {
-				ConsoleOut("Open the object info dialog.");
-			}
-			else if (!_strnicmp(ppc, "tacc", 4)) {
-				ConsoleOut("Open the time acceleration dialog.");
-			}
-			else if (!_strnicmp(ppc, "function", 8)) {
-				ConsoleOut("Open the Plugin function list.");
-			}
-			else {
-				ConsoleOut("Open a dialog. The following sub-commands are recognize:\n");
-				ConsoleOut("focus map info tacc function\n");
-				ConsoleOut("Type \"help dlg <subcommand>\" to get information for a command.");
-			}
-		}
-		else if (!_strnicmp(pc, "gui", 3)) {
-			ConsoleOut("Toggles the display of a dialog box that continuously monitors the simulation");
-			ConsoleOut("state.");
-		} else {
-			ConsoleOut ("The following top-level commands are available:\n");
-			ConsoleOut ("  help exit vessel time tacc pause step dlg gui\n");
-			ConsoleOut ("To get help for a command, type \"help <cmd>\"");
-		}
-	} else if (!_strnicmp (cmd, "exit", 4)) {
-		CloseSession();
-		return true;
-	} else if (!_strnicmp (cmd, "vessel", 6)) {
-		pc = trim_string (cmd+6);
-		if (!_strnicmp (pc, "list", 4)) {
-			for (i = 0; i < g_psys->nVessel(); i++)
-				ConsoleOut (g_psys->GetVessel(i)->Name());
-			return true;
-		} else if (!_strnicmp (pc, "count", 5)) {
-			_itoa (g_psys->nVessel(), cbuf, 10);
-			ConsoleOut (cbuf);
-		} else if (!_strnicmp (pc, "focus", 5)) {
-			ConsoleOut (g_focusobj->Name());
-		} else if (!_strnicmp (pc, "del", 3)) {
-			Vessel *v = g_psys->GetVessel (trim_string(pc+3), true);
-			if (v) v->RequestDestruct();
-		}
-	} else if (!_strnicmp (cmd, "tacc", 4)) {
-		double w;
-		if (sscanf (trim_string(cmd+4), "%lf", &w) == 1)
-			SetWarpFactor (w);
-		else {
-			sprintf (cbuf, "Time acceleration is %0.1f", td.Warp());
-			ConsoleOut (cbuf);
-		}
-	} else if (!_strnicmp (cmd, "time", 4)) {
-		pc = trim_string(cmd+4);
-		if (!_strnicmp (pc, "simt", 4)) {
-			sprintf (cbuf, "%0.1f", td.SimT0);
-		} else if (!_strnicmp (pc, "syst", 4)) {
-			sprintf (cbuf, "%0.1f", td.SysT0);
-		} else if (!_strnicmp (pc, "mjd", 3)) {
-			sprintf (cbuf, "%0.6f", td.MJD0);
-		} else if (!_strnicmp (pc, "ut", 2)) {
-			strcpy (cbuf, DateStr (td.MJD0));
-		} else {
-			sprintf (cbuf, "SysT=%0.1f SimT=%0.1f, MJD=%0.6f, UT=%s", td.SysT0, td.SimT0, td.MJD0, DateStr(td.MJD0));
-		}
-		ConsoleOut (cbuf);
-	} else if (!_strnicmp (cmd, "pause", 5)) {
-		pc = trim_string (cmd+5);
-		if (!_strnicmp (pc, "on", 2)) Pause (true);
-		else if (!_strnicmp (pc, "off", 3)) Pause (false);
-		else if (!_strnicmp (pc, "toggle", 6)) Pause (bRunning);
-		sprintf_s (cbuf, 256, "Simulation %s", bRunning ? "running":"paused");
-		ConsoleOut (cbuf);
-	} else if (!_strnicmp (cmd, "step", 4)) {
-		sprintf_s (cbuf, 256, "dt=%f, FPS=%f", td.SimDT, td.FPS());
-		ConsoleOut (cbuf);
-	} else if (!_strnicmp (cmd, "gui", 3)) {
-		if (!DestroyServerGuiDlg())
-			hServerWnd = CreateDialog (hInst, MAKEINTRESOURCE(IDD_SERVER), hDlg, ServerDlgProc);
-	}
-	else if (!_strnicmp(cmd, "dlg", 3)) {
-		pc = trim_string(cmd + 3);
-		if (!_strnicmp(pc, "focus", 5))
-			pDlgMgr->EnsureEntry<DlgFocus>();
-		else if (!_strnicmp(pc, "map", 3))
-			pDlgMgr->EnsureEntry<DlgMap>();
-		else if (!_strnicmp(pc, "info", 4))
-			pDlgMgr->EnsureEntry<DlgInfo>();
-		else if (!_strnicmp(pc, "tacc", 4))
-			pDlgMgr->EnsureEntry<DlgTacc>();
-		else if (!_strnicmp(pc, "function", 8))
-			pDlgMgr->EnsureEntry<DlgFunction>();
-	}
-	return false;
-}
-
 void Orbiter::InitRotationMode ()
 {
 	bKeepFocus = true;
@@ -1334,16 +1162,6 @@ void Orbiter::ExitRotationMode ()
 	if (!bFullscreen && hRenderWnd) {
 		ClipCursor (NULL);
 	}
-}
-
-bool Orbiter::DestroyServerGuiDlg()
-{
-	if (hServerWnd) {
-		DestroyWindow (hServerWnd);
-		hServerWnd = NULL;
-		return true;
-	} else
-		return false;
 }
 
 #ifdef DO_NETWORK_OLD
@@ -1524,10 +1342,10 @@ bool Orbiter::KillVessels ()
 			//if (gclient) gclient->clbkDialogBroadcast (MSG_KILLVESSEL, vessel);
 			if (pDlgMgr) pDlgMgr->BroadcastMessage (MSG_KILLVESSEL, vessel);
 			// echo deletion on console window
-			if (hConsoleTh) {
+			if (m_pConsole) {
 				char cbuf[256];
 				sprintf (cbuf, "Vessel %s deleted", vessel->Name());
-				ConsoleOut (cbuf);
+				m_pConsole->Echo(cbuf);
 			}
 			// kill the vessel
 			g_psys->DelVessel (vessel, 0);
@@ -1581,10 +1399,10 @@ void Orbiter::SetWarpFactor (double warp, bool force, double delay)
 			//	g_psys->GetVessel(i)->FRecorder_SaveEvent ("TACC", cbuf);
 		}
 	}
-	if (hConsoleTh) {
+	if (m_pConsole) {
 		char cbuf[256];
 		sprintf (cbuf, "Time acceleration set to %0.1f", warp);
-		ConsoleOut (cbuf);
+		m_pConsole->Echo(cbuf);
 	}
 }
 
@@ -3354,51 +3172,4 @@ INT_PTR CALLBACK BkMsgProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 INT_PTR CALLBACK CloseMsgProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	return 0;
-}
-
-INT_PTR CALLBACK ServerDlgProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-	switch (uMsg) {
-	case WM_INITDIALOG:
-		SetTimer (hDlg, 1, 1000, NULL);
-		return TRUE;
-	case WM_TIMER:
-		g_pOrbiter->UpdateServerWnd (hDlg);
-		return 0;
-	case WM_COMMAND:
-		switch (LOWORD(wParam)) {
-		case IDOK:
-			g_pOrbiter->CloseSession ();
-		}
-		break;
-	case WM_CLOSE:
-		g_pOrbiter->DestroyServerGuiDlg();
-		return 0;
-	case WM_DESTROY:
-		KillTimer (hDlg, 1);
-		return 0;
-	}
-	return FALSE;
-}
-
-DWORD WINAPI ConsoleInputProc (LPVOID context)
-{
-	DWORD count, c;
-	char cbuf[1024];
-	HANDLE hStdI = GetStdHandle (STD_INPUT_HANDLE);
-	HANDLE hStdO = GetStdHandle (STD_OUTPUT_HANDLE);
-	Orbiter *orbiter = (Orbiter*)context;
-	SetConsoleMode (hStdI, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
-	SetConsoleTextAttribute (hStdI, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-	hConsoleMutex = CreateMutex (NULL, FALSE, NULL);
-	for (;;) {
-		ReadConsole (hStdI, cbuf, 1024, &count, NULL);
-		WriteConsole (hStdO, "> ", 2, &c, NULL);
-
-		WaitForSingleObject (hConsoleMutex, 1000);
-		cConsoleCmd[0] = 'x';
-		memcpy (cConsoleCmd+1, cbuf, count);
-		cConsoleCmd[count-1] = '\0'; // eliminates CR
-		ReleaseMutex (hConsoleMutex);
-	}
 }

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -29,6 +29,9 @@ class PlaybackEditor;
 class MemStat;
 class DDEServer;
 class ImageIO;
+namespace orbiter {
+	class ConsoleNG;
+}
 
 //-----------------------------------------------------------------------------
 // Structure for module callback functions
@@ -133,7 +136,6 @@ public:
 	void OutputLoadTick (int line, bool ok = true);
 	void TerminateOnError();
 	void UpdateServerWnd (HWND hWnd);
-	bool ParseConsoleCmd ();
 	void InitRotationMode ();
 	void ExitRotationMode ();
 	bool StickyFocus() const { return bKeepFocus; }
@@ -168,8 +170,6 @@ public:
 	bool RegisterWindow (HINSTANCE hInstance, HWND hWnd, DWORD flag);
 
 	void UpdateDeallocationProgress();
-
-	bool DestroyServerGuiDlg();
 
 	// plugin module loading/unloading
 	HINSTANCE LoadModule (const char *path, const char *name);   // load a plugin
@@ -409,14 +409,12 @@ private:
 	State          *pState;
 	MainDialog     *pMainDlg;
 	DialogManager  *pDlgMgr;
+	orbiter::ConsoleNG* m_pConsole;    // The console window opened when Orbiter server is launched without a graphics client
 	DInput         *pDI;
 	HINSTANCE       hInst;         // orbiter instance handle
 	HWND            hRenderWnd;    // render window handle (NULL if no render support)
-	HWND            hConsoleWnd;   // console window handle (graphics-less mode only)
-	HWND            hServerWnd;    // server dialog (graphics-less mode only)
 	HWND            hDlg;          // main dialog handle
 	HWND            hBk;           // background window handle (demo mode only)
-	HANDLE          hConsoleTh;    // console input thread
 	BOOL            bRenderOnce;   // flag for single frame render request
 	BOOL            bEnableLighting;
 	bool			bUseStencil;   // render device provides stencil buffer (and user requests it)

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -412,6 +412,7 @@ private:
 	DInput         *pDI;
 	HINSTANCE       hInst;         // orbiter instance handle
 	HWND            hRenderWnd;    // render window handle (NULL if no render support)
+	HWND            hConsoleWnd;   // console window handle (graphics-less mode only)
 	HWND            hServerWnd;    // server dialog (graphics-less mode only)
 	HWND            hDlg;          // main dialog handle
 	HWND            hBk;           // background window handle (demo mode only)

--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -1639,12 +1639,13 @@ DLLEXPORT void oapiRegisterMFD (int mfd, const EXTMFDSPEC *spec)
 
 DLLEXPORT void oapiRegisterExternMFD (ExternMFD *emfd, const MFDSPEC &spec)
 {
-	g_pane->RegisterExternMFD (emfd, spec);
+	if (g_pane)
+		g_pane->RegisterExternMFD (emfd, spec);
 }
 
 DLLEXPORT bool oapiUnregisterExternMFD (ExternMFD *emfd)
 {
-	return g_pane->UnregisterExternMFD (emfd);
+	return (g_pane ? g_pane->UnregisterExternMFD (emfd) : false);
 }
 
 DLLEXPORT void oapiDisableMFDMode (int mode)

--- a/Src/Orbiter/console_ng.cpp
+++ b/Src/Orbiter/console_ng.cpp
@@ -12,6 +12,7 @@
 #include "DlgInfo.h"
 #include "DlgTacc.h"
 #include "DlgFunction.h"
+#include "DlgRecorder.h"
 #include "DlgHelp.h"
 #include "resource.h"
 
@@ -132,6 +133,7 @@ bool orbiter::ConsoleNG::ParseCmd()
 			Echo("dlg info     -- Open the object info dialog");
 			Echo("dlg tacc     -- Open the time acceleration dialog");
 			Echo("dlg help     -- Open the help dialog");
+			Echo("dlg record   -- Open the flight recorder dialog");
 			Echo("dlg function -- Open the plugin function list");
 		}
 		else if (!_strnicmp(pc, "gui", 3)) {
@@ -225,6 +227,8 @@ bool orbiter::ConsoleNG::ParseCmd()
 				pDlgMgr->EnsureEntry<DlgTacc>();
 			else if (!_strnicmp(pc, "function", 8))
 				pDlgMgr->EnsureEntry<DlgFunction>();
+			else if (!_strnicmp(pc, "record", 6))
+				pDlgMgr->EnsureEntry<DlgRecorder>();
 			else if (!_strnicmp(pc, "help", 4))
 				pDlgMgr->EnsureEntry<DlgHelp>();
 		}

--- a/Src/Orbiter/console_ng.cpp
+++ b/Src/Orbiter/console_ng.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) Martin Schweiger
+// Licensed under the MIT License
+
+#include "console_ng.h"
+#include "Orbiter.h"
+#include "DlgMgr.h"
+#include "Psys.h"
+#include "Vessel.h"
+#include "Log.h"
+#include "DlgFocus.h"
+#include "DlgMap.h"
+#include "DlgInfo.h"
+#include "DlgTacc.h"
+#include "DlgFunction.h"
+#include "resource.h"
+
+extern PlanetarySystem* g_psys;
+extern Vessel* g_focusobj;
+extern TimeData td;
+
+DWORD WINAPI InputProc(LPVOID);
+INT_PTR CALLBACK ServerDlgProc(HWND, UINT, WPARAM, LPARAM);
+static HANDLE hMutex = 0;
+static char cConsoleCmd[1024] = "\0";
+static orbiter::ConsoleNG* s_console = NULL; // access to console instance from message callback functions
+
+orbiter::ConsoleNG::ConsoleNG(Orbiter* pOrbiter)
+	: m_pOrbiter(pOrbiter)
+	, m_hWnd(NULL)
+	, m_hStatWnd(NULL)
+	, hThread(NULL)
+{
+	static const PSTR title = "Orbiter Server Console";
+	static SIZE_T stackSize = 4096;
+
+	s_console = this;
+
+	if (AllocConsole() == TRUE) {
+		DWORD id;
+		SetConsoleTitle(title);
+		Sleep(40); // Ugly, but suggested by MS document to make sure title is changed
+		m_hWnd = FindWindow(NULL, title); // Ugly, but apparently nothing better is available
+		hThread = CreateThread(NULL, stackSize, InputProc, this, 0, &id);
+		SetConsole(true);
+
+		ConsoleOut("-----------------\nOrbiter NG (no graphics)");
+		ConsoleOut("Running in server mode (no graphics client attached).");
+		ConsoleOut("Type \"help\" for a list of commands.");
+	}
+}
+
+orbiter::ConsoleNG::~ConsoleNG()
+{
+	DestroyStatDlg();
+	if (hThread) {
+		TerminateThread(hThread, 0);
+		FreeConsole();
+	}
+	s_console = NULL;
+}
+
+bool orbiter::ConsoleNG::ParseCmd()
+{
+	if (!cConsoleCmd[0]) return false;
+	char cmd[1024], cbuf[256], * pc, * ppc;
+
+	WaitForSingleObject(hMutex, 1000);
+	strcpy(cmd, cConsoleCmd + 1);
+	cConsoleCmd[0] = '\0';
+	ReleaseMutex(hMutex);
+
+	DWORD i;
+	if (!_strnicmp(cmd, "help", 4)) {
+		pc = trim_string(cmd + 4);
+		if (!_strnicmp(pc, "help", 4)) {
+			ConsoleOut("Brief onscreen help for console commands.");
+			ConsoleOut("Type \"help\" followed by a top-level command to get information for this command.");
+		}
+		else if (!_strnicmp(pc, "exit", 4)) {
+			ConsoleOut("Exits the simulation session and returns to the Launchpad dialog.");
+		}
+		else if (!_strnicmp(pc, "vessel", 6)) {
+			ppc = trim_string(pc + 6);
+			if (!_strnicmp(ppc, "list", 4)) {
+				ConsoleOut("Lists all vessels in the current session.");
+			}
+			else if (!_strnicmp(ppc, "count", 5)) {
+				ConsoleOut("Prints the number of vessels in the current session.");
+			}
+			else if (!_strnicmp(ppc, "focus", 5)) {
+				ConsoleOut("Prints the name of the current focus vessel.");
+			}
+			else if (!_strnicmp(ppc, "del", 3)) {
+				ConsoleOut("vessel del <name> -- Destroy vessel <name>.");
+			}
+			else {
+				ConsoleOut("Vessel-specific commands. The following sub-commands are recognized:\n");
+				ConsoleOut("list count focus del\n");
+				ConsoleOut("Type \"help vessel <subcommand>\" to get information for a command.");
+			}
+		}
+		else if (!_strnicmp(pc, "time", 4)) {
+			ConsoleOut("Output current simulation time.");
+			ConsoleOut("time syst  --  Session up time (seconds)");
+			ConsoleOut("time simt  --  Simulation time (seconds)");
+			ConsoleOut("time mjd   --  Absolute simulation time (MJD format)");
+			ConsoleOut("time ut    --  Absolute simulation time (UT format)");
+			ConsoleOut("Without arguments, all 4 time values are displayed.");
+		}
+		else if (!_strnicmp(pc, "tacc", 4)) {
+			ConsoleOut("Display or set time acceleration factor.");
+			ConsoleOut("tacc <x>  --  Set new time acceleration factor x.");
+			ConsoleOut("Without argument, prints the current time acceleration factor.");
+		}
+		else if (!_strnicmp(pc, "pause", 5)) {
+			ConsoleOut("Pause/resume simulation session.");
+			ConsoleOut("pause on      --  pause simulation");
+			ConsoleOut("pause off     --  resume simulation");
+			ConsoleOut("pause toggle  --  toggle pause/resume state");
+			ConsoleOut("Without arguments, the current simulation state is displayed.");
+		}
+		else if (!_strnicmp(pc, "step", 4)) {
+			ConsoleOut("Display momentary simulation step length and steps per second.");
+		}
+		else if (!_strnicmp(pc, "dlg", 3)) {
+			ppc = trim_string(pc + 3);
+			if (!_strnicmp(ppc, "focus", 5)) {
+				ConsoleOut("Open the vessel selection dialog.");
+			}
+			else if (!_strnicmp(ppc, "map", 3)) {
+				ConsoleOut("Open the map window.");
+			}
+			else if (!_strnicmp(ppc, "info", 4)) {
+				ConsoleOut("Open the object info dialog.");
+			}
+			else if (!_strnicmp(ppc, "tacc", 4)) {
+				ConsoleOut("Open the time acceleration dialog.");
+			}
+			else if (!_strnicmp(ppc, "function", 8)) {
+				ConsoleOut("Open the Plugin function list.");
+			}
+			else {
+				ConsoleOut("Open a dialog. The following sub-commands are recognize:\n");
+				ConsoleOut("focus map info tacc function\n");
+				ConsoleOut("Type \"help dlg <subcommand>\" to get information for a command.");
+			}
+		}
+		else if (!_strnicmp(pc, "gui", 3)) {
+			ConsoleOut("Toggles the display of a dialog box that continuously monitors the simulation");
+			ConsoleOut("state.");
+		}
+		else {
+			ConsoleOut("The following top-level commands are available:\n");
+			ConsoleOut("  help exit vessel time tacc pause step dlg gui\n");
+			ConsoleOut("To get help for a command, type \"help <cmd>\"");
+		}
+	}
+	else if (!_strnicmp(cmd, "exit", 4)) {
+		m_pOrbiter->CloseSession();
+		return true;
+	}
+	else if (!_strnicmp(cmd, "vessel", 6)) {
+		pc = trim_string(cmd + 6);
+		if (!_strnicmp(pc, "list", 4)) {
+			for (i = 0; i < g_psys->nVessel(); i++)
+				ConsoleOut(g_psys->GetVessel(i)->Name());
+			return true;
+		}
+		else if (!_strnicmp(pc, "count", 5)) {
+			_itoa(g_psys->nVessel(), cbuf, 10);
+			ConsoleOut(cbuf);
+		}
+		else if (!_strnicmp(pc, "focus", 5)) {
+			ConsoleOut(g_focusobj->Name());
+		}
+		else if (!_strnicmp(pc, "del", 3)) {
+			Vessel* v = g_psys->GetVessel(trim_string(pc + 3), true);
+			if (v) v->RequestDestruct();
+		}
+	}
+	else if (!_strnicmp(cmd, "tacc", 4)) {
+		double w;
+		if (sscanf(trim_string(cmd + 4), "%lf", &w) == 1)
+			m_pOrbiter->SetWarpFactor(w);
+		else {
+			sprintf(cbuf, "Time acceleration is %0.1f", td.Warp());
+			ConsoleOut(cbuf);
+		}
+	}
+	else if (!_strnicmp(cmd, "time", 4)) {
+		pc = trim_string(cmd + 4);
+		if (!_strnicmp(pc, "simt", 4)) {
+			sprintf(cbuf, "%0.1f", td.SimT0);
+		}
+		else if (!_strnicmp(pc, "syst", 4)) {
+			sprintf(cbuf, "%0.1f", td.SysT0);
+		}
+		else if (!_strnicmp(pc, "mjd", 3)) {
+			sprintf(cbuf, "%0.6f", td.MJD0);
+		}
+		else if (!_strnicmp(pc, "ut", 2)) {
+			strcpy(cbuf, DateStr(td.MJD0));
+		}
+		else {
+			sprintf(cbuf, "SysT=%0.1f SimT=%0.1f, MJD=%0.6f, UT=%s", td.SysT0, td.SimT0, td.MJD0, DateStr(td.MJD0));
+		}
+		ConsoleOut(cbuf);
+	}
+	else if (!_strnicmp(cmd, "pause", 5)) {
+		pc = trim_string(cmd + 5);
+		if (!_strnicmp(pc, "on", 2)) m_pOrbiter->Pause(true);
+		else if (!_strnicmp(pc, "off", 3)) m_pOrbiter->Pause(false);
+		else if (!_strnicmp(pc, "toggle", 6)) m_pOrbiter->TogglePause();
+		sprintf_s(cbuf, 256, "Simulation %s", m_pOrbiter->IsRunning() ? "running" : "paused");
+		ConsoleOut(cbuf);
+	}
+	else if (!_strnicmp(cmd, "step", 4)) {
+		sprintf_s(cbuf, 256, "dt=%f, FPS=%f", td.SimDT, td.FPS());
+		ConsoleOut(cbuf);
+	}
+	else if (!_strnicmp(cmd, "gui", 3)) {
+		if (!DestroyStatDlg())
+			m_hStatWnd = CreateDialog(m_pOrbiter->GetInstance(), MAKEINTRESOURCE(IDD_SERVER), m_pOrbiter->Get_hDlg(), ServerDlgProc);
+	}
+	else if (!_strnicmp(cmd, "dlg", 3)) {
+		DialogManager* pDlgMgr = m_pOrbiter->DlgMgr();
+		if (pDlgMgr) {
+			pc = trim_string(cmd + 3);
+			if (!_strnicmp(pc, "focus", 5))
+				pDlgMgr->EnsureEntry<DlgFocus>();
+			else if (!_strnicmp(pc, "map", 3))
+				pDlgMgr->EnsureEntry<DlgMap>();
+			else if (!_strnicmp(pc, "info", 4))
+				pDlgMgr->EnsureEntry<DlgInfo>();
+			else if (!_strnicmp(pc, "tacc", 4))
+				pDlgMgr->EnsureEntry<DlgTacc>();
+			else if (!_strnicmp(pc, "function", 8))
+				pDlgMgr->EnsureEntry<DlgFunction>();
+		}
+	}
+	return false;
+}
+
+void orbiter::ConsoleNG::Echo(const char* str) const
+{
+	ConsoleOut(str);
+}
+
+bool orbiter::ConsoleNG::DestroyStatDlg()
+{
+	if (m_hStatWnd) {
+		DestroyWindow(m_hStatWnd);
+		m_hStatWnd = NULL;
+		return true;
+	}
+	else
+		return false;
+}
+
+
+DWORD WINAPI InputProc(LPVOID context)
+{
+	DWORD count, c;
+	char cbuf[1024];
+	HANDLE hStdI = GetStdHandle(STD_INPUT_HANDLE);
+	HANDLE hStdO = GetStdHandle(STD_OUTPUT_HANDLE);
+	orbiter::ConsoleNG* console = (orbiter::ConsoleNG*)context;
+	SetConsoleMode(hStdI, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+	SetConsoleTextAttribute(hStdI, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+	hMutex = CreateMutex(NULL, FALSE, NULL);
+	for (;;) {
+		ReadConsole(hStdI, cbuf, 1024, &count, NULL);
+		WriteConsole(hStdO, "> ", 2, &c, NULL);
+
+		WaitForSingleObject(hMutex, 1000);
+		cConsoleCmd[0] = 'x';
+		memcpy(cConsoleCmd + 1, cbuf, count);
+		cConsoleCmd[count - 1] = '\0'; // eliminates CR
+		ReleaseMutex(hMutex);
+	}
+	return 0;
+}
+
+INT_PTR CALLBACK ServerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	switch (uMsg) {
+	case WM_INITDIALOG:
+		SetTimer(hDlg, 1, 1000, NULL);
+		return TRUE;
+	case WM_TIMER:
+		if (s_console)
+			s_console->GetOrbiter()->UpdateServerWnd(hDlg);
+		return 0;
+	case WM_COMMAND:
+		switch (LOWORD(wParam)) {
+		case IDOK:
+			if (s_console)
+				s_console->GetOrbiter()->CloseSession();
+		}
+		break;
+	case WM_CLOSE:
+		if (s_console)
+			s_console->DestroyStatDlg();
+		return 0;
+	case WM_DESTROY:
+		KillTimer(hDlg, 1);
+		return 0;
+	}
+	return FALSE;
+}

--- a/Src/Orbiter/console_ng.h
+++ b/Src/Orbiter/console_ng.h
@@ -19,6 +19,7 @@ namespace orbiter {
 		HWND WindowHandle() const { return m_hWnd; }
 		bool ParseCmd();
 		void Echo(const char* str) const;
+		void EchoIntro() const;
 		bool DestroyStatDlg();
 
 	private:
@@ -26,7 +27,7 @@ namespace orbiter {
 		Orbiter* m_pOrbiter;
 		HWND m_hWnd;       // console window handle
 		HWND m_hStatWnd;   // stats dialog
-		HANDLE hThread;  // console thread handle
+		HANDLE m_hThread;  // console thread handle
 	};
 
 }

--- a/Src/Orbiter/console_ng.h
+++ b/Src/Orbiter/console_ng.h
@@ -1,0 +1,34 @@
+// Copyright (c) Martin Schweiger
+// Licensed under the MIT License
+
+#ifndef __console_ng_h
+#define __console_ng_h
+
+#include <windows.h>
+
+class Orbiter;
+
+namespace orbiter {
+
+	class ConsoleNG {
+	public:
+		ConsoleNG(Orbiter* pOrbiter);
+		~ConsoleNG();
+
+		Orbiter* GetOrbiter() const { return m_pOrbiter; }
+		HWND WindowHandle() const { return m_hWnd; }
+		bool ParseCmd();
+		void Echo(const char* str) const;
+		bool DestroyStatDlg();
+
+	private:
+
+		Orbiter* m_pOrbiter;
+		HWND m_hWnd;       // console window handle
+		HWND m_hStatWnd;   // stats dialog
+		HANDLE hThread;  // console thread handle
+	};
+
+}
+
+#endif // !__console_ng_h


### PR DESCRIPTION
- Console functionality has been moved from Orbiter class to separate orbiter::ConsoleNG class.
- Console now supports 'dlg' command to open dialog windows in the absence of a graphics window.
- The following dialogs can be opened: focus (vessel selection), map, info, tacc (time acceleration), help, record (flight recorder) and function (plugin function list)
- The ExtMFD windows currently don't work in console mode, because of graphics client dependencies

closes #93 