### PR TITLE
#248: Implemented clbkLoadSurface method for inline graphics client.

### DIFF
--- a/Src/Orbiter/OGraphics.cpp
+++ b/Src/Orbiter/OGraphics.cpp
@@ -1456,6 +1456,16 @@ bool OrbiterGraphics::clbkParticleStreamExists (const oapi::ParticleStream *ps)
 // Texture functions
 // =======================================================================
 
+SURFHANDLE OrbiterGraphics::clbkLoadSurface(const char* fname, DWORD attrib, bool bPath)
+{
+	DWORD flags = 0;
+	if (attrib & OAPISURFACE_SYSMEM)     flags |= 0x1;
+	if (attrib & OAPISURFACE_UNCOMPRESS) flags |= 0x2;
+	if (attrib & OAPISURFACE_NOMIPMAPS)  flags |= 0x4;
+	if (attrib & OAPISURFACE_SHARED)     flags |= 0x8;
+	return clbkLoadTexture(fname, flags);
+}
+
 SURFHANDLE OrbiterGraphics::clbkLoadTexture (const char *fname, DWORD flags)
 {
 	LPDIRECTDRAWSURFACE7 tex =  NULL;

--- a/Src/Orbiter/OGraphics.h
+++ b/Src/Orbiter/OGraphics.h
@@ -136,6 +136,7 @@ public:
 	bool clbkParticleStreamExists (const oapi::ParticleStream *ps);
 
 	// texture functions
+	SURFHANDLE clbkLoadSurface(const char* fname, DWORD attrib, bool bPath = false);
 	SURFHANDLE clbkLoadTexture (const char *fname, DWORD flags = 0);
 	void clbkReleaseTexture (SURFHANDLE hTex);
 	bool clbkSetMeshTexture (DEVMESHHANDLE hMesh, DWORD texidx, SURFHANDLE tex);


### PR DESCRIPTION
This fixes the Shuttle-A issue of dynamic panel elements displayed as white rectangles.