### PR TITLE
Add msvc problem matcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       
+    - name: Setup Problem Matcher
+      uses: ammaraskar/msvc-problem-matcher@master
+      
     - name: Prepare
       run: |
         mkdir out\build


### PR DESCRIPTION
Adds warnings/errors from MSVC compiler as GitHub annotations (will highlight compilation warnings/errors in PR diff)