### PR TITLE
fix ShiftCG() in out-of-focus vessel

### DIFF
--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -7638,7 +7638,8 @@ void VESSEL::ShiftCG (const VECTOR3 &shift)
 	vessel->ShiftDocks (vs);
 	vessel->ShiftLightEmitters (nshift);
 	vessel->campos.Set (vessel->campos+vs);
-	if (g_pane) g_pane->ShiftVC (vs);
+	// only shift the vc of this vessel
+	if ((g_pane) && (g_focusobj == vessel)) g_pane->ShiftVC (vs);
 	ShiftCentreOfMass (shift);
 }
 


### PR DESCRIPTION
This fixes the ShiftCG() call from an out-of-focus vessel shifting the vc click areas of the in-focus vessel, as reported in https://www.orbiter-forum.com/threads/orbiter-beta-r90-suspected-bug-with-shiftcg-call-and-vc-click-spots.40308/