### PR TITLE
209 crash extprm

### DIFF
--- a/OVP/D3D7Client/D3D7Client.h
+++ b/OVP/D3D7Client/D3D7Client.h
@@ -38,6 +38,7 @@ class D3D7Config;
 class MeshManager;
 class TextureManager;
 class Scene;
+class D3D7PlanetRenderCfg;
 
 HRESULT clbkConfirmDevice (DDCAPS*, D3DDEVICEDESC7*);
 
@@ -64,6 +65,7 @@ class D3D7Client: public GDIClient {
 	friend class ::Scene;
 	friend class ::MeshManager;
 	friend class ::TextureManager;
+	friend class ::D3D7PlanetRenderCfg;
 
 public:
 	D3D7Client (HINSTANCE hInstance);
@@ -262,13 +264,13 @@ public:
 	inline const D3D7Config *Cfg() const { return cfg; }
 
 	/// Returns the DirectDraw object
-    inline const LPDIRECTDRAW7        GetDirectDraw() const   { return pDD; }
+    inline const LPDIRECTDRAW7        GetDirectDraw() const   { return m_pDD; }
 
 	/// Returns the Direct3D object
-	inline const LPDIRECT3D7          GetDirect3D7() const    { return pD3D; }
+	inline const LPDIRECT3D7          GetDirect3D7() const    { return m_pD3D; }
 
 	/// Returns the Direct3D device
-    inline const LPDIRECT3DDEVICE7    GetDevice() const       { return pd3dDevice; }
+    inline const LPDIRECT3DDEVICE7    GetDevice() const       { return m_pD3DDevice; }
 
 	/// Returns the render surface
 	inline const LPDIRECTDRAWSURFACE7 GetRenderTarget() const { return pddsRenderTarget; }
@@ -640,9 +642,9 @@ private:
 	void LogRenderParams () const;
 
     D3D7Enum_DeviceInfo* m_pDeviceInfo;
-	LPDIRECTDRAW7        pDD;
-    LPDIRECT3D7          pD3D;
-    LPDIRECT3DDEVICE7    pd3dDevice;
+	LPDIRECTDRAW7        m_pDD;
+    LPDIRECT3D7          m_pD3D;
+    LPDIRECT3DDEVICE7    m_pD3DDevice;
     LPDIRECTDRAWSURFACE7 pddsRenderTarget;
 	LPDIRECTDRAWCLIPPER  clipper;
 	CD3DFramework7* m_pFramework;
@@ -660,7 +662,7 @@ private:
 	MeshManager *meshmgr;   // mesh manager
 	TextureManager *texmgr; // texture manager
 
-	LaunchpadItem *lpiCfg, *lpiPlanetRender;
+	//LaunchpadItem *lpiCfg, *lpiPlanetRender;
 
 	// Load status output parameters
 	struct {

--- a/OVP/D3D7Client/D3D7Extra.cpp
+++ b/OVP/D3D7Client/D3D7Extra.cpp
@@ -31,9 +31,11 @@ char *D3D7ClientCfg::Description ()
 }
 
 
-D3D7PlanetRenderCfg::D3D7PlanetRenderCfg (oapi::D3D7Client *_gc, D3D7Config *_cfg)
-: LaunchpadItem (), gc(_gc), cfg(_cfg)
-{}
+D3D7PlanetRenderCfg::D3D7PlanetRenderCfg (oapi::D3D7Client *_gc)
+: LaunchpadItem (), gc(_gc)
+{
+	cfg = gc->cfg;
+}
 
 char *D3D7PlanetRenderCfg::Name ()
 {
@@ -49,8 +51,8 @@ char *D3D7PlanetRenderCfg::Description ()
 
 bool D3D7PlanetRenderCfg::clbkOpen (HWND hLaunchpad)
 {
-	extern HINSTANCE g_hInst;
-	return OpenDialog (g_hInst, hLaunchpad, IDD_EXTRA_PLANETRENDER, DlgProc);
+	HINSTANCE hInst = gc->GetModule();
+	return OpenDialog (hInst, hLaunchpad, IDD_EXTRA_PLANETRENDER, DlgProc);
 }
 
 void D3D7PlanetRenderCfg::InitDialog (HWND hDlg)

--- a/OVP/D3D7Client/D3D7Extra.h
+++ b/OVP/D3D7Client/D3D7Extra.h
@@ -29,7 +29,7 @@ public:
 
 class D3D7PlanetRenderCfg: public LaunchpadItem {
 public:
-	D3D7PlanetRenderCfg (oapi::D3D7Client *_gc, D3D7Config *_cfg);
+	D3D7PlanetRenderCfg (oapi::D3D7Client *_gc);
 	char *Name ();
 	char *Description ();
 	void InitDialog (HWND hDlg);

--- a/Src/Orbiter/OGraphics.cpp
+++ b/Src/Orbiter/OGraphics.cpp
@@ -374,13 +374,13 @@ OrbiterGraphics::OrbiterGraphics (Orbiter *po): GDIClient (po->GetInstance())
 	scene                  = NULL;
 	vtab                   = NULL;
 	clipper                = NULL;
-    m_pFramework           = NULL;
-	m_pDD                  = NULL;
-	m_pD3D                 = NULL;
-	m_pd3dDevice           = NULL;
-    m_pddsRenderTarget     = NULL;
+    m_pFramework           = nullptr;
+	m_pDD                  = nullptr;
+	m_pD3D                 = nullptr;
+	m_pD3DDevice           = nullptr;
+	m_pDeviceInfo          = nullptr;
+	m_pddsRenderTarget     = NULL;
 	m_pddsRenderTargetLeft = NULL;
-	m_pDeviceInfo          = NULL;
 	viewW = viewH          = 0;
 	viewBPP                = 0;
 	bFullscreen            = false;
@@ -622,18 +622,18 @@ void OrbiterGraphics::clbkRenderScene ()
 	if (bUseStereo && m_pDeviceInfo->bStereo && !m_pDeviceInfo->bWindowed) {
 
 		// TODO: Translate view matrix for left eye
-		m_pd3dDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
-		m_pd3dDevice->SetRenderTarget (m_pddsRenderTargetLeft, 0);
+		m_pD3DDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
+		m_pD3DDevice->SetRenderTarget (m_pddsRenderTargetLeft, 0);
 		scene->Render (&rect);
 
 		// TODO: Translate view matrix for right eye
-		m_pd3dDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
-		m_pd3dDevice->SetRenderTarget (m_pddsRenderTarget, 0);
+		m_pD3DDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
+		m_pD3DDevice->SetRenderTarget (m_pddsRenderTarget, 0);
 		scene->Render (&rect);
 
 	} else {
 	
-		m_pd3dDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
+		m_pD3DDevice->SetTransform (D3DTRANSFORMSTATE_VIEW, &mView);
 		scene->Render (&rect);
 
 	}
@@ -885,11 +885,11 @@ void OrbiterGraphics::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MA
 
 	DWORD vtxFmt = D3DFVF_XYZRHW | D3DFVF_TEX1 | D3DFVF_TEXCOORDSIZE2(0);
 	DWORD dAlpha;
-	m_pd3dDevice->GetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, &dAlpha);
-	m_pd3dDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, TRUE);
-	m_pd3dDevice->SetTextureStageState (0, D3DTSS_ADDRESS, D3DTADDRESS_CLAMP);
+	m_pD3DDevice->GetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, &dAlpha);
+	m_pD3DDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, TRUE);
+	m_pD3DDevice->SetTextureStageState (0, D3DTSS_ADDRESS, D3DTADDRESS_CLAMP);
 	if (transparent)
-		m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_ONE);
+		m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_ONE);
 	float rhw = 1;
 	DWORD i, j, nvtx, ngrp = oapiMeshGroupCount (hMesh);
 	SURFHANDLE surf = (SURFHANDLE)-1, newsurf = 0;
@@ -902,8 +902,8 @@ void OrbiterGraphics::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MA
 		if (grp->UsrFlag & 0x2) continue; // skip this group
 
 		if (grp->UsrFlag & 0x8) { // additive blend
-			m_pd3dDevice->SetRenderState (D3DRENDERSTATE_SRCBLEND, D3DBLEND_ONE);
-			m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_ONE);
+			m_pD3DDevice->SetRenderState (D3DRENDERSTATE_SRCBLEND, D3DBLEND_ONE);
+			m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_ONE);
 		}
 
 		if (grp->TexIdx == SPEC_DEFAULT) {
@@ -920,7 +920,7 @@ void OrbiterGraphics::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MA
 			newsurf = oapiGetTextureHandle (hMesh, grp->TexIdx+1);
 		}
 		if (newsurf != surf) {
-			m_pd3dDevice->SetTexture (0, (LPDIRECTDRAWSURFACE7)(surf = newsurf));
+			m_pD3DDevice->SetTexture (0, (LPDIRECTDRAWSURFACE7)(surf = newsurf));
 		}
 
 		nvtx = grp->nVtx;
@@ -940,19 +940,19 @@ void OrbiterGraphics::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MA
 			tgtvtx->tu = srcvtx->tu;
 			tgtvtx->tv = srcvtx->tv;
 		}
-		m_pd3dDevice->DrawIndexedPrimitive (D3DPT_TRIANGLELIST, vtxFmt, hvtx, nvtx, grp->Idx, grp->nIdx, 0);
+		m_pD3DDevice->DrawIndexedPrimitive (D3DPT_TRIANGLELIST, vtxFmt, hvtx, nvtx, grp->Idx, grp->nIdx, 0);
 
 		if (grp->UsrFlag & 0x8) { // reset additive
-			m_pd3dDevice->SetRenderState (D3DRENDERSTATE_SRCBLEND, D3DBLEND_SRCALPHA);
-			m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
+			m_pD3DDevice->SetRenderState (D3DRENDERSTATE_SRCBLEND, D3DBLEND_SRCALPHA);
+			m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
 		}
 	}
 	
-	m_pd3dDevice->SetTextureStageState (0, D3DTSS_ADDRESS, D3DTADDRESS_WRAP);
+	m_pD3DDevice->SetTextureStageState (0, D3DTSS_ADDRESS, D3DTADDRESS_WRAP);
 	if (transparent)
-		m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
+		m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
 	if (dAlpha != TRUE)
-		m_pd3dDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, dAlpha);
+		m_pD3DDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, dAlpha);
 }
 
 // =======================================================================
@@ -962,19 +962,19 @@ void OrbiterGraphics::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MA
 	bool reset = false;
 	DWORD alphaop, alphaarg2, tfactor;
 	if (alpha < 1.0f) {
-		m_pd3dDevice->GetTextureStageState (0, D3DTSS_ALPHAOP, &alphaop);
-		m_pd3dDevice->GetTextureStageState (0, D3DTSS_ALPHAARG2, &alphaarg2);
-		m_pd3dDevice->GetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, &tfactor);
-		m_pd3dDevice->SetTextureStageState (0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
-		m_pd3dDevice->SetTextureStageState (0, D3DTSS_ALPHAARG2, D3DTA_TFACTOR);
-		m_pd3dDevice->SetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, D3DRGBA(1,1,1,alpha));
+		m_pD3DDevice->GetTextureStageState (0, D3DTSS_ALPHAOP, &alphaop);
+		m_pD3DDevice->GetTextureStageState (0, D3DTSS_ALPHAARG2, &alphaarg2);
+		m_pD3DDevice->GetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, &tfactor);
+		m_pD3DDevice->SetTextureStageState (0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+		m_pD3DDevice->SetTextureStageState (0, D3DTSS_ALPHAARG2, D3DTA_TFACTOR);
+		m_pD3DDevice->SetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, D3DRGBA(1,1,1,alpha));
 		reset = true;
 	}
 	clbkRender2DPanel (hSurf, hMesh, T, additive);
 	if (reset) {
-		m_pd3dDevice->SetTextureStageState (0, D3DTSS_ALPHAOP, alphaop);
-		m_pd3dDevice->SetTextureStageState (0, D3DTSS_ALPHAARG2, alphaarg2);
-		m_pd3dDevice->SetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, tfactor);
+		m_pD3DDevice->SetTextureStageState (0, D3DTSS_ALPHAOP, alphaop);
+		m_pD3DDevice->SetTextureStageState (0, D3DTSS_ALPHAARG2, alphaarg2);
+		m_pD3DDevice->SetRenderState (D3DRENDERSTATE_TEXTUREFACTOR, tfactor);
 	}
 }
 
@@ -984,7 +984,7 @@ void OrbiterGraphics::clbkSetCamera (double aspect, double tan_ap, double nearpl
 {
 	static D3DMATRIX mProj;
 
-	if (m_pd3dDevice) {
+	if (m_pD3DDevice) {
 		ZeroMemory (&mProj, sizeof (D3DMATRIX));
 		mProj._11 = (FLOAT)(aspect / tan_ap);
 		mProj._22 = (FLOAT)(1.0    / tan_ap);
@@ -992,7 +992,7 @@ void OrbiterGraphics::clbkSetCamera (double aspect, double tan_ap, double nearpl
 		mProj._34 = 1.0f;
 
 		// register new projection matrix with device
-		m_pd3dDevice->SetTransform (D3DTRANSFORMSTATE_PROJECTION, &mProj);
+		m_pD3DDevice->SetTransform (D3DTRANSFORMSTATE_PROJECTION, &mProj);
 	}
 }
 
@@ -1019,7 +1019,7 @@ HRESULT OrbiterGraphics::Init3DEnvironment ()
 
 		m_pDD        = m_pFramework->GetDirectDraw();
         m_pD3D       = m_pFramework->GetDirect3D();
-        m_pd3dDevice = m_pFramework->GetD3DDevice();
+        m_pD3DDevice = m_pFramework->GetD3DDevice();
 
 		m_pddsRenderTarget        = m_pFramework->GetRenderSurface();
         m_pddsRenderTargetLeft    = m_pFramework->GetRenderSurfaceLeft();
@@ -1041,7 +1041,7 @@ HRESULT OrbiterGraphics::Init3DEnvironment ()
 		LogRenderParams();
 
 		// Create texture manager
-		g_texmanager2 = new TextureManager2 (m_pd3dDevice); TRACENEW
+		g_texmanager2 = new TextureManager2 (m_pD3DDevice); TRACENEW
 
 		// Create clipper object
 		if (bFullscreen) {

--- a/Src/Orbiter/OGraphics.h
+++ b/Src/Orbiter/OGraphics.h
@@ -112,7 +112,7 @@ public:
 	inline CD3DFramework7*      GetFramework() const  { return m_pFramework; }
 	inline LPDIRECTDRAW7        GetDirectDraw() const { return m_pDD; }
 	inline LPDIRECT3D7          GetDirect3D7() const  { return m_pD3D; }
-    inline LPDIRECT3DDEVICE7    GetDevice()		 	  { return m_pd3dDevice; }
+    inline LPDIRECT3DDEVICE7    GetDevice()		 	  { return m_pD3DDevice; }
 	inline LPDIRECTDRAWSURFACE7 GetRenderTarget()     {
 		return m_pddsRenderTarget;
 	}
@@ -202,7 +202,7 @@ private:
 	CD3DFramework7      *m_pFramework;
 	LPDIRECTDRAW7        m_pDD;
 	LPDIRECT3D7          m_pD3D;
-	LPDIRECT3DDEVICE7    m_pd3dDevice;
+	LPDIRECT3DDEVICE7    m_pD3DDevice;
     LPDIRECTDRAWSURFACE7 m_pddsRenderTarget;
 	LPDIRECTDRAWSURFACE7 m_pddsRenderTargetLeft; // For stereo modes (not supported)
 	DDSURFACEDESC2       m_ddsdRenderTarget;

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -744,13 +744,13 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 	// Generate logical world objects
 #ifdef INLINEGRAPHICS
 	// these should be called from withing oclient
-	CreatePatchDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
+	CreatePatchDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
 	VObject::CreateDeviceObjects (oclient);
-	PatchManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	TileManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	TileManager2Base::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	CSphereManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	VVessel::CreateDeviceObjects (oclient->m_pd3dDevice);
+	PatchManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	TileManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	TileManager2Base::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	CSphereManager::CreateDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	VVessel::CreateDeviceObjects (oclient->m_pD3DDevice);
 #endif // INLINEGRAPHICS
 	if (gclient) {
 		Base::CreateStaticDeviceObjects();
@@ -1645,40 +1645,40 @@ HRESULT Orbiter::InitDeviceObjects ()
 	// All of this should be moved into the inline graphics client!
 #ifdef INLINEGRAPHICS
     D3DVIEWPORT7 vp;
-    oclient->m_pd3dDevice->GetViewport(&vp);
+    oclient->m_pD3DDevice->GetViewport(&vp);
 	// viewport-related code here
 
     // Turn on lighting. Light will be set during FrameMove() call
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_LIGHTING, bEnableLighting);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_AMBIENT, g_pOrbiter->Cfg()->AmbientColour);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_LIGHTING, bEnableLighting);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_AMBIENT, g_pOrbiter->Cfg()->AmbientColour);
 
 	//if (!pCWorld->LoadRRTextures(m_hWnd, "textures.dat"))
 	//	LOGOUT("LoadRRTextures failed");
 
     // Set miscellaneous renderstates
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DITHERENABLE, TRUE);
-    oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_ZENABLE, TRUE);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_FILLMODE, pConfig->CfgDebugPrm.bWireframeMode ? D3DFILL_WIREFRAME : D3DFILL_SOLID);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_SHADEMODE, D3DSHADE_GOURAUD);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_SPECULARENABLE, FALSE);
-    oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, FALSE);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
-	oclient->m_pd3dDevice->SetRenderState (D3DRENDERSTATE_NORMALIZENORMALS, pConfig->CfgDebugPrm.bNormaliseNormals ? TRUE : FALSE);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DITHERENABLE, TRUE);
+    oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_ZENABLE, TRUE);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_FILLMODE, pConfig->CfgDebugPrm.bWireframeMode ? D3DFILL_WIREFRAME : D3DFILL_SOLID);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_SHADEMODE, D3DSHADE_GOURAUD);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_SPECULARENABLE, FALSE);
+    oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_ALPHABLENDENABLE, FALSE);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_DESTBLEND, D3DBLEND_INVSRCALPHA);
+	oclient->m_pD3DDevice->SetRenderState (D3DRENDERSTATE_NORMALIZENORMALS, pConfig->CfgDebugPrm.bNormaliseNormals ? TRUE : FALSE);
 
 	// Set texture renderstates
     //D3DTextr_RestoreAllTextures( pd3dDevice );
-    oclient->m_pd3dDevice->SetTextureStageState (0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-    oclient->m_pd3dDevice->SetTextureStageState (0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-    oclient->m_pd3dDevice->SetTextureStageState (0, D3DTSS_COLOROP,   D3DTOP_MODULATE);
-	oclient->m_pd3dDevice->SetTextureStageState (0, D3DTSS_MINFILTER, D3DTFN_LINEAR);
-	oclient->m_pd3dDevice->SetTextureStageState (0, D3DTSS_MAGFILTER, D3DTFG_LINEAR);
-	oclient->m_pd3dDevice->SetTextureStageState (1, D3DTSS_MINFILTER, D3DTFN_LINEAR);
-	oclient->m_pd3dDevice->SetTextureStageState (1, D3DTSS_MAGFILTER, D3DTFG_LINEAR);
+    oclient->m_pD3DDevice->SetTextureStageState (0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+    oclient->m_pD3DDevice->SetTextureStageState (0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+    oclient->m_pD3DDevice->SetTextureStageState (0, D3DTSS_COLOROP,   D3DTOP_MODULATE);
+	oclient->m_pD3DDevice->SetTextureStageState (0, D3DTSS_MINFILTER, D3DTFN_LINEAR);
+	oclient->m_pD3DDevice->SetTextureStageState (0, D3DTSS_MAGFILTER, D3DTFG_LINEAR);
+	oclient->m_pD3DDevice->SetTextureStageState (1, D3DTSS_MINFILTER, D3DTFN_LINEAR);
+	oclient->m_pD3DDevice->SetTextureStageState (1, D3DTSS_MAGFILTER, D3DTFG_LINEAR);
 
 	viewW = oclient->viewW;
 	viewH = oclient->viewH;
 
-	g_texmanager = new TextureManager (oclient->m_pd3dDevice, MAX_TEXTURE_BUFSIZE); TRACENEW
+	g_texmanager = new TextureManager (oclient->m_pD3DDevice, MAX_TEXTURE_BUFSIZE); TRACENEW
 	g_texmanager->SetTexturePath (pConfig->CfgDirPrm.TextureDir);
 	//g_texmanager2 = new TextureManager2 (oclient->m_pd3dDevice); TRACENEW
 #endif // INLINEGRAPHICS
@@ -1697,9 +1697,9 @@ HRESULT Orbiter::InitDeviceObjects ()
 HRESULT Orbiter::RestoreDeviceObjects ()
 {
 #ifdef INLINEGRAPHICS
-	RestorePatchDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	PatchManager::RestoreDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
-	g_pane->RestoreDeviceObjects (oclient->m_pD3D, oclient->m_pd3dDevice);
+	RestorePatchDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	PatchManager::RestoreDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
+	g_pane->RestoreDeviceObjects (oclient->m_pD3D, oclient->m_pD3DDevice);
 #endif // INLINEGRAPHICS
 	return S_OK;
 }

--- a/Src/Orbiter/TabExtra.cpp
+++ b/Src/Orbiter/TabExtra.cpp
@@ -27,17 +27,17 @@ extern Orbiter *g_pOrbiter;
 
 orbiter::ExtraTab::ExtraTab (const LaunchpadDialog *lp): LaunchpadTab (lp)
 {
-	nExtPrm = 0;
+	m_internalPrm = 0;
 }
 
 //-----------------------------------------------------------------------------
 
 orbiter::ExtraTab::~ExtraTab ()
 {
-	if (nExtPrm) {
-		for (DWORD i = 0; i < nExtPrm; i++) delete ExtPrm[i];
-		delete []ExtPrm;
-	}
+	// at this point, only the internally created entries should be left
+	// so they should be safe to delete
+	for (int i = 0; i < m_ExtPrm.size(); i++)
+		delete m_ExtPrm[i];
 }
 
 //-----------------------------------------------------------------------------
@@ -58,22 +58,22 @@ void orbiter::ExtraTab::Create ()
 void orbiter::ExtraTab::GetConfig (const Config *cfg)
 {
 	HTREEITEM ht;
-	ht = RegisterExtraParam (new ExtraPropagation (this), NULL); TRACENEW
-	RegisterExtraParam (new ExtraDynamics (this), ht); TRACENEW
-	//RegisterExtraParam (new ExtraAngDynamics (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraStabilisation (this), ht); TRACENEW
-	ht = RegisterExtraParam (new ExtraInstruments (this), NULL); TRACENEW
-	RegisterExtraParam (new ExtraMfdConfig (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraVesselConfig (this), NULL); TRACENEW
-	RegisterExtraParam (new ExtraPlanetConfig (this), NULL); TRACENEW
-	ht = RegisterExtraParam (new ExtraDebug (this), NULL); TRACENEW
-	RegisterExtraParam (new ExtraShutdown (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraFixedStep (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraRenderingOptions (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraTimerSettings (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraLaunchpadOptions (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraLogfileOptions (this), ht); TRACENEW
-	RegisterExtraParam (new ExtraPerformanceSettings (this), ht); TRACENEW
+	ht = RegisterExtraParam(new ExtraPropagation(this), NULL); TRACENEW
+	RegisterExtraParam(new ExtraDynamics(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraStabilisation(this), ht); TRACENEW
+	ht = RegisterExtraParam(new ExtraInstruments(this), NULL); TRACENEW
+	RegisterExtraParam(new ExtraMfdConfig(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraVesselConfig(this), NULL); TRACENEW
+	RegisterExtraParam(new ExtraPlanetConfig(this), NULL); TRACENEW
+	ht = RegisterExtraParam(new ExtraDebug(this), NULL); TRACENEW
+	RegisterExtraParam(new ExtraShutdown(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraFixedStep(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraRenderingOptions(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraTimerSettings(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraLaunchpadOptions(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraLogfileOptions(this), ht); TRACENEW
+	RegisterExtraParam(new ExtraPerformanceSettings(this), ht); TRACENEW
+	m_internalPrm = m_ExtPrm.size();
 	SetWindowText (GetDlgItem (hTab, IDC_EXT_TEXT), "Advanced and addon-specific configuration parameters.\r\n\r\nClick on an item to get a description.\r\n\r\nDouble-click to open or expand.");
 	int listw = cfg->CfgWindowPos.LaunchpadExtListWidth;
 	if (!listw) {
@@ -143,13 +143,7 @@ HTREEITEM orbiter::ExtraTab::RegisterExtraParam (LaunchpadItem *item, HTREEITEM 
 	if (hti) return hti;
 
 	// add extra parameter instance to list
-	LaunchpadItem **tmp = new LaunchpadItem*[nExtPrm+1]; TRACENEW
-	if (nExtPrm) {
-		memcpy (tmp, ExtPrm, nExtPrm*sizeof(LaunchpadItem*));
-		delete []ExtPrm;
-	}
-	ExtPrm = tmp;
-	ExtPrm[nExtPrm++] = item;
+	m_ExtPrm.push_back(item);
 
 	// if a name is provided, add item to tree list
 	char *name = item->Name();
@@ -170,20 +164,11 @@ HTREEITEM orbiter::ExtraTab::RegisterExtraParam (LaunchpadItem *item, HTREEITEM 
 
 bool orbiter::ExtraTab::UnregisterExtraParam (LaunchpadItem *item)
 {
-	DWORD i, j, k;
-	for (i = 0; i < nExtPrm; i++) {
-		if (ExtPrm[i] == item) {
-			TreeView_DeleteItem (GetDlgItem (hTab, IDC_EXT_LIST), item->hItem);
-			LaunchpadItem **tmp = 0;
-			if (nExtPrm > 1) {
-				tmp = new LaunchpadItem*[nExtPrm-1]; TRACENEW
-				for (j = k = 0; j < nExtPrm; j++)
-					if (j != i) tmp[k++] = ExtPrm[j];
-			}
-			delete []ExtPrm;
-			ExtPrm = tmp;
-			nExtPrm--;
-			item->clbkWriteConfig (); // save state before removing
+	for (auto it = m_ExtPrm.begin(); it != m_ExtPrm.end(); it++) {
+		if (*it == item) {
+			TreeView_DeleteItem(GetDlgItem(hTab, IDC_EXT_LIST), item->hItem); // remove entry from UI
+			item->clbkWriteConfig(); // allow item to save state before removing
+			m_ExtPrm.erase(it);        // delete the container - the actual item has to be deleted by the caller
 			return true;
 		}
 	}
@@ -227,8 +212,8 @@ HTREEITEM orbiter::ExtraTab::FindExtraParamChild (const HTREEITEM parent)
 
 void orbiter::ExtraTab::WriteExtraParams ()
 {
-	for (DWORD i = 0; i < nExtPrm; i++)
-		ExtPrm[i]->clbkWriteConfig ();
+	for (auto it = m_ExtPrm.begin(); it != m_ExtPrm.end(); it++)
+		(*it)->clbkWriteConfig();
 }
 
 //-----------------------------------------------------------------------------

--- a/Src/Orbiter/TabExtra.h
+++ b/Src/Orbiter/TabExtra.h
@@ -39,6 +39,10 @@ namespace orbiter {
 		// as a root (top level) item. Otherwise it appears as a sub-item under
 		// the parent item.
 
+		/// \brief Unregister an item in the Extra list
+		/// \param item LaunchpadItem to be unregistered
+		/// \return true if item was found and unregistered
+		/// \note This function does not 
 		bool UnregisterExtraParam(LaunchpadItem* item);
 		// Unregister an item in the "Extra" list.
 
@@ -54,8 +58,8 @@ namespace orbiter {
 		// (internal "extra" items use the Config class to write to Orbiter.cfg)
 
 	private:
-		LaunchpadItem** ExtPrm;  // list of parameter items on "Extra" list
-		DWORD nExtPrm;
+		std::vector<LaunchpadItem*> m_ExtPrm; // list of parameter items on "Extra" list
+		int m_internalPrm;                    // number of internally created entries
 
 		SplitterCtrl splitListDesc;  // splitter control for extras list(left) and description(right)
 		RECT r_pane, r_edit0;


### PR DESCRIPTION
Crash was caused by invalid order of de-registration of Launchpad "Extra" items by D3D7 client. Moved registration calls to "InitModule" and de-registration calls to "ExitModule" to fix this.

Closes #209