### PR TITLE
207 loading cache tiles fails

### DIFF
--- a/OVP/D3D7Client/Texture.cpp
+++ b/OVP/D3D7Client/Texture.cpp
@@ -159,12 +159,7 @@ HRESULT TextureManager::LoadTexture (const char *fname, LPDIRECTDRAWSURFACE7 *pp
 	FILE* ftex = 0;
 	char cpath[256];
 	*ppdds = 0;
-	gc->PlanetTexturePath(fname, cpath);
-	if (ftex = fopen(cpath, "rb")) {
-		hr = ReadTexture(ftex, ppdds, flags);
-		fclose(ftex);
-	}
-	else if (gc->TexturePath(fname, cpath)) {
+	if (gc->TexturePath(fname, cpath)) {
 		ftex = fopen(cpath, "rb");
 		if (ftex) {
 			hr = ReadTexture(ftex, ppdds, flags);
@@ -182,12 +177,7 @@ HRESULT TextureManager::LoadTexture (const char *fname, long ofs, LPDIRECTDRAWSU
 	FILE* ftex = 0;
 	char cpath[256];
 	*ppdds = 0;
-	gc->PlanetTexturePath(fname, cpath);
-	if (ftex = fopen(cpath, "rb")) {
-		fseek(ftex, ofs, SEEK_SET);
-		hr = ReadTexture(ftex, ppdds, flags);
-		fclose(ftex);
-	} else if (gc->TexturePath(fname, cpath)) {
+	if (gc->TexturePath(fname, cpath)) {
 		ftex = fopen(cpath, "rb");
 		if (ftex) {
 			fseek(ftex, ofs, SEEK_SET);
@@ -205,14 +195,7 @@ int TextureManager::LoadTextures (const char *fname, LPDIRECTDRAWSURFACE7 *ppdds
 	char cpath[256];
 	int ntex = 0;
 	FILE* ftex = 0;
-	gc->PlanetTexturePath(fname, cpath);
-	if (ftex = fopen(cpath, "rb")) {
-		for (ntex = 0; ntex < n; ntex++) {
-			if (FAILED(ReadTexture(ftex, ppdds + ntex, flags)))
-				break;
-		}
-		fclose(ftex);
-	} else if (gc->TexturePath(fname, cpath)) {
+	if (gc->TexturePath(fname, cpath)) {
 		ftex = fopen(cpath, "rb");
 		if (ftex) {
 			for (ntex = 0; ntex < n; ntex++) {

--- a/OVP/D3D7Client/Texture.h
+++ b/OVP/D3D7Client/Texture.h
@@ -28,10 +28,19 @@ public:
 	TextureManager (oapi::D3D7Client *gclient);
 	~TextureManager ();
 
+	/// \brief Load a DDS texture from file into a DX7 surface.
+	/// \param fname file name including extension (.dds). Any included paths are interpreted relative to
+	///    the default texture directories (usually .\Textures and .\Textures2).
+	/// \param ppdds pointer to pointer to surface which receives the texture data.
+	/// \param flags passed on to ReadTexture
+	/// \return S_OK if successful, S_FALSE otherwise
+	/// \note This follows the standard Orbiter texture loading convention: First check if the file is found
+	///    in the high-resolution texture directory (usually .\Textures2 or below), then check the low-resolution
+	///    directory (usually .\Textures or below).
+	/// \note Don't use this function to load planetary surface or cloud textures that use the quadtree mechanism,
+	///    because they can be redirected to a different directory.
+	/// \sa ReadTexture(FILE*, LPDIRECTDRAWSURFACE7*, DWORD)
 	HRESULT LoadTexture (const char *fname, LPDIRECTDRAWSURFACE7 *ppdds, DWORD flags);
-	// Read a texture from file 'fname' into the DX7 surface
-	// pointed to by 'ppdds'.
-	// flags: passed on to ReadTexture
 
 	HRESULT LoadTexture (const char *fname, long ofs, LPDIRECTDRAWSURFACE7 *ppdds, DWORD flags = 0);
 	// Read a single texture from a multi-texture file at offset ofs

--- a/OVP/D3D7Client/cloudmgr2.cpp
+++ b/OVP/D3D7Client/cloudmgr2.cpp
@@ -261,9 +261,7 @@ void TileManager2<CloudTile>::LoadZTrees()
 {
 	treeMgr = new ZTreeMgr*[ntreeMgr = 1];
 	if (cprm.tileLoadFlags & 0x0002) {
-		char cbuf[256];
-		GClient()->PlanetTexturePath (CbodyName(), cbuf);
-		treeMgr[0] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_CLOUD);
+		treeMgr[0] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_CLOUD);
 	} else
 		treeMgr[0] = 0;
 }

--- a/OVP/D3D7Client/surfmgr2.cpp
+++ b/OVP/D3D7Client/surfmgr2.cpp
@@ -91,8 +91,12 @@ void SurfTile::Load ()
 	ok = false;
 	owntex = true;
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-		sprintf (path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->CbodyName(), lvl+4, ilat, ilng);
-		ok = (mgr->GClient()->GetTexMgr()->LoadTexture (path, &tex, flag) == S_OK);
+		sprintf(path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
+		FILE* f = fopen(path, "rb");
+		if (f) {
+			ok = (mgr->GClient()->GetTexMgr()->ReadTexture(f, &tex, flag) == S_OK);
+			fclose(f);
+		}
 	}
 	if (!ok && smgr->ZTreeManager(0)) { // try loading from compressed archive
 		BYTE *buf;
@@ -116,8 +120,12 @@ void SurfTile::Load ()
 		if (owntex) {
 			ok = false;
 			if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-				sprintf (path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->CbodyName(), lvl+4, ilat, ilng);
-				ok = (mgr->GClient()->GetTexMgr()->LoadTexture (path, &ltex, flag) == S_OK);
+				sprintf (path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
+				FILE* f = fopen(path, "rb");
+				if (f) {
+					ok = (mgr->GClient()->GetTexMgr()->ReadTexture(f, &ltex, flag) == S_OK);
+					fclose(f);
+				}
 			}
 			if (!ok && smgr->ZTreeManager(1)) { // try loading from compressed archive
 				BYTE *buf;
@@ -156,22 +164,21 @@ void SurfTile::Load ()
 
 // -----------------------------------------------------------------------
 
-INT16 *SurfTile::ReadElevationFile (const char *name, int lvl, int ilat, int ilng, double tgt_res, double *mean_elev)
+INT16 *SurfTile::ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res, double *mean_elev)
 {
 	const int ndat = TILE_ELEVSTRIDE*TILE_ELEVSTRIDE;
 	ELEVFILEHEADER hdr;
 	INT16 *e = NULL;
 	INT16 ofs;
 	double scale, offset;
-	char path[256], texpath[256];
+	char path[256];
 	FILE *f;
 	int i;
 
 	// Elevation data
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-		sprintf (path, "%s\\Elev\\%02d\\%06d\\%06d.elv", name, lvl, ilat, ilng);
-		mgr->GClient()->PlanetTexturePath(path, texpath);
-		if (f = fopen(texpath, "rb")) {
+		sprintf (path, "%s\\Elev\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
+		if (f = fopen(path, "rb")) {
 			e = new INT16[ndat];
 			// read the elevation file header
 			fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
@@ -247,9 +254,8 @@ INT16 *SurfTile::ReadElevationFile (const char *name, int lvl, int ilat, int iln
 		INT16 offset;
 		bool do_rescale, do_shift;
 		if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-			sprintf (path, "%s\\Elev_mod\\%02d\\%06d\\%06d.elv", name, lvl, ilat, ilng);
-			mgr->GClient()->PlanetTexturePath(path, texpath);
-			if (f = fopen(texpath, "rb")) {
+			sprintf (path, "%s\\Elev_mod\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
+			if (f = fopen(path, "rb")) {
 				fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
 				if (hdr.hdrsize != sizeof(ELEVFILEHEADER)) {
 					fseek (f, hdr.hdrsize, SEEK_SET);
@@ -349,7 +355,7 @@ bool SurfTile::LoadElevationData ()
 	if (!mode) return false;
 
 	int ndat = TILE_ELEVSTRIDE*TILE_ELEVSTRIDE;
-	elev = ReadElevationFile (mgr->CbodyName(), lvl+4, ilat, ilng, mgr->ElevRes());
+	elev = ReadElevationFile (lvl + 4, ilat, ilng, mgr->ElevRes());
 	if (elev) {
 
 		has_elevfile = true;
@@ -976,13 +982,11 @@ void TileManager2<SurfTile>::LoadZTrees()
 {
 	treeMgr = new ZTreeMgr*[ntreeMgr = 5];
 	if (cprm.tileLoadFlags & 0x0002) {
-		char cbuf[256];
-		GClient()->PlanetTexturePath (CbodyName(), cbuf);
-		treeMgr[0] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_SURF);
-		treeMgr[1] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_MASK);
-		treeMgr[2] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_ELEV);
-		treeMgr[3] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_ELEVMOD);
-		treeMgr[4] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_LABEL);
+		treeMgr[0] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_SURF);
+		treeMgr[1] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_MASK);
+		treeMgr[2] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_ELEV);
+		treeMgr[3] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_ELEVMOD);
+		treeMgr[4] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_LABEL);
 	} else {
 		for (int i = 0; i < ntreeMgr; i++)
 			treeMgr[i] = 0;

--- a/OVP/D3D7Client/surfmgr2.cpp
+++ b/OVP/D3D7Client/surfmgr2.cpp
@@ -81,19 +81,17 @@ SurfTile::~SurfTile ()
 
 void SurfTile::Load ()
 {
-	bool bLoadMip = true; // for now
+	const bool bLoadMip = true; // for now
 	bool ok;
-
 	DWORD flag = (bLoadMip ? 0:4);
-	char path[256];
+	char path[512];
 
 	// Load surface texture
 	ok = false;
 	owntex = true;
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 		sprintf(path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
-		FILE* f = fopen(path, "rb");
-		if (f) {
+		if (FILE* f = fopen(path, "rb")) {
 			ok = (mgr->GClient()->GetTexMgr()->ReadTexture(f, &tex, flag) == S_OK);
 			fclose(f);
 		}
@@ -121,8 +119,7 @@ void SurfTile::Load ()
 			ok = false;
 			if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 				sprintf (path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
-				FILE* f = fopen(path, "rb");
-				if (f) {
+				if (FILE* f = fopen(path, "rb")) {
 					ok = (mgr->GClient()->GetTexMgr()->ReadTexture(f, &ltex, flag) == S_OK);
 					fclose(f);
 				}
@@ -172,13 +169,12 @@ INT16 *SurfTile::ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res,
 	INT16 ofs;
 	double scale, offset;
 	char path[256];
-	FILE *f;
 	int i;
 
 	// Elevation data
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 		sprintf (path, "%s\\Elev\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
-		if (f = fopen(path, "rb")) {
+		if (FILE* f = fopen(path, "rb")) {
 			e = new INT16[ndat];
 			// read the elevation file header
 			fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
@@ -255,7 +251,7 @@ INT16 *SurfTile::ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res,
 		bool do_rescale, do_shift;
 		if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 			sprintf (path, "%s\\Elev_mod\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
-			if (f = fopen(path, "rb")) {
+			if (FILE* f = fopen(path, "rb")) {
 				fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
 				if (hdr.hdrsize != sizeof(ELEVFILEHEADER)) {
 					fseek (f, hdr.hdrsize, SEEK_SET);

--- a/OVP/D3D7Client/surfmgr2.h
+++ b/OVP/D3D7Client/surfmgr2.h
@@ -37,7 +37,7 @@ protected:
 	// Return pointer to parent tile, if exists
 
 	void Load ();
-	INT16 *ReadElevationFile (const char *name, int lvl, int ilat, int ilng, double tgt_res, double *mean_elev=0);
+	INT16 *ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res, double *mean_elev=0);
 	bool LoadElevationData ();
 	void Render ();
 	void RenderLabels (oapi::Sketchpad *skp, oapi::Font **labelfont, int *fontidx);

--- a/OVP/D3D7Client/tilemgr2.cpp
+++ b/OVP/D3D7Client/tilemgr2.cpp
@@ -731,6 +731,9 @@ TileManager2Base::TileManager2Base (const vPlanet *vplanet, int _maxres, int _gr
 	camera = gc->GetScene()->GetCamera();
 	emgr = oapiElevationManager(obj);
 	elevRes = *(double*)oapiGetObjectParam (obj, OBJPRM_PLANET_ELEVRESOLUTION);
+	char path[1024];
+	gc->PlanetTexturePath(cbody_name, path);
+	m_dataRootDir = path;
 }
 
 // -----------------------------------------------------------------------

--- a/OVP/D3D7Client/tilemgr2.h
+++ b/OVP/D3D7Client/tilemgr2.h
@@ -215,6 +215,9 @@ public:
 	inline const int GridRes() const { return gridRes; }
 	inline const double ElevRes() const { return elevRes; }
 
+	/// \brief Return the root directory containing the body's texture data (surface, elevation, mask, cloud tiles)
+	inline const std::string& DataRootDir() const { return m_dataRootDir; }
+
 protected:
 	MATRIX4 WorldMatrix (int ilng, int nlng, int ilat, int nlat);
 	void SetWorldMatrix (const MATRIX4 &W);
@@ -224,6 +227,7 @@ protected:
 	// loads one of the four subnodes of 'node', given by 'idx'
 
 	static configPrm cprm;
+	std::string m_dataRootDir;       // the root directory (usually ending in the cbody's name) for all tile data (textures, elevations, etc.)
 	double obj_size;                 // planet radius
 	static TileLoader *loader;
 

--- a/Src/Orbiter/Texture.h
+++ b/Src/Orbiter/Texture.h
@@ -30,6 +30,12 @@ public:
 	// flags: bit 0 set: force creation in system memory
 	//        bit 1 set: uncompress texture
 
+	HRESULT ReadCompatibleSurface(FILE* file, LPDIRECTDRAWSURFACE7* ppdds, DWORD flags = 0);
+	// Read a DDS surface from an open stream
+	// Uncompress if required by the current device
+	// flags: bit 1 set: force map to uncompressed surface, even if hardware understands compression format
+	//        other flags are passed on to ReadDDSSurface
+
 	int ReadTextures (FILE *file, LPDIRECTDRAWSURFACE7 *pptex, int n, DWORD flags = 0);
 	// Read up to 'n' textures from an open stream into texture
 	// array 'pptex'. Return value is actual number of textures read
@@ -70,12 +76,6 @@ private:
 
 	HRESULT ReadDDSSurfaceFromMemory (BYTE *buf, DWORD nbuf,
 		DDSURFACEDESC2 *pddsd, LPDIRECTDRAWSURFACE7* ppddsDXT, DWORD flags);
-
-	HRESULT ReadCompatibleSurface (FILE *file, LPDIRECTDRAWSURFACE7 *ppdds, DWORD flags = 0);
-	// Read a DDS surface from an open stream
-	// Uncompress if required by the current device
-	// flags: bit 1 set: force map to uncompressed surface, even if hardware understands compression format
-	//        other flags are passed on to ReadDDSSurface
 
 	HRESULT FindBestPixelFormatMatch (DDPIXELFORMAT ddsdDDSTexture,
 		DDPIXELFORMAT *pddsdBestMatch);

--- a/Src/Orbiter/cloudmgr2.cpp
+++ b/Src/Orbiter/cloudmgr2.cpp
@@ -261,9 +261,7 @@ void TileManager2<CloudTile>::LoadZTrees()
 {
 	treeMgr = new ZTreeMgr*[ntreeMgr = 1];
 	if (cprm.tileLoadFlags & 0x0002) {
-		char cbuf[256];
-		g_pOrbiter->Cfg()->PTexPath (cbuf, cbody->Name());
-		treeMgr[0] = ZTreeMgr::CreateFromFile(cbuf, ZTreeMgr::LAYER_CLOUD);
+		treeMgr[0] = ZTreeMgr::CreateFromFile(m_dataRootDir.c_str(), ZTreeMgr::LAYER_CLOUD);
 	} else
 		treeMgr[0] = 0;
 }

--- a/Src/Orbiter/surfmgr2.cpp
+++ b/Src/Orbiter/surfmgr2.cpp
@@ -87,19 +87,17 @@ SurfTile::~SurfTile ()
 
 void SurfTile::Load ()
 {
-	bool bLoadMip = true; // for now
+	const bool bLoadMip = true; // for now
 	bool ok;
-
 	DWORD flag = (bLoadMip ? 0:4);
-	char path[256];
+	char path[512];
 
 	// Load surface texture
 	ok = false;
 	owntex = true;
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 		sprintf(path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
-		FILE* f = fopen(path, "rb");
-		if (f) {
+		if (FILE* f = fopen(path, "rb")) {
 			ok = (g_texmanager2->ReadCompatibleSurface(f, &tex, flag) == S_OK);
 			fclose(f);
 		}
@@ -127,8 +125,7 @@ void SurfTile::Load ()
 			ok = false;
 			if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 				sprintf(path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
-				FILE* f = fopen(path, "rb");
-				if (f) {
+				if (FILE* f = fopen(path, "rb")) {
 					ok = (g_texmanager2->ReadCompatibleSurface(f, &ltex, flag) == S_OK);
 					fclose(f);
 				}
@@ -179,12 +176,11 @@ INT16 *SurfTile::ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res,
 	INT16 ofs;
 	double scale, offset;
 	char path[256];
-	FILE *f;
 
 	// Elevation data
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 		sprintf (path, "%s\\Elev\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
-		if (f = fopen (path, "rb")) {
+		if (FILE* f = fopen (path, "rb")) {
 			e = new INT16[ndat];
 			// read the elevation file header
 			fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
@@ -261,7 +257,7 @@ INT16 *SurfTile::ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res,
 		INT16 offset;
 		if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
 			sprintf (path, "%s\\Elev_mod\\%02d\\%06d\\%06d.elv", mgr->DataRootDir().c_str(), lvl, ilat, ilng);
-			if (f = fopen (path, "rb")) {
+			if (FILE* f = fopen (path, "rb")) {
 				fread (&hdr, sizeof(ELEVFILEHEADER), 1, f);
 				if (hdr.hdrsize != sizeof(ELEVFILEHEADER)) {
 					fseek (f, hdr.hdrsize, SEEK_SET);

--- a/Src/Orbiter/surfmgr2.cpp
+++ b/Src/Orbiter/surfmgr2.cpp
@@ -97,8 +97,12 @@ void SurfTile::Load ()
 	ok = false;
 	owntex = true;
 	if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-		sprintf (path, "%s\\Surf\\%02d\\%06d\\%06d", mgr->Cbody()->Name(), lvl+4, ilat, ilng);
-		ok = (g_texmanager2->OpenTexture (path, ".dds", 0, &tex, flag) != 0);
+		sprintf(path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
+		FILE* f = fopen(path, "rb");
+		if (f) {
+			ok = (g_texmanager2->ReadCompatibleSurface(f, &tex, flag) == DD_OK);
+			fclose(f);
+		}
 	}
 	if (!ok && smgr->treeMgr[0]) { // try loading from compressed archive
 		BYTE *buf;
@@ -122,8 +126,12 @@ void SurfTile::Load ()
 		if (owntex) {
 			ok = false;
 			if (mgr->Cprm().tileLoadFlags & 0x0001) { // try loading from individual tile file
-				sprintf (path, "%s\\Mask\\%02d\\%06d\\%06d", mgr->Cbody()->Name(), lvl+4, ilat, ilng);
-				ok = (g_texmanager2->OpenTexture (path, ".dds", 0, &ltex, flag) != 0);
+				sprintf(path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
+				FILE* f = fopen(path, "rb");
+				if (f) {
+					ok = (g_texmanager2->ReadCompatibleSurface(f, &ltex, flag) == DD_OK);
+					fclose(f);
+				}
 			}
 			if (!ok && smgr->treeMgr[1]) { // try loading from compressed archive
 				BYTE *buf;

--- a/Src/Orbiter/surfmgr2.cpp
+++ b/Src/Orbiter/surfmgr2.cpp
@@ -100,7 +100,7 @@ void SurfTile::Load ()
 		sprintf(path, "%s\\Surf\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
 		FILE* f = fopen(path, "rb");
 		if (f) {
-			ok = (g_texmanager2->ReadCompatibleSurface(f, &tex, flag) == DD_OK);
+			ok = (g_texmanager2->ReadCompatibleSurface(f, &tex, flag) == S_OK);
 			fclose(f);
 		}
 	}
@@ -129,7 +129,7 @@ void SurfTile::Load ()
 				sprintf(path, "%s\\Mask\\%02d\\%06d\\%06d.dds", mgr->DataRootDir().c_str(), lvl + 4, ilat, ilng);
 				FILE* f = fopen(path, "rb");
 				if (f) {
-					ok = (g_texmanager2->ReadCompatibleSurface(f, &ltex, flag) == DD_OK);
+					ok = (g_texmanager2->ReadCompatibleSurface(f, &ltex, flag) == S_OK);
 					fclose(f);
 				}
 			}

--- a/Src/Orbiter/surfmgr2.h
+++ b/Src/Orbiter/surfmgr2.h
@@ -30,7 +30,7 @@ protected:
 	// Return pointer to parent tile, if exists
 
 	void Load ();
-	INT16 *ReadElevationFile (const char *name, int lvl, int ilat, int ilng, double tgt_res, double *mean_elev=0);
+	INT16 *ReadElevationFile (int lvl, int ilat, int ilng, double tgt_res, double *mean_elev=0);
 	bool LoadElevationData ();
 	void Render ();
 	void RenderLabels (oapi::Sketchpad *skp, oapi::Font **labelfont, int *fontidx);

--- a/Src/Orbiter/tilemgr2.cpp
+++ b/Src/Orbiter/tilemgr2.cpp
@@ -869,6 +869,9 @@ TileManager2Base::TileManager2Base (const Planet *_cbody, int _maxres, int _grid
 	// set persistent parameters
 	prm.maxlvl = max (0, _maxres-4);
 	gridRes = _gridres;
+	char path[1024];
+	g_pOrbiter->Cfg()->PTexPath(path, cbody->Name());
+	m_dataRootDir = path;
 }
 
 // -----------------------------------------------------------------------

--- a/Src/Orbiter/tilemgr2.h
+++ b/Src/Orbiter/tilemgr2.h
@@ -207,6 +207,9 @@ public:
 	inline const Planet *Cbody() const { return cbody; }
 	// Private member const access functions
 
+	/// \brief Return the root directory containing the body's texture data (surface, elevation, mask, cloud tiles)
+	inline const std::string& DataRootDir() const { return m_dataRootDir; }
+
 	template<class TileType>
 	QuadTreeNode<TileType> *FindNode (QuadTreeNode<TileType> root[2], int lvl, int ilng, int ilat);
 	// Returns the node at the specified position, or 0 if it doesn't exist
@@ -233,6 +236,7 @@ protected:
 	// loads one of the four subnodes of 'node', given by 'idx'
 
 	const Planet *cbody;			// the planet we are rendering
+	std::string m_dataRootDir;      // the root directory (usually ending in the cbody's name) for all tile data (textures, elevations, etc.)
 
 	static TileLoader *loader;		// pointer to global tile loader
 	static configPrm cprm;


### PR DESCRIPTION
- inline client now loads planet surface tiles from cache, even if the root is not under the .\Textures directory.
- cleaned up and synchronised some of the equivalent code in OVP\D3D7Client, although this didn't have the same problem.

closes #207