### PR TITLE
Add DXSDK download into GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,7 @@ jobs:
   build:
     name: Build with CMake
     env:
-      CMAKE_BUILD_PARALLEL_LEVEL: 2
-      VCToolsInstallDir: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\"
+      DXSDK_DIR: "${{ github.workspace }}\\DXSDK"
     strategy:
       fail-fast: false
       matrix:
@@ -34,13 +33,30 @@ jobs:
       run: |
         mkdir out\build
         mkdir out\install
-      
+    
     - name: Cache irrKlang package
       uses: actions/cache@v2
       with:
         path: ${{ github.workspace }}/out/build/Extern/irrKlang/${{ matrix.architecture }}
         key: irrKlang-${{ matrix.architecture }}
-      
+        
+    - name: Cache DirectX SDK
+      id:   cache
+      uses: actions/cache@v2
+      with:
+        path: "${{ github.workspace }}\\DXSDK"
+        key:  dxsdk_jun10
+
+    - name: Download DirectX SDK
+      if:   steps.cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+         curl -L https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe -o DXSDK_Jun10.exe
+         7z x DXSDK_Jun10.exe DXSDK/Include
+         7z x DXSDK_Jun10.exe DXSDK/Lib
+         del DXSDK_Jun10.exe
+         dir /S /B DXSDK
+
     - name: Build & Test
       shell: cmd
       working-directory: ${{ github.workspace }}/out/build


### PR DESCRIPTION
This adds support of new D3D9Client build into GitHub Actions build

Example successful build: https://github.com/DarkWanderer/orbiter/actions/runs/1263239535