### PR TITLE
213 d3d7 tile loader shutdown

### DIFF
--- a/OVP/D3D7Client/D3D7Client.cpp
+++ b/OVP/D3D7Client/D3D7Client.cpp
@@ -240,12 +240,12 @@ bool D3D7Client::clbkSplashLoadMsg (const char *msg, int line)
 
 void D3D7Client::clbkCloseSession (bool fastclose)
 {
+	GlobalExit();
 	GDIClient::clbkCloseSession (fastclose);
 	if (scene) {
 		delete scene;
 		scene = NULL;
 	}
-	GlobalExit();
 }
 
 // ==============================================================
@@ -519,8 +519,8 @@ HRESULT D3D7Client::Initialise3DEnvironment ()
 
 void D3D7Client::GlobalExit()
 {
-	TileManager::GlobalExit();
 	TileManager2Base::GlobalExit();
+	TileManager::GlobalExit();
 	D3D7ParticleStream::GlobalExit();
 	vVessel::GlobalExit();
 	vStar::GlobalExit();

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -186,6 +186,16 @@ int _matherr(struct _exception *except )
 
 INT WINAPI WinMain (HINSTANCE hInstance, HINSTANCE, PSTR strCmdLine, INT nCmdShow)
 {
+#ifndef INLINEGRAPHICS
+	// Verify working directory
+	char dir[1024];
+	GetCurrentDirectory(1024, dir);
+	// If the server version was launched from its own subdirectory, step back
+	// up to the Orbiter main directory
+	if (strlen(dir) >= 15 && !stricmp (dir+strlen(dir)-15, "\\Modules\\Server"))
+		SetCurrentDirectory("..\\..");
+#endif
+
 #ifdef INLINEGRAPHICS
 	// determine whether another instance already exists
 	hMutex = CreateMutex (NULL, TRUE, "Test");

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -203,21 +203,17 @@ void orbiter::DefVideoTab::ScanDir(HWND hTab, const PSTR dir)
 	intptr_t fh = _findfirst(pattern, &fdata);
 	if (fh == -1) return; // nothing found
 	do {
-		if (fdata.attrib & _A_SUBDIR && fdata.name[0]!='.') // directory found
-		{
-			// Skip if directory does not contain plugin with same name as directory
+		if (fdata.attrib & _A_SUBDIR) { // directory found
+			if (fdata.name[0] == '.')
+				continue; // skip self and parent directory entries
+			// Special case: look for DLLs in subdirectories if subdir and DLL names match
 			sprintf(filepath, "%s\\%s\\%s.dll", dir, fdata.name, fdata.name);
 			if (!FileExists(filepath))
-			{
 				continue;
-			}
 		}
-		else // file found
-		{
+		else { // file found
 			if (!HasExtension(fdata.name, "dll")) // skip if not a DLL
-			{
 				continue;
-			}
 			sprintf(filepath, "%s\\%s", dir, fdata.name);
 		}
 

--- a/Src/Orbiter/cryptstring.h.in
+++ b/Src/Orbiter/cryptstring.h.in
@@ -11,14 +11,14 @@
 // ORBITER Space Flight Simulator
 #define NAME1 @@ORBITER Space Flight Simulator@@
 
-// © 2000-2021 Martin Schweiger
-#define SIG1A @@© 2000-2021 Martin Schweiger@@
+// © 2000-2022 Martin Schweiger
+#define SIG1A @@© 2000-2022 Martin Schweiger@@
 
-// Copyright (c) 2000-2021 Martin Schweiger
-#define SIG1B @@Copyright (c) 2000-2021 Martin Schweiger@@
+// Copyright (c) 2000-2022 Martin Schweiger
+#define SIG1B @@Copyright (c) 2000-2022 Martin Schweiger@@
 
-// (c) 2000-2021
-#define SIG1AA @@(c) 2000-2021@@
+// (c) 2000-2022
+#define SIG1AA @@(c) 2000-2022@@
 
 // Martin Schweiger
 #define SIG1AB @@Martin Schweiger@@


### PR DESCRIPTION
D3D7 client closes tile loader thread earlier on simulation shutdown to avoid accessing deleted resources.

Closes #213