### PR TITLE
fixes visual 2022 studio build error (copydata fails)

### DIFF
--- a/OVP/D3D9Client/CMakeLists.txt
+++ b/OVP/D3D9Client/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 set(DXSDK_LIB_DIR ${DXSDK_DIR}/lib/${ARCH})
 
-set(ORBITER_SOURCE_SDK_INCLUDE_DIR "${CMAKE_BINARY_DIR}/Orbitersdk/include" "${CMAKE_SOURCE_DIR}/Orbitersdk/include")
+set(ORBITER_SOURCE_SDK_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/Orbitersdk/include")
 set(ORBITER_SOURCE_SDK_LIB_DIR ${CMAKE_BINARY_DIR}/Orbitersdk/lib)
 
 set(D3D9_SOURCE_DIR ${CMAKE_SOURCE_DIR}/OVP/D3D9Client)

--- a/Sound/XRSound/XRSound/assets/XRSound/XRSound.cfg
+++ b/Sound/XRSound/XRSound/assets/XRSound/XRSound.cfg
@@ -205,6 +205,13 @@ AudioGreeting = XRSound\Default\Welcome Aboard All Systems Nominal.wav
 MainEngines = XRSound\Default\Main Engines.wav
 
 #--------------------------------------------------------------------------
+# Main User engines sound; volume varies by thrust level.
+# Sound ID = 10046
+# Default = XRSound\Default\Main Engines.wav
+#--------------------------------------------------------------------------
+MainUserEngines = XRSound\Default\Main Engines.wav
+
+#--------------------------------------------------------------------------
 # Retro engines sound; volume varies by thrust level.
 # Sound ID = 10005
 # Default = XRSound\Default\Main Engines.wav

--- a/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.cpp
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.cpp
@@ -585,6 +585,7 @@ void VesselXRSoundEngine::LoadDefaultSounds()
     AddDefaultSound(new DockingRadarDefaultSoundPreStep(this), XRSound::DockingRadarBeep, GetConfig().DockingRadarBeep, XRSound::PlaybackType::InternalOnly);
 
     AddDefaultSound(new EngineDefaultSoundPreStep(this, THGROUP_MAIN, 0.20f, 1.0f), XRSound::MainEngines, GetConfig().MainEngines, XRSound::PlaybackType::BothViewFar);
+    AddDefaultSound(new EngineDefaultSoundPreStep(this, THGROUP_USER, 0.20f, 1.0f), XRSound::MainUserEngines, GetConfig().MainEngines, XRSound::PlaybackType::BothViewFar);
     AddDefaultSound(new EngineDefaultSoundPreStep(this, THGROUP_RETRO, 0.10f, 0.60f), XRSound::RetroEngines, GetConfig().RetroEngines, XRSound::PlaybackType::BothViewFar);
     AddDefaultSound(new EngineDefaultSoundPreStep(this, THGROUP_HOVER, 0.20f, 1.0f), XRSound::HoverEngines, GetConfig().HoverEngines, XRSound::PlaybackType::BothViewFar);
     AddDefaultSound(new RCSDefaultSoundPreStep(this), XRSound::RCSSustain, GetConfig().RCSSustain, XRSound::PlaybackType::BothViewMedium);

--- a/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.h
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.h
@@ -38,7 +38,7 @@ public:
     // Methods only invoked by XRSoundDLL (our Orbiter module class).  Because these are non-virtual, it is impossible for XRSoundLib to invoke them
     // because it cannot link with them when the Orbiter vessel using XRSoundLib tries to link.
     bool HasFocus() const { return (oapiGetFocusObject() == m_hVessel); }
-    bool InCockpitView() const { return (HasFocus() && oapiCameraInternalFocus()); }
+    bool InCockpitView() const { return (HasFocus() && oapiCameraInternal()); }
     bool InAtmosphere();
     bool IsLanded();    // can't be const; we get the vessel * from Orbiter
     bool InReentry();   // ditto

--- a/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.h
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/VesselXRSoundEngine.h
@@ -38,7 +38,7 @@ public:
     // Methods only invoked by XRSoundDLL (our Orbiter module class).  Because these are non-virtual, it is impossible for XRSoundLib to invoke them
     // because it cannot link with them when the Orbiter vessel using XRSoundLib tries to link.
     bool HasFocus() const { return (oapiGetFocusObject() == m_hVessel); }
-    bool InCockpitView() const { return (HasFocus() && oapiCameraInternal()); }
+    bool InCockpitView() const { return (HasFocus() && oapiCameraInternalFocus()); }
     bool InAtmosphere();
     bool IsLanded();    // can't be const; we get the vessel * from Orbiter
     bool InReentry();   // ditto

--- a/Sound/XRSound/XRSound/src/XRSoundDLL/XRSoundConfigFileParser.cpp
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/XRSoundConfigFileParser.cpp
@@ -233,6 +233,7 @@ bool XRSoundConfigFileParser::ParseLine(const char *pSection, const char *pPrope
         else PARSE_STRING_PROPERTY(LandedWind)
         else PARSE_STRING_PROPERTY(AudioGreeting)
         else PARSE_STRING_PROPERTY(MainEngines)
+        else PARSE_STRING_PROPERTY(MainUserEngines)
         else PARSE_STRING_PROPERTY(HoverEngines)
         else PARSE_STRING_PROPERTY(RetroEngines)
         else PARSE_STRING_PROPERTY(RCSAttackPlusX)

--- a/Sound/XRSound/XRSound/src/XRSoundDLL/XRSoundConfigFileParser.h
+++ b/Sound/XRSound/XRSound/src/XRSoundDLL/XRSoundConfigFileParser.h
@@ -155,6 +155,7 @@ public:
     CString AudioGreeting;
 
     CString MainEngines;
+    CString MainUserEngines;
     CString HoverEngines;
     CString RetroEngines;
 

--- a/Sound/XRSound/XRSound/src/XRSoundLib/XRSound.h
+++ b/Sound/XRSound/XRSound/src/XRSoundLib/XRSound.h
@@ -80,6 +80,7 @@ public:
         RCSAttackMinusX,            // 10043
         RCSAttackMinusY,            // 10044
         RCSAttackMinusZ,            // 10045
+        MainUserEngines,            // 10046
         LastDefaultSound,
 
         // these are sound IDs that play from a group of files, each in a configured folder


### PR DESCRIPTION
a small fix in D3D9 client cmakelist.txt (visual studio 2022 building problem)
fixes issue #184