### PR TITLE
211 module deletion

### DIFF
--- a/OVP/D3D7Client/D3D7Client.cpp
+++ b/OVP/D3D7Client/D3D7Client.cpp
@@ -44,7 +44,7 @@ struct G_PARAM {
 	D3D7Client* client;             // the client soliton
 	LaunchpadItem* lpiD3D7;         // "Extra" group header: D3D7 configuration items
 	LaunchpadItem* lpiPlanetRender; // "Extra" item: planet render parameters
-} g_Param = { 0, 0, 0, 0 };
+} g_Param = { 0, nullptr, nullptr, nullptr };
 
 // ==============================================================
 // API interface
@@ -87,7 +87,7 @@ DLLCLBK void ExitModule (HINSTANCE hDLL)
 	if (g_Param.client) {
 		oapiUnregisterGraphicsClient (g_Param.client);
 		delete g_Param.client;
-		g_Param.client = 0;
+		g_Param.client = nullptr;
 	}
 }
 

--- a/OVP/D3D7Client/D3D7Client.cpp
+++ b/OVP/D3D7Client/D3D7Client.cpp
@@ -84,11 +84,11 @@ DLLCLBK void ExitModule (HINSTANCE hDLL)
 	delete g_Param.lpiD3D7;
 	g_Param.lpiD3D7 = 0;
 
-	//if (g_client) {
-	//	oapiUnregisterGraphicsClient (g_client);
-	//	delete g_client;
-	//	g_client = 0;
-	//}
+	if (g_Param.client) {
+		oapiUnregisterGraphicsClient (g_Param.client);
+		delete g_Param.client;
+		g_Param.client = 0;
+	}
 }
 
 // ==============================================================

--- a/Src/Module/LuaScript/LuaInline/LuaInline.cpp
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.cpp
@@ -159,7 +159,7 @@ int InterpreterList::DelInterpreter (InterpreterList::Environment *env)
 // ==============================================================
 // API interface
 
-static InterpreterList *g_IList = NULL;
+static InterpreterList *g_IList = nullptr;
 
 DLLCLBK void InitModule (HINSTANCE hDLL)
 {
@@ -169,7 +169,10 @@ DLLCLBK void InitModule (HINSTANCE hDLL)
 
 DLLCLBK void ExitModule (HINSTANCE hDLL)
 {
-	// note g_IList has already been deleted by Orbiter
+	if (g_IList) {
+		delete g_IList;
+		g_IList = nullptr;
+	}
 }
 
 // interpreter-specific callback functions

--- a/Src/Orbiter/Config.cpp
+++ b/Src/Orbiter/Config.cpp
@@ -405,7 +405,7 @@ bool GetItemVECTOR (istream &is, const char *label, VECTOR3 &val)
 	return true;
 }
 
-bool FindLine (istream &is, char *line)
+bool FindLine (istream &is, const char *line)
 {
 	bool ok = false;
 	is.seekg (0); // rewind stream

--- a/Src/Orbiter/Config.h
+++ b/Src/Orbiter/Config.h
@@ -316,7 +316,7 @@ bool GetItemBool   (std::istream &is, const char *label, bool &val);
 bool GetItemVector (std::istream &is, const char *label, Vector &val);
 bool GetItemVECTOR (std::istream &is, const char *label, VECTOR3 &val);
 
-bool FindLine      (std::istream &is, char *line);
+bool FindLine      (std::istream &is, const char *line);
 // scans stream 'is' from beginning for a line beginning with 'line' 
 // and leaves file pointer on the beginning of the next line
 // return value is false if line is not found

--- a/Src/Orbiter/Log.cpp
+++ b/Src/Orbiter/Log.cpp
@@ -19,6 +19,7 @@ extern TimeData td;
 char logname[256] = "Orbiter.log";
 char logs[256] = "";
 bool finelog = false;
+DWORD t0 = 0;
 
 LogOutFunc logOut = 0;
 
@@ -27,6 +28,7 @@ void InitLog (char *logfile, bool append)
 	strcpy (logname, logfile);
 	ofstream ofs (logname, append ? ios::app : ios::out);
 	ofs << "**** " << logname << endl;
+	t0 = timeGetTime();
 }
 
 void SetLogOutFunc(LogOutFunc func)
@@ -49,9 +51,8 @@ void LogOut (const char *msg, ...)
 
 void LogOutVA(const char *format, va_list ap)
 {
-	extern TimeData td;
 	FILE *f = fopen(logname, "a+t");
-	fprintf(f, "%010.3f: ", td.SysT0);
+	fprintf(f, "%010.3f: ", (timeGetTime() - t0) * 1e-3);
 	vfprintf(f, format, ap);
 	fputc('\n', f);
 	fclose(f);
@@ -64,11 +65,10 @@ void LogOutVA(const char *format, va_list ap)
 void LogOutFine (const char *msg, ...)
 {
 	if (finelog) {
-		extern TimeData td;
 		va_list ap;
 		va_start (ap, msg);
 		FILE *f = fopen (logname, "a+t");
-		fprintf (f, "%010.3f: ", td.SysT0);
+		fprintf (f, "%010.3f: ", (timeGetTime() - t0) * 1e-3);
 		vfprintf (f, msg, ap);
 		fputc ('\n', f);
 		fclose (f);

--- a/Src/Orbiter/Log.cpp
+++ b/Src/Orbiter/Log.cpp
@@ -16,12 +16,12 @@ using namespace std;
 extern char DBG_MSG[256];
 extern TimeData td;
 
-char logname[256] = "Orbiter.log";
-char logs[256] = "";
-bool finelog = false;
-DWORD t0 = 0;
+static char logname[256] = "Orbiter.log";
+static char logs[256] = "";
+static bool finelog = false;
+static DWORD t0 = 0;
 
-LogOutFunc logOut = 0;
+static LogOutFunc logOut = 0;
 
 void InitLog (char *logfile, bool append)
 {

--- a/Src/Orbiter/OGraphics.h
+++ b/Src/Orbiter/OGraphics.h
@@ -67,6 +67,7 @@ public:
 	~OrbiterGraphics ();
 	void clbkRefreshVideoData ();
 	bool clbkInitialise ();
+	void clbkCleanup();
 	HWND clbkCreateRenderWindow ();
 	void clbkPostCreation ();
 	bool clbkSplashLoadMsg (const char *msg, int line);
@@ -197,6 +198,10 @@ private:
 	bool bUseZBuffer;       // supports z-buffer? (should always be true!)
     bool bUseStereo;        // stereo view enabled device? (not supported)
 	bool bNoVSync;
+
+	// The Launchpad "Extra" entries added by the client
+	LaunchpadItem* m_lpiGroup;
+	LaunchpadItem* m_lpiPlanetRenderOptions;
 
 	// Framework objects
 	CD3DFramework7      *m_pFramework;

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -595,7 +595,7 @@ HINSTANCE Orbiter::LoadModule (const char *path, const char *name)
 
 	if (hDLL) {
 		DLLModule module = { hDLL, register_module, std::string(name) };
-		// register_module may be 0 if the DLL didn't register an oapi::Module instance
+		LOGOUT("Loading module %s", name);
 		m_Plugin.push_back(module);
 	} else {
 		DWORD err = GetLastError();
@@ -611,6 +611,7 @@ HINSTANCE Orbiter::LoadModule (const char *path, const char *name)
 bool Orbiter::UnloadModule (const std::string &name)
 {
 	for (auto it = m_Plugin.begin(); it != m_Plugin.end(); it++) {
+		LOGOUT("Unloading module %s", it->sName.c_str());
 		if (iequal(it->sName, name)) {
 			FreeLibrary(it->hDLL);
 			m_Plugin.erase(it);
@@ -628,6 +629,7 @@ bool Orbiter::UnloadModule (HINSTANCE hDLL)
 {
 	for (auto it = m_Plugin.begin(); it != m_Plugin.end(); it++) {
 		if (it->hDLL == hDLL) {
+			LOGOUT("Unloading module %s", it->sName.c_str());
 			FreeLibrary(it->hDLL);
 			m_Plugin.erase(it);
 			return true;

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -479,6 +479,7 @@ VOID Orbiter::CloseApp (bool fast_shutdown)
 	if (!fast_shutdown) {
 #ifdef INLINEGRAPHICS
 		if (oclient) {
+			oclient->clbkCleanup();
 			delete oclient;
 			oclient = 0;
 			gclient = 0;
@@ -595,7 +596,7 @@ HINSTANCE Orbiter::LoadModule (const char *path, const char *name)
 
 	if (hDLL) {
 		DLLModule module = { hDLL, register_module, std::string(name) };
-		LOGOUT("Loading module %s", name);
+		LOGOUT("Loading module %s (oapi::Module interface: %s)", name, register_module ? "yes" : "no");
 		m_Plugin.push_back(module);
 	} else {
 		DWORD err = GetLastError();
@@ -611,8 +612,8 @@ HINSTANCE Orbiter::LoadModule (const char *path, const char *name)
 bool Orbiter::UnloadModule (const std::string &name)
 {
 	for (auto it = m_Plugin.begin(); it != m_Plugin.end(); it++) {
-		LOGOUT("Unloading module %s", it->sName.c_str());
 		if (iequal(it->sName, name)) {
+			LOGOUT("Unloading module %s", it->sName.c_str());
 			FreeLibrary(it->hDLL);
 			m_Plugin.erase(it);
 			return true;

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -172,8 +172,16 @@ public:
 
 	// plugin module loading/unloading
 	HINSTANCE LoadModule (const char *path, const char *name);   // load a plugin
-	void UnloadModule (const char *name); // unload a plugin
-	void UnloadModule (HINSTANCE hi);
+
+	/// \brief Unload a DLL plugin identified by its name
+	/// \param name DLL name
+	/// \return true on success (module found and unloaded)
+	bool UnloadModule (const std::string &name);
+
+	/// \brief Unload a DLL plugin identified by its instance handle
+	/// \param hDLL DLL handle
+	/// \return true on success (module found and unloaded)
+	bool UnloadModule (HINSTANCE hDLL);
 
 	Vessel *SetFocusObject (Vessel *vessel, bool setview = true);
 	// Select a new user-controlled vessel
@@ -460,19 +468,19 @@ private:
 	VOID SavePlaybackScn (const char *fname);
 
 	// === The plugin module interface ===
-	struct DLLModule {               // list of plugin modules
-		oapi::Module *module;
-		HINSTANCE hMod;
-		//OPC_Interface *intf;
-		char *name;
-	} *module;
-	DWORD nmodule;                  // number of plugins
+	struct DLLModule {
+		HINSTANCE hDLL;        // DLL instance handle
+		oapi::Module* pModule; // pointer to module instance, if the plugin registered one
+		std::string sName;     // DLL name
+	};
+	std::list<DLLModule> m_Plugin;
 
 	oapi::Module *register_module;  // used during module registration
 	friend OAPIFUNC void oapiRegisterModule (oapi::Module* module);
 
 	void LoadFixedModules ();                   // load all startup plugins
-	OPC_Proc FindModuleProc (DWORD nmod, const char *procname);
+
+	OPC_Proc FindModuleProc (HINSTANCE hDLL, const char *procname);
 	// returns address of a procedure in a plugin module, or NULL if procedure not found
 
 	// list of custom commands

--- a/Src/Orbiter/TabExtra.cpp
+++ b/Src/Orbiter/TabExtra.cpp
@@ -36,6 +36,9 @@ orbiter::ExtraTab::~ExtraTab ()
 {
 	// at this point, only the internally created entries should be left
 	// so they should be safe to delete
+	if (m_ExtPrm.size() > m_internalPrm)
+		LOGOUT_WARN("Orphaned Launchpad Extra entries: %d. Some plugins may not have un-registered their entries.",
+			m_ExtPrm.size() - m_internalPrm);
 	for (int i = 0; i < m_ExtPrm.size(); i++)
 		delete m_ExtPrm[i];
 }

--- a/Src/Orbiter/Util.cpp
+++ b/Src/Orbiter/Util.cpp
@@ -57,6 +57,18 @@ bool MakePath (const char *fname)
 	return res == ERROR_SUCCESS;
 }
 
+bool iequal(const std::string& s1, const std::string& s2)
+{
+	unsigned int len = s1.size();
+	if (s2.size() != len)
+		return false;
+	for (unsigned int i = 0; i < len; i++) {
+		if (tolower(s1[i]) != tolower(s2[i]))
+			return false;
+	}
+	return true;
+}
+
 static bool need_timer_setup = true;
 static LARGE_INTEGER fine_counter_freq; // high-precision tick frequency
 static LARGE_INTEGER hi_start;

--- a/Src/Orbiter/Util.h
+++ b/Src/Orbiter/Util.h
@@ -31,6 +31,9 @@ char *uscram (const char *str);
 // create the directories 
 bool MakePath (const char *fname);
 
+// case-insensitive comparison of std::strings
+bool iequal(const std::string& s1, const std::string& s2);
+
 // conversion between Vector and VECTOR3 structures
 
 inline Vector MakeVector (const VECTOR3 &v)

--- a/Src/Plugin/Rcontrol/Rcontrol.cpp
+++ b/Src/Plugin/Rcontrol/Rcontrol.cpp
@@ -118,7 +118,7 @@ DLLCLBK void InitModule (HINSTANCE hDLL)
 	// Register custom dialog controls
 	oapiRegisterCustomControls (hDLL);
 
-	// Register the module
+	// Create and register the module
 	g_Param.rcontrol = new RControl (hDLL);
 	oapiRegisterModule (g_Param.rcontrol);
 }
@@ -132,6 +132,7 @@ DLLCLBK void ExitModule (HINSTANCE hDLL)
 	// Unregister custom dialog controls
 	oapiUnregisterCustomControls (hDLL);
 
+	// Delete the module
 	delete g_Param.rcontrol;
 }
 


### PR DESCRIPTION
- Cleaned up module registration and un-registration in Orbiter core.
- Plugin DLLs are responsible for deleting the their module instances after unregistering them with Orbiter.
- Additional log output to diagnose problems with module registration/unregistration.
- Clearer way for plugins to register an unregister items in the Launchpad Extra tab.
- Inline and D3D7 clients now properly unregister and deallocate their resources.

Closes 211