### PR TITLE
Fixed <string> include in State.cpp for compatibility with vs2017

### DIFF
--- a/Src/Orbiter/State.cpp
+++ b/Src/Orbiter/State.cpp
@@ -11,7 +11,7 @@
 
 #include <fstream>
 #include <iomanip>
-#include <string.h>
+#include <string>
 #include <stdio.h>
 #include "Orbiter.h"
 #include "Config.h"


### PR DESCRIPTION
Fixes compilation error on vs2017, where ```<string>``` must be included for std::string.
Including ```<string.h>``` seems unnecessary.