### PR TITLE
Default Module interfaces for legacy callbacks

### DIFF
--- a/Orbitersdk/include/OrbiterAPI.h
+++ b/Orbitersdk/include/OrbiterAPI.h
@@ -2397,11 +2397,10 @@ OAPIFUNC void oapiGetViewportSize (DWORD *w, DWORD *h, DWORD *bpp = 0);
  *
  * Plugin modules that use an interface class instance derived
  * from oapi::Module must register it with this function during module
- * initialisation (typically in the body of InitModule).
+ * initialisation, in the body of InitModule.
  * \param module pointer to the interface class instance
- * \note The DLL should \e not delete the module instance in
- *   ExitModule. Orbiter destroys all registered modules automatically
- *   when required.
+ * \note The DLL must delete the oapi::Module instance in the body of
+ *   ExitModule.
  */
 OAPIFUNC void oapiRegisterModule (oapi::Module *module);
 

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -472,6 +472,7 @@ private:
 		HINSTANCE hDLL;        // DLL instance handle
 		oapi::Module* pModule; // pointer to module instance, if the plugin registered one
 		std::string sName;     // DLL name
+		bool bLocalAlloc;      // locally allocated; should be freed by Orbiter core
 	};
 	std::list<DLLModule> m_Plugin;
 


### PR DESCRIPTION
Plugins: orbiter provides default oapi::Module interfaces for any plugins that don't define their own to manage the legacy style callbacks. Locally defined Module instances are freed by Orbiter, DLL-provided ones must be freed by the DLL itself.

Closes #215