### PR TITLE
#116: added missing source file to CMakeLists.txt

### DIFF
--- a/Sound/XRSound/XRSound/src/XRSoundDLL/CMakeLists.txt
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(XRSound_dll SHARED
 	XRSoundConfigFileParser.cpp
 	XRSoundDLL.cpp
 	XRSoundEngine.cpp
+	XRSoundEngine30.cpp
 	Resource.rc
 	../Utils/ConfigFileParser.cpp
 	../Utils/FileList.cpp


### PR DESCRIPTION
Fixes build failure of cmake-based build introduced with #115
closes #116

@dbeachy1 : Doug, it would be good if XRSound could be included in the CI build tests to avoid these problems in the future. I guess you are not keen on downloading the irrKlang libraries as part of the build process, but do you think it would be ok to incorporate them into the repository, under the Extern directory? This way they would be accessible from the CI server, and XRSound could be included in the build. This would also open the possibility of adding unit tests for the XRSound module later.

What do you think?