### PR TITLE
Orbiter now searches for graphics client plugins within an optional module subfolder

### DIFF
--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -175,27 +175,61 @@ void orbiter::DefVideoTab::EnumerateClients(HWND hTab)
 	SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_SETCURSEL, 0, 0);
 }
 
-//-----------------------------------------------------------------------------
+static bool FileExists(const char* path)
+{
+	return access(path, 0) != -1;
+}
 
+//! @param extension is a file extension without the '.'
+static bool HasExtension(const char* filepath, const char* extension)
+{
+	std::string str(filepath);
+	return (str.substr(str.find_last_of(".") + 1) == extension);
+}
+
+static std::string GetNameWithoutFileExtension(const char* filepath)
+{
+	std::string str(filepath);
+	return str.substr(0, str.find_last_of("."));
+}
+
+//-----------------------------------------------------------------------------
+//! Find Graphics engine DLLs in dir
 void orbiter::DefVideoTab::ScanDir(HWND hTab, const PSTR dir)
 {
-	char pattern[256], name[256];
-	sprintf(pattern, "%s\\*.dll", dir);
+	char pattern[256], filepath[256];
+	sprintf(pattern, "%s\\*", dir);
 	struct _finddata_t fdata;
 	intptr_t fh = _findfirst(pattern, &fdata);
 	if (fh == -1) return; // nothing found
 	do {
-		sprintf(name, "%s\\%s", dir, fdata.name);
-		HMODULE hMod = LoadLibraryEx(name, 0, LOAD_LIBRARY_AS_DATAFILE);
+		if (fdata.attrib & _A_SUBDIR && fdata.name[0]!='.') // directory found
+		{
+			// Skip if directory does not contain plugin with same name as directory
+			sprintf(filepath, "%s\\%s\\%s.dll", dir, fdata.name, fdata.name);
+			if (!FileExists(filepath))
+			{
+				continue;
+			}
+		}
+		else // file found
+		{
+			if (!HasExtension(fdata.name, "dll")) // skip if not a DLL
+			{
+				continue;
+			}
+			sprintf(filepath, "%s\\%s", dir, fdata.name);
+		}
+
+		// We've found a potential module DLL. Load it.
+		HMODULE hMod = LoadLibraryEx(filepath, 0, LOAD_LIBRARY_AS_DATAFILE);
 		if (hMod) {
 			char catstr[256];
+			std::string clientname = GetNameWithoutFileExtension(fdata.name);
 			// read category string
 			if (LoadString(hMod, 1001, catstr, 256)) {
 				if (!strcmp(catstr, "Graphics engines")) {
-					char clientname[256];
-					strncpy(clientname, fdata.name, strlen(fdata.name) - 4);
-					clientname[strlen(fdata.name) - 4] = '\0';
-					SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_ADDSTRING, 0, (LPARAM)clientname);
+					SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_ADDSTRING, 0, (LPARAM)clientname.c_str());
 				}
 			}
 		}


### PR DESCRIPTION
As discussed in [this thread](https://www.orbiter-forum.com/threads/support-for-plugin-subfolder-dll-search-path.40449/), with the help of @Face-1 I've changed plugin load behavior to:

1. Search for plugins with the pattern `Modules/Plugins/XXX.dll (existing behavior)
2. If not found, search for plugins with the pattern: Modules/Plugins/XXX/XXX.dll

This is useful for cases where plugin A.dll depends on B.dll. Currently orbiter searches for DLLs on the PATH. This means users must install all dependency plugin DLLs to Modules or Modules/Plugins, which adds clutter and potential conflicts between plugins. With this new behavior, a plugin and all its dependencies can be installed to its own subfolder, and will not interfere with the loading of other plugins.

I have only introduce this behavior for graphics clients. If this feature is successful, it would be good to extend the behavior to all module types (vessels etc) as well.