### PR TITLE
Fix bug #145 using @spacex15 approach

### DIFF
--- a/OVP/D3D9Client/D3D9Client.cpp
+++ b/OVP/D3D9Client/D3D9Client.cpp
@@ -1191,7 +1191,7 @@ bool D3D9Client::clbkDisplayFrame()
 //	static int iRefrState = 0;
 	double time = D3D9GetTime();
 
-	if (!bRunning) {
+	if (!bRunning && pDevice) {
 		RECT txt = _RECT( loadd_x, loadd_y, loadd_x+loadd_w, loadd_y+loadd_h );
 		pDevice->StretchRect(pSplashScreen, NULL, pBackBuffer, NULL, D3DTEXF_POINT);
 		pDevice->StretchRect(pTextScreen, NULL, pBackBuffer, &txt, D3DTEXF_POINT);

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -1270,6 +1270,9 @@ bool Orbiter::KillVessels ()
 			}
 #ifdef INLINEGRAPHICS
 			oclient->clbkDeleteVessel ((OBJHANDLE)vessel);
+#else
+			if (gclient)
+				gclient->clbkDeleteVessel((OBJHANDLE)vessel);
 #endif
 			// broadcast vessel destruction to all vessels
 			g_psys->BroadcastVessel (MSG_KILLVESSEL, vessel);
@@ -1778,11 +1781,13 @@ const Mesh *Orbiter::LoadMeshGlobal (const char *fname, LoadMeshClbkFunc fClbk)
 VOID Orbiter::Output2DData ()
 {
 	g_pane->Draw ();
-	for (DWORD i = 0; i < nsnote; i++)
-		snote[i]->Render();
-	if (snote_playback && pConfig->CfgRecPlayPrm.bShowNotes) snote_playback->Render();
-	if (g_select->IsActive()) g_select->Display (0/*oclient->m_pddsRenderTarget*/);
-	if (g_input->IsActive()) g_input->Display (0/*oclient->m_pddsRenderTarget*/);
+	if (g_pane) {
+		for (DWORD i = 0; i < nsnote; i++)
+			snote[i]->Render();
+		if (snote_playback && pConfig->CfgRecPlayPrm.bShowNotes) snote_playback->Render();
+		if (g_select->IsActive()) g_select->Display(0/*oclient->m_pddsRenderTarget*/);
+		if (g_input->IsActive()) g_input->Display(0/*oclient->m_pddsRenderTarget*/);
+	}
 
 #ifdef INLINEGRAPHICS
 #ifdef OUTPUT_DBG
@@ -1874,7 +1879,7 @@ bool Orbiter::BeginTimeStep (bool running)
 void Orbiter::EndTimeStep (bool running)
 {
 	if (running) {
-		g_psys->FinaliseUpdate ();
+		if (g_psys) g_psys->FinaliseUpdate ();
 		//ModulePostStep();
 	}
 
@@ -1882,7 +1887,7 @@ void Orbiter::EndTimeStep (bool running)
 	td.EndStep (running);
 
 	// Update panels
-	g_camera->Update ();                           // camera
+	if (g_camera) g_camera->Update ();                           // camera
 	if (g_pane) g_pane->Update (td.SimT1, td.SysT1);
 
 	// Update visual states

--- a/Src/Orbiter/Pane.cpp
+++ b/Src/Orbiter/Pane.cpp
@@ -626,7 +626,7 @@ void Pane::Update (double simt, double syst)
 
 void Pane::Draw ()
 {
-	if (!g_camera->IsExternal() && !vcockpit && hud) {
+	if (g_camera && !g_camera->IsExternal() && !vcockpit && hud) {
 		oapi::Sketchpad *skp = gc->clbkGetSketchpad (0);
 		if (skp) {
 			SetSketchpadDefault (skp);

--- a/Src/Orbiter/hud.cpp
+++ b/Src/Orbiter/hud.cpp
@@ -1027,7 +1027,7 @@ bool HUD::DrawCenterMarker (oapi::Sketchpad *skp) const
 void HUD::DrawLadderBar (oapi::Sketchpad *skp, double lwcosa, double lwsina,
 	double dcosa, double dsina, int phi10, bool mark_subzero)
 {
-	int x1, y1, x2, y2, dx, dy, dx1, dy1, dx2, dy2;
+	int x1, y1, x2, y2, dx, dy, dx1, dy1, dx2=0, dy2=0;
 	char cbuf[5];
 
 	bool is_subzero = (phi10 < 0);


### PR DESCRIPTION
Fix bug #145 using @spacex15 approach.

Also this was made:
- Add checks to avoid crashes on vessel deleting
- Initialize HUD variables

As EXTERNALGRAPHICS preprocessor variable isn't defined, the change on Src/Orbiter/Orbiter.cpp relies on #else and checking if gclient exists. This work well on headless sessions, but we can save this check (on headless) defining a dedicated variable.
Anyway I think that to do that is out scope of a bug fix, by that I'm using this approach and taking it account for future improves.