### PR TITLE
NG version: allow proper work from interactive console (stdin/stdout)

### DIFF
--- a/Src/Orbiter/CMakeLists.txt
+++ b/Src/Orbiter/CMakeLists.txt
@@ -29,6 +29,7 @@ set(common_src
 	State.cpp
 	Vecmat.cpp
 	VectorMap.cpp
+    ConsoleManager.cpp
 # Launchpad
 	Launchpad.cpp
 	LpadTab.cpp
@@ -241,7 +242,7 @@ if(BUILD_ORBITER_SERVER)
 
 	set_target_properties(Orbiter_server
 		PROPERTIES
-		LINK_FLAGS "/SUBSYSTEM:WINDOWS"
+		LINK_FLAGS "/SUBSYSTEM:CONSOLE /ENTRY:WinMainCRTStartup"
 		RUNTIME_OUTPUT_DIRECTORY ${ORBITER_BINARY_MODULE_DIR}/Server
 		OUTPUT_NAME Orbiter
 		VS_DEBUGGER_WORKING_DIRECTORY ${ORBITER_BINARY_ROOT_DIR}

--- a/Src/Orbiter/ConsoleManager.cpp
+++ b/Src/Orbiter/ConsoleManager.cpp
@@ -1,0 +1,16 @@
+#include "ConsoleManager.h"
+
+#include <windows.h>
+
+bool ConsoleManager::IsConsoleExclusive(void) {
+    DWORD pids[2];
+    DWORD num_pids = GetConsoleProcessList(pids, 2);
+    return num_pids <= 1;
+}
+
+void ConsoleManager::ShowConsole(bool show)
+{
+    HWND wnd = GetConsoleWindow();
+    if (wnd)
+        ShowWindow(wnd, show ? SW_SHOW : SW_HIDE);
+}

--- a/Src/Orbiter/ConsoleManager.h
+++ b/Src/Orbiter/ConsoleManager.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class ConsoleManager {
+public:
+    static bool IsConsoleExclusive(void);
+    static void ShowConsole(bool show);
+};

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -48,6 +48,7 @@
 #include "htmlctrl.h"
 #include "DlgCtrl.h"
 #include "GraphicsAPI.h"
+#include "ConsoleManager.h"
 
 #ifdef INLINEGRAPHICS
 #include "OGraphics.h"
@@ -195,7 +196,11 @@ INT WINAPI WinMain (HINSTANCE hInstance, HINSTANCE, PSTR strCmdLine, INT nCmdSho
 	}
 #endif
 
-	SetEnvironmentVars();
+    // If we're not running from actual console, hide the window
+    if (ConsoleManager::IsConsoleExclusive())
+        ConsoleManager::ShowConsole(false);
+    
+    SetEnvironmentVars();
 	g_pOrbiter = new Orbiter; // application instance
 
 	// Parse command line

--- a/Src/Orbiter/console_ng.cpp
+++ b/Src/Orbiter/console_ng.cpp
@@ -14,6 +14,7 @@
 #include "DlgFunction.h"
 #include "DlgRecorder.h"
 #include "DlgHelp.h"
+#include "ConsoleManager.h"
 #include "resource.h"
 
 extern PlanetarySystem* g_psys;
@@ -30,25 +31,23 @@ static char cConsoleCmd[1024] = "\0";
 static orbiter::ConsoleNG* s_console = NULL; // access to console instance from message callback functions
 
 orbiter::ConsoleNG::ConsoleNG(Orbiter* pOrbiter)
-	: m_pOrbiter(pOrbiter)
-	, m_hWnd(NULL)
-	, m_hStatWnd(NULL)
-	, m_hThread(NULL)
+    : m_pOrbiter(pOrbiter)
+    , m_hWnd(NULL)
+    , m_hStatWnd(NULL)
+    , m_hThread(NULL)
 {
-	static const PSTR title = "Orbiter Server Console";
-	static SIZE_T stackSize = 4096;
+    static const PSTR title = "Orbiter Server Console";
+    static SIZE_T stackSize = 4096;
 
-	s_console = this;
+    s_console = this;
 
-	if (AllocConsole() == TRUE) {
-		DWORD id;
-		SetConsoleTitle(title);
-		Sleep(40); // Ugly, but suggested by MS document to make sure title is changed
-		m_hWnd = FindWindow(NULL, title); // Ugly, but apparently nothing better is available
-		m_hThread = CreateThread(NULL, stackSize, InputProc, this, 0, &id);
-		s_hStdO = GetStdHandle(STD_OUTPUT_HANDLE);
-		SetLogOutFunc(&ConsoleOut); // clone log output to console
-	}
+    ConsoleManager::ShowConsole(true);
+    DWORD id;
+    SetConsoleTitle(title);
+    m_hWnd = GetConsoleWindow();
+    m_hThread = CreateThread(NULL, stackSize, InputProc, this, 0, &id);
+    s_hStdO = GetStdHandle(STD_OUTPUT_HANDLE);
+    SetLogOutFunc(&ConsoleOut); // clone log output to console
 }
 
 orbiter::ConsoleNG::~ConsoleNG()
@@ -57,7 +56,6 @@ orbiter::ConsoleNG::~ConsoleNG()
 	SetLogOutFunc(0);
 	if (m_hThread) {
 		TerminateThread(m_hThread, 0);
-		FreeConsole();
 	}
 	s_console = NULL;
 	s_hStdO = NULL;


### PR DESCRIPTION
- Server version of Orbiter changed to use CONSOLE subsystem
- will now reuse existing console if launched from one
- Allows proper stdout logging for tests
- Allows running/interacting with NG version directly in Visual Studio console
- Downside: flicker of console window on launch (visual only)