### PR TITLE
246 user defined thruster groups

### DIFF
--- a/Orbitersdk/doxygen/CMakeLists.txt
+++ b/Orbitersdk/doxygen/CMakeLists.txt
@@ -3,9 +3,14 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DI
 
 set(out ${ORBITER_BINARY_SDK_DIR}/doc/API_Reference.chm)
 
+file(GLOB_RECURSE doxysrc
+	${ORBITER_SOURCE_SDK_DIR}/include/*
+)
+
 set(api_ref_out "")
 add_custom_command(
 	OUTPUT ${out}
+	DEPENDS ${doxysrc}
 	COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 2> nul
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different html/API_Reference.chm ${out}
 	JOB_POOL htmlhelp

--- a/Orbitersdk/include/OrbiterAPI.h
+++ b/Orbitersdk/include/OrbiterAPI.h
@@ -1595,7 +1595,8 @@ enum THGROUP_TYPE {
 	THGROUP_ATT_DOWN,        ///< translation: move down
 	THGROUP_ATT_FORWARD,     ///< translation: move forward
 	THGROUP_ATT_BACK,        ///< translation: move back
-	THGROUP_USER = 0x40      ///< user-defined group
+	THGROUP_USER = 0x40,     ///< user-defined group
+	THGROUP_USER_LAST = 0xFF ///< range limit for user-defined groups
 };
 //@}
 

--- a/Orbitersdk/include/VesselAPI.h
+++ b/Orbitersdk/include/VesselAPI.h
@@ -2745,6 +2745,14 @@ public:
 	 *   significant angular momentum.
 	 * \note If a vessel does not define a complete set of attitude thruster
 	 *   groups, certain navmode sequences (e.g. KILLROT) may fail.
+	 * \note In addition to the pre-defined set of default thruster groups, multiple
+	 *   user-defined groups can be created like this:
+	 *   \code{.cpp}
+	 *     THGROUP_TYPE MyThrusterGroup1 = THGROUP_USER;
+	 *     THGROUP_TYPE MyThrusterGroup2 = (THGROUP_TYPE)(THGROUP_USER+1);
+	 *     CreateThrusterGroup(th1, nth1, MyThrusterGroup1);
+	 *     CreateThrusterGroup(th2, nth2, MyThrusterGroup2);
+	 *   \endcode
 	 * \sa DelThrusterGroup, CreateThruster, thrusterparam
 	 */
 	THGROUP_HANDLE CreateThrusterGroup (THRUSTER_HANDLE *th, int nth, THGROUP_TYPE thgt) const;

--- a/Orbitersdk/include/VesselAPI.h
+++ b/Orbitersdk/include/VesselAPI.h
@@ -2781,7 +2781,7 @@ public:
 	bool DelThrusterGroup (THGROUP_TYPE thgt, bool delth = false) const;
 
 	/**
-	 * \brief Returns the handle of a default thruster group.
+	 * \brief Returns the handle of a thruster group (default or user-defined).
 	 * \param thgt thruster group type (see \ref thrusterparam)
 	 * \return thruster group handle (or NULL if no group is defined for the
 	 *   specified type).
@@ -2842,8 +2842,8 @@ public:
 	THRUSTER_HANDLE GetGroupThruster (THGROUP_HANDLE thg, DWORD idx) const;
 
 	/**
-	 * \brief Returns a handle for a thruster that belongs to a standard thruster
-	 *   group.
+	 * \brief Returns a handle for a thruster that belongs to a thruster
+	 *   group (default or user-defined).
 	 * \param thgt thruster group enumeration type (see \ref thrusterparam)
 	 * \param idx thruster index (0 <= idx < GetGroupThrusterCount())
 	 * \return Thruster handle

--- a/Src/Orbiter/Body.cpp
+++ b/Src/Orbiter/Body.cpp
@@ -132,7 +132,7 @@ void Body::RPlace (const Vector &rpos, const Vector &rvel)
 
 void Body::SetRPos (const Vector &p)
 {
-	dASSERT(s1, "Update state not available");
+	dCHECK(s1, "Update state not available")
 	rpos_base = s1->pos = p;
 	rpos_add.Set (0,0,0);
 }
@@ -151,14 +151,14 @@ void Body::FlushRPos ()
 
 void Body::SetRVel (const Vector &v)
 {
-	dASSERT(s1, "Update state not available");
+	dCHECK(s1, "Update state not available")
 	rvel_base = s1->vel = v;
 	rvel_add.Set (0,0,0);
 }
 
 void Body::AddRVel (const Vector &dv)
 {
-	dASSERT(s1, "Update state not available");
+	dCHECK(s1, "Update state not available")
 	rvel_base += dv;
 	s1->vel = rvel_base + rvel_add;
 }

--- a/Src/Orbiter/Celbody.cpp
+++ b/Src/Orbiter/Celbody.cpp
@@ -656,7 +656,7 @@ StateVectors CelestialBody::InterpolateState (double n) const
 	// BeginStateUpdate and EndStateUpdate)
 
 	if (!n) return *s0;
-	dASSERT(s1, "Update state not available");
+	dCHECK(s1, "Update state not available")
 	if (n == 1.0) return *s1;
 
 	StateVectors sv;

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -479,7 +479,7 @@ bool Vessel::FRecorder_Read (const char *scname)
 
 void Vessel::FRecorder_Play ()
 {
-	dASSERT(s1, "Update state not available.");
+	dCHECK(s1, "Update state not available.")
 	StateVectors *sv = s1;
 
 	if (fstatus == FLIGHTSTATUS_FREEFLIGHT) {

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -610,8 +610,11 @@ void Vessel::FRecorder_PlayEvent ()
 						for (i = 0; i < NTHGROUP; i++)
 							if (!_strnicmp (s, THGROUPSTR[i], strlen (THGROUPSTR[i]))) break;
 						if (i < NTHGROUP && sscanf (s+strlen(THGROUPSTR[i])+1, "%lf", &lvl)) {
-							for (DWORD j = 0; j < thruster_grp_default[i].nts; j++)
-								SetThrusterLevel_playback (thruster_grp_default[i].ts[j], lvl);
+							ThrustGroupSpec* tgs = GetThrusterGroup((THGROUP_TYPE)i);
+							if (tgs) {
+								for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+									SetThrusterLevel_playback(*it, lvl);
+							}
 						}
 					}
 				}

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -268,14 +268,14 @@ void Vessel::FRecorder_Save (bool force)
 	}
 
 	// engine attributes
-	if (nfrec_eng != nthruster) {
+	if (nfrec_eng != m_thruster.size()) {
 		if (nfrec_eng) {
 			delete []frec_eng;
 			frec_eng = NULL;
 		}
-		if (nthruster) {
-			frec_eng = new double[nfrec_eng = nthruster]; TRACENEW
-			for (j = 0; j < nthruster; j++) frec_eng[j] = -1;
+		if (m_thruster.size()) {
+			frec_eng = new double[nfrec_eng = m_thruster.size()]; TRACENEW
+			for (j = 0; j < m_thruster.size(); j++) frec_eng[j] = -1;
 			frec_eng_simt = -1e10; // force output
 		}
 		else frec_eng = 0;
@@ -284,8 +284,8 @@ void Vessel::FRecorder_Save (bool force)
 	dt = td.SimT1-frec_eng_simt;
 	alim = min (0.2, 0.1/dt);
 	ofstream ofs;
-	for (j = 0; j < nthruster; j++) {
-		if (fabs(frec_eng[j]-thruster[j]->level) > alim || force) {
+	for (j = 0; j < m_thruster.size(); j++) {
+		if (fabs(frec_eng[j]-m_thruster[j]->level) > alim || force) {
 			if (!bfopen) {
 				frec_eng_simt = td.SimT1;
 				char cbuf[256];
@@ -294,7 +294,7 @@ void Vessel::FRecorder_Save (bool force)
 				ofs << setprecision(10) << (frec_eng_simt-Tofs) << " ENG";
 				bfopen = true;
 			}
-			ofs << ' ' << j << ':' << setprecision(2) << (frec_eng[j] = thruster[j]->level);
+			ofs << ' ' << j << ':' << setprecision(2) << (frec_eng[j] = m_thruster[j]->level);
 		}
 	}
 	if (bfopen) {
@@ -605,7 +605,7 @@ void Vessel::FRecorder_PlayEvent ()
 			if (!_stricmp (s, "ENG")) {
 				while (s = strtok (NULL, " \t\n")) {
 					if (sscanf (s, "%d%c%lf", &id, &c, &lvl) == 3 && c == ':') {
-						if (id < nthruster) SetThrusterLevel_playback (thruster[id], lvl);
+						if (id < m_thruster.size()) SetThrusterLevel_playback (m_thruster[id], lvl);
 					} else {
 						for (i = 0; i < NTHGROUP; i++)
 							if (!_strnicmp (s, THGROUPSTR[i], strlen (THGROUPSTR[i]))) break;

--- a/Src/Orbiter/Log.h
+++ b/Src/Orbiter/Log.h
@@ -95,9 +95,13 @@ void LogOut_Location(const char* func, const char* file, int line);
 #define dVERIFY(test,msg,...) { \
 	ASSERT(!FAILED(test), true, msg, ##__VA_ARGS__); \
 }
+#define dCHECK(test,msg,...) { \
+	ASSERT(test, true, msg, ##__VA_ARGS__); \
+}
 #else
 #define dASSERT(test,msg,...) (test)
 #define dVERIFY(test,msg,...) (test)
+#define dCHECK(test,msg,...)
 #endif
 
 #define CHECKCWD(cwd,name) { char c[512]; _getcwd(c,512); if(strcmp(c,cwd)) { _chdir(cwd); sprintf (c,"CWD modified by module %s - Fixing.",name); LOGOUT_WARN(c); } }

--- a/Src/Orbiter/MenuInfoBar.cpp
+++ b/Src/Orbiter/MenuInfoBar.cpp
@@ -425,7 +425,7 @@ MenuInfoBar::MenuInfoBar (const Pane *_pane)
 	menuSrc = gc->clbkLoadSurface("main_menu.dds", OAPISURFACE_RENDERTARGET | OAPISURFACE_TEXTURE);
 	menuTgt = gc->clbkLoadSurface("main_menu_tgt.dds", OAPISURFACE_RENDERTARGET | OAPISURFACE_TEXTURE);
 #endif
-	dASSERT(menuSrc && menuTgt, "MenuInfoBar: main_menu.dds or main_menu_tgt.dds could not be loaded from Textures directory.");
+	dCHECK(menuSrc && menuTgt, "MenuInfoBar: main_menu.dds or main_menu_tgt.dds could not be loaded from Textures directory.")
 	gc->clbkBlt (menuTgt, 0, tgtTexH-menuH, menuSrc, 0, 23+menuH, menuW, menuH);
 	int yofs = (menumode == 0 ? -menuH+scrollrange:-menuH);
 	int yofs_info = (infomode == 0 ? 0:-menuH);

--- a/Src/Orbiter/SuperVessel.cpp
+++ b/Src/Orbiter/SuperVessel.cpp
@@ -74,7 +74,7 @@ SuperVessel::SuperVessel (Vessel *vessel)
 SuperVessel::SuperVessel (Vessel *vessel1, Vessel *vessel2, int port1, int port2, bool mixmoments)
 : VesselBase ()
 {
-	dASSERT (!g_bStateUpdate, "SuperVessel constructor must not be called during state update"); // only create supervessels outside update phase
+	dCHECK(!g_bStateUpdate, "SuperVessel constructor must not be called during state update") // only create supervessels outside update phase
 
 	int i;
 
@@ -773,8 +773,8 @@ bool SuperVessel::CheckSurfaceContact () const
 
 void SuperVessel::InitLanded (Planet *planet, double lng, double lat, double dir, const Matrix *hrot, double cgelev, bool asComponent)
 {
-	dASSERT(!g_bStateUpdate, "SuperVessel::InitLanded must not be called during state update"); // not valid during update phase
-	dASSERT(hrot, "hrot parameter for SuperVessel::InitLanded must be supplied");               // only support dynamic impact model for now
+	dCHECK(!g_bStateUpdate, "SuperVessel::InitLanded must not be called during state update") // not valid during update phase
+	dCHECK(hrot, "hrot parameter for SuperVessel::InitLanded must be supplied")               // only support dynamic impact model for now
 
 	DWORD comp;
 	proxybody = proxyplanet = planet;

--- a/Src/Orbiter/VBase.cpp
+++ b/Src/Orbiter/VBase.cpp
@@ -351,11 +351,11 @@ void VBase::RenderSurfaceTiles (LPDIRECT3DDEVICE7 dev)
 	// D3DTSS_ADDRESS(0) == D3DTADDRESS_WRAP
 	DWORD val;
 	dev->GetRenderState(D3DRENDERSTATE_ALPHABLENDENABLE, &val);
-	dASSERT(val == TRUE, "LPDIRECT3DDEVICE7::GetRenderState: expected return TRUE");
+	dCHECK(val == TRUE, "LPDIRECT3DDEVICE7::GetRenderState: expected return TRUE")
 	dev->GetRenderState(D3DRENDERSTATE_ZENABLE, &val);
-	dASSERT(val == FALSE, "LPDIRECT3DDEVICE7::GetRenderState: expected return FALSE");
+	dCHECK(val == FALSE, "LPDIRECT3DDEVICE7::GetRenderState: expected return FALSE")
 	dev->GetTextureStageState (0, D3DTSS_ADDRESS, &val);
-	dASSERT(val == D3DTADDRESS_WRAP, "LPDIRECT3DDEVICE7::GetTextureStageState: expected return D3DTADDRESS_WRAP");
+	dCHECK(val == D3DTADDRESS_WRAP, "LPDIRECT3DDEVICE7::GetTextureStageState: expected return D3DTADDRESS_WRAP")
 #endif
 
 	if (nsurftile) {
@@ -440,9 +440,9 @@ void VBase::RenderShadows (LPDIRECT3DDEVICE7 dev)
 	// ALPHABLENDENABLE=TRUE
 	DWORD val;
 	dev->GetRenderState(D3DRENDERSTATE_ALPHABLENDENABLE, &val);
-	dASSERT(val == TRUE, "LPDIRECT3DDEVICE7::GetRenderState: expected return TRUE");
+	dCHECK(val == TRUE, "LPDIRECT3DDEVICE7::GetRenderState: expected return TRUE");
 	dev->GetRenderState(D3DRENDERSTATE_ZENABLE, &val);
-	dASSERT(val == FALSE, "LPDIRECT3DDEVICE7::GetRenderState: expected return FALSE");
+	dCHECK(val == FALSE, "LPDIRECT3DDEVICE7::GetRenderState: expected return FALSE");
 #endif
 
 	// we render base objects only if the apparent size of the object scale

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -536,7 +536,7 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 
 
 	// main engine exhaust refs
-	if (thruster_grp_default[0].nts) {
+	if (thruster_grp_default[0].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "MEngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
@@ -545,7 +545,7 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 		}
 	}
 	// retro engine exhaust refs
-	if (thruster_grp_default[1].nts) {
+	if (thruster_grp_default[1].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "REngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
@@ -554,7 +554,7 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 		}
 	}
 	// hover engine exhaust refs
-	if (thruster_grp_default[2].nts) {
+	if (thruster_grp_default[2].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "HEngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
@@ -564,106 +564,106 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 	}
 	// attitude thruster exhaust refs
 	if (GetItemVECTOR (ifs, "AttRefX00", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHUP].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_PITCHUP].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHUP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_UP].nts) {
+		if (thruster_grp_default[THGROUP_ATT_UP].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX01", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHUP].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_PITCHUP].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHUP].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_DOWN].nts) {
+		if (thruster_grp_default[THGROUP_ATT_DOWN].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX10", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_DOWN].nts) {
+		if (thruster_grp_default[THGROUP_ATT_DOWN].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX11", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_UP].nts) {
+		if (thruster_grp_default[THGROUP_ATT_UP].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY01", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_LEFT].nts) {
+		if (thruster_grp_default[THGROUP_ATT_LEFT].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY00", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_RIGHT].nts) {
+		if (thruster_grp_default[THGROUP_ATT_RIGHT].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY11", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_RIGHT].nts) {
+		if (thruster_grp_default[THGROUP_ATT_RIGHT].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY10", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_LEFT].nts) {
+		if (thruster_grp_default[THGROUP_ATT_LEFT].ts.size()) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefZ00", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ01", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ11", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].nts >= 1) {
+		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].ts.size() >= 1) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ10", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].nts >= 2) {
+		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].ts.size() >= 2) {
 			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-	if (thruster_grp_default[THGROUP_ATT_BACK].nts) {
+	if (thruster_grp_default[THGROUP_ATT_BACK].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "LongAttRef0%d", i);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
@@ -671,7 +671,7 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 			AddExhaust (&es);
 		}
 	}
-	if (thruster_grp_default[THGROUP_ATT_FORWARD].nts) {
+	if (thruster_grp_default[THGROUP_ATT_FORWARD].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "LongAttRef1%d", i);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
@@ -1331,37 +1331,19 @@ bool Vessel::DelThruster (ThrustSpec *ts)
 	}
 
 	// remove from default thruster group lists
-	for (i = 0; i < 15; i++) {
-		tgs = &thruster_grp_default[i];
-		for (j = 0; j < tgs->nts; j++) {
-			if (tgs->ts[j] == ts) {
-				if (tgs->nts > 1) {
-					tmp = new ThrustSpec*[tgs->nts-1]; TRACENEW
-					for (k = m = 0; k < tgs->nts; k++)
-						if (k != j) tmp[m++] = tgs->ts[k];
-				} else tmp = 0;
-				delete []tgs->ts;
-				tgs->ts = tmp;
-				tgs->nts--;
-				j--;
-			}
+	for (auto it = thruster_grp_default.begin(); it != thruster_grp_default.end(); it++) {
+		ThrustGroupSpec* tgs = &(*it);
+		for (auto its = tgs->ts.begin(); its != tgs->ts.end(); its++) {
+			if (*its == ts)
+				tgs->ts.erase(its);
 		}
 	}
 	// remove from user thruster group lists
-	for (i = 0; i < thruster_grp_user.size(); i++) {
-		tgs = thruster_grp_user[i];
-		for (j = 0; j < tgs->nts; j++) {
-			if (tgs->ts[j] == ts) {
-				if (tgs->nts > 1) {
-					tmp = new ThrustSpec*[tgs->nts-1]; TRACENEW
-					for (k = m = 0; k < tgs->nts; k++)
-						if (k != j) tmp[m++] = tgs->ts[k];
-				} else tmp = 0;
-				delete []tgs->ts;
-				tgs->ts = tmp;
-				tgs->nts--;
-				j--;
-			}
+	for (auto it = thruster_grp_user.begin(); it != thruster_grp_user.end(); it++) {
+		ThrustGroupSpec* tgs = *it;
+		for (auto its = tgs->ts.begin(); its != tgs->ts.end(); its++) {
+			if (*its == ts)
+				tgs->ts.erase(its);
 		}
 	}
 	// remove from full thruster list
@@ -1435,26 +1417,18 @@ void Vessel::ClearThrusterDefinitions ()
 	ClearExhaustStreamDefinitions();
 
 	// delete the default group definitions
-	for (grp = 0; grp < thruster_grp_default.size(); grp++) {
-		tgs = &thruster_grp_default[grp];
-		if (tgs->nts) {
-			delete []tgs->ts;
-			tgs->ts = NULL;
-			tgs->nts = 0;
-		}
+	for (auto it = thruster_grp_default.begin(); it != thruster_grp_default.end(); it++) {
+		ThrustGroupSpec* tgs = &(*it);
+		tgs->ts.clear();
+		tgs->maxth_sum = 0.0;
 	}
 	// delete the user group definitions
-	if (thruster_grp_user.size()) {
-		for (grp = 0; grp < thruster_grp_user.size(); grp++) {
-			tgs = thruster_grp_user[grp];
-			if (tgs->nts) {
-				delete []tgs->ts;
-				tgs->ts = NULL;
-			}
-			delete tgs;
-		}
-		thruster_grp_user.clear();
+	for (auto it = thruster_grp_user.begin(); it != thruster_grp_user.end(); it++) {
+		ThrustGroupSpec* tgs = *it;
+		delete tgs;
 	}
+	thruster_grp_user.clear();
+
 	// delete thrusters
 	if (nthruster) {
 		for (DWORD i = 0; i < nthruster; i++)
@@ -1541,14 +1515,7 @@ ThrustGroupSpec *Vessel::CreateThrusterGroup (ThrustSpec **ts, DWORD nts, THGROU
 	}
 	dCHECK(tgs, "Invalid THGROUP_TYPE")
 
-	// clear the group, if it has been defined previously
-	if (tgs->nts) {
-		delete[]tgs->ts;
-		tgs->ts = nullptr;
-		tgs->nts = 0;
-	}
-
-	tgs->ts = new ThrustSpec*[tgs->nts = nts]; TRACENEW
+	tgs->ts.resize(nts);
 	tgs->maxth_sum = 0.0;
 	for (i = 0; i < nts; i++) {
 		tgs->ts[i] = ts[i];
@@ -1585,29 +1552,6 @@ bool Vessel::DeleteThrusterGroup (ThrustGroupSpec *tgs, bool delth)
 			return DeleteThrusterGroup((THGROUP_TYPE)(THGROUP_USER + i), delth);
 
 	return false;
-
-#ifdef UNDEF
-	for (i = 0; i < nthruster_grp_user; i++)
-		if (tgs == thruster_grp_user[i]) break;
-	if (i == nthruster_grp_user) return false;            // group not found
-	if (delth) { // destroy thrusters
-		while (thruster_grp_user[i]->nts) DelThruster (thruster_grp_user[i]->ts[0]);
-	} else if (thruster_grp_user[i]->nts) {
-		delete []thruster_grp_user[i]->ts;
-		thruster_grp_user[i]->ts = NULL;
-	}
-	delete thruster_grp_user[i];
-	ThrustGroupSpec **tmp;
-	if (nthruster_grp_user > 1) {
-		tmp = new ThrustGroupSpec*[nthruster_grp_user-1]; TRACENEW
-		for (j = k = 0; j < nthruster_grp_user; j++)
-			if (j != i) tmp[k++] = thruster_grp_user[j];
-	} else tmp = 0;
-	delete []thruster_grp_user;
-	thruster_grp_user = tmp;
-	nthruster_grp_user--;
-	return true;
-#endif
 }
 
 // ==============================================================
@@ -1617,17 +1561,14 @@ bool Vessel::DeleteThrusterGroup (THGROUP_TYPE thgt, bool delth)
 	ThrustGroupSpec* tgs = GetThrusterGroup(thgt);
 	if (!tgs) return false;
 
-	bool success = (tgs->nts > 0);
+	bool success = (tgs->ts.size() > 0);
 
 	if (delth) { // delete the thrusters
-		while (tgs->nts) DelThruster(tgs->ts[0]);
+		while (tgs->ts.size()) DelThruster(tgs->ts[0]);
 		// this also takes care of removing the thruster from the group
 	}
-	else { // delete the list but not the thrusters
-		delete[]tgs->ts;
-		tgs->ts = nullptr;
-		tgs->nts = 0;
-	}
+	else // delete the list but not the thrusters
+		tgs->ts.clear();
 
 	if (thgt >= THGROUP_USER) {
 		delete tgs;
@@ -1652,6 +1593,8 @@ ThrustGroupSpec* Vessel::GetThrusterGroup(THGROUP_TYPE thgt)
 	return tgs;
 }
 
+// ==============================================================
+
 const ThrustGroupSpec* Vessel::GetThrusterGroup(THGROUP_TYPE thgt) const
 {
 	const ThrustGroupSpec* tgs = nullptr;
@@ -1660,6 +1603,25 @@ const ThrustGroupSpec* Vessel::GetThrusterGroup(THGROUP_TYPE thgt) const
 	else if (thgt - THGROUP_USER < thruster_grp_user.size())
 		tgs = thruster_grp_user[thgt - THGROUP_USER];
 	return tgs;
+}
+
+// ==============================================================
+
+DWORD Vessel::NumThrusters(THGROUP_TYPE thgt) const
+{
+	const ThrustGroupSpec* tgs = GetThrusterGroup(thgt);
+	return (tgs ? tgs->ts.size() : 0);
+}
+
+// ==============================================================
+
+bool Vessel::IsGroupThruster(ThrustGroupSpec* tgs, ThrustSpec* ts) const
+{
+	dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
+
+	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+		if (ts == *it) return true;
+	return false;
 }
 
 // ==============================================================
@@ -1688,8 +1650,8 @@ void Vessel::IncThrusterGroupLevel(ThrustGroupSpec *tgs, double dlevel)
 
 	dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 
-	for (DWORD i = 0; i < tgs->nts; i++)
-		IncThrusterLevel (tgs->ts[i], dlevel);
+	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+		IncThrusterLevel (*it, dlevel);
 }
 
 // ==============================================================
@@ -1717,9 +1679,10 @@ double Vessel::GetThrusterGroupLevel(const ThrustGroupSpec *tgs) const
 	dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 
 	double level = 0.0;
-	for (DWORD i = 0; i < tgs->nts; i++)
-		level += tgs->ts[i]->level;
-	return (tgs->nts ? level / tgs->nts : 0.0);
+	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+		level += (*it)->level;
+	int nt = tgs->ts.size();
+	return (nt ? level / nt : 0.0);
 }
 
 // ==============================================================
@@ -1753,8 +1716,8 @@ Vector Vessel::GetThrusterGroupForce (const ThrustGroupSpec *tgs) const
 	dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 
 	Vector F;
-	for (DWORD i = 0; i < tgs->nts; i++)
-		F += GetThrusterForce (tgs->ts[i]);
+	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+		F += GetThrusterForce (*it);
 	return F;
 }
 
@@ -2097,31 +2060,31 @@ bool Vessel::SetMaxThrust_old (ENGINETYPE eng, double maxth)
 
 	switch (eng) {
 	case ENGINE_MAIN:
-		if (!thruster_grp_default[THGROUP_MAIN].nts) {
+		if (!thruster_grp_default[THGROUP_MAIN].ts.size()) {
 			ts = CreateThruster (Vector(0,0,0), Vector(0,0,1), maxth, tnk, isp_default);
 			CreateThrusterGroup (&ts, 1, THGROUP_MAIN);
 			return true;
-		} else if (thruster_grp_default[THGROUP_MAIN].nts == 1) {
+		} else if (thruster_grp_default[THGROUP_MAIN].ts.size() == 1) {
 			thruster_grp_default[THGROUP_MAIN].ts[0]->maxth0 = 
 			thruster_grp_default[THGROUP_MAIN].maxth_sum = maxth;
 			return true;
 		} else return false;
 	case ENGINE_RETRO:
-		if (!thruster_grp_default[THGROUP_RETRO].nts) {
+		if (!thruster_grp_default[THGROUP_RETRO].ts.size()) {
 			ts = CreateThruster (Vector(0,0,0), Vector(0,0,-1), maxth, tnk, isp_default);
 			CreateThrusterGroup (&ts, 1, THGROUP_RETRO);
 			return true;
-		} else if (thruster_grp_default[THGROUP_RETRO].nts == 1) {
+		} else if (thruster_grp_default[THGROUP_RETRO].ts.size() == 1) {
 			thruster_grp_default[THGROUP_RETRO].ts[0]->maxth0 = 
 			thruster_grp_default[THGROUP_RETRO].maxth_sum = maxth;
 			return true;
 		} else return false;
 	case ENGINE_HOVER:
-		if (!thruster_grp_default[THGROUP_HOVER].nts) {
+		if (!thruster_grp_default[THGROUP_HOVER].ts.size()) {
 			ts = CreateThruster (Vector(0,0,0), Vector(0,1,0), maxth, tnk, isp_default);
 			CreateThrusterGroup (&ts, 1, THGROUP_HOVER);
 			return true;
-		} else if (thruster_grp_default[THGROUP_HOVER].nts == 1) {
+		} else if (thruster_grp_default[THGROUP_HOVER].ts.size() == 1) {
 			thruster_grp_default[THGROUP_HOVER].ts[0]->maxth0 = 
 			thruster_grp_default[THGROUP_HOVER].maxth_sum = maxth;
 			return true;
@@ -3759,10 +3722,8 @@ double Vessel::MaxAngularMoment (int axis) const
 	VECTOR3 M = {0,0,0};
 	supervessel->GetCG (this, vcg);
 	const ThrustGroupSpec *tgs = &thruster_grp_default[THGROUP_ATT_PITCHUP+axis];
-	ThrustSpec **ts = tgs->ts;
-	int i, nts = tgs->nts;
-	for (i = 0; i < nts; i++)
-		M += crossp (ts[i]->dir * ts[i]->maxth0, ts[i]->ref-MakeVECTOR3(vcg));
+	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+		M += crossp ((*it)->dir * (*it)->maxth0, (*it)->ref-MakeVECTOR3(vcg));
 	return length (M);
 }
 
@@ -7609,15 +7570,15 @@ UINT VESSEL::AddExhaustRef (EXHAUSTTYPE exh, VECTOR3 &pos, double lscale, double
 
 	switch (exh) {
 	case EXHAUST_MAIN:
-		if (!vessel->thruster_grp_default[THGROUP_MAIN].nts) return 0; // not defined
+		if (!vessel->thruster_grp_default[THGROUP_MAIN].ts.size()) return 0; // not defined
 		th = vessel->thruster_grp_default[THGROUP_MAIN].ts[0];
 		break;
 	case EXHAUST_RETRO:
-		if (!vessel->thruster_grp_default[THGROUP_RETRO].nts) return 0; // not defined
+		if (!vessel->thruster_grp_default[THGROUP_RETRO].ts.size()) return 0; // not defined
 		th = vessel->thruster_grp_default[THGROUP_RETRO].ts[0];
 		break;
 	case EXHAUST_HOVER:
-		if (!vessel->thruster_grp_default[THGROUP_HOVER].nts) return 0; // not defined
+		if (!vessel->thruster_grp_default[THGROUP_HOVER].ts.size()) return 0; // not defined
 		th = vessel->thruster_grp_default[THGROUP_HOVER].ts[0];
 		break;
 	default: return 0;
@@ -7729,7 +7690,7 @@ void VESSEL::AddAttExhaustMode (UINT idx, ATTITUDEMODE mode, int axis, int dir) 
 	}
 	if (idx >= vessel->noexhaust) return;
 	OldExhaustSpec *oes = vessel->oexhaust[idx];
-	if (tgs->nts) {
+	if (tgs->ts.size()) {
 		VECTOR3 ref = {oes->ref.x, oes->ref.y, oes->ref.z};
 		VECTOR3 dir = {oes->dir.x, oes->dir.y, oes->dir.z};
 		EXHAUSTSPEC es = {(THRUSTER_HANDLE)tgs->ts[0], NULL, &ref, &dir, oes->lscale, oes->wscale, 0, 0, NULL, EXHAUST_CONSTANTPOS|EXHAUST_CONSTANTDIR};
@@ -8228,24 +8189,26 @@ THGROUP_HANDLE VESSEL::GetUserThrusterGroupHandleByIndex (DWORD idx) const
 
 DWORD VESSEL::GetGroupThrusterCount (THGROUP_HANDLE thg) const
 {
-	return ((ThrustGroupSpec*)thg)->nts;
+	return ((ThrustGroupSpec*)thg)->ts.size();
 }
 
 DWORD VESSEL::GetGroupThrusterCount (THGROUP_TYPE thgt) const
 {
-	return vessel->thruster_grp_default[thgt].nts;
+	const ThrustGroupSpec* tgs = vessel->GetThrusterGroup(thgt);
+	return (tgs ? tgs->ts.size() : 0);
 }
 
 THRUSTER_HANDLE VESSEL::GetGroupThruster (THGROUP_HANDLE thg, DWORD idx) const
 {
-	ThrustGroupSpec *tgs = (ThrustGroupSpec*)thg;
-	return (idx < tgs->nts ? (THRUSTER_HANDLE)(tgs->ts[idx]) : NULL);
+	const ThrustGroupSpec *tgs = (const ThrustGroupSpec*)thg;
+	dCHECK(tgs, "Invalid thruster group handle.")
+	return (THRUSTER_HANDLE)(idx < tgs->ts.size() ? tgs->ts[idx] : nullptr);
 }
 
 THRUSTER_HANDLE VESSEL::GetGroupThruster (THGROUP_TYPE thgt, DWORD idx) const
 {
-	ThrustGroupSpec* tgs = vessel->GetThrusterGroup(thgt);
-	return (THRUSTER_HANDLE)(tgs && idx < tgs->nts ? tgs->ts[idx] : nullptr);
+	const ThrustGroupSpec* tgs = vessel->GetThrusterGroup(thgt);
+	return (THRUSTER_HANDLE)(tgs && idx < tgs->ts.size() ? tgs->ts[idx] : nullptr);
 }
 
 DWORD VESSEL::GetUserThrusterGroupCount () const
@@ -8255,8 +8218,8 @@ DWORD VESSEL::GetUserThrusterGroupCount () const
 
 bool VESSEL::ThrusterGroupDefined (THGROUP_TYPE thgt) const
 {
-	if (thgt < THGROUP_USER) return (vessel->thruster_grp_default[thgt].nts > 0);
-	else return false; // not implemented for user-defined groups
+	const ThrustGroupSpec* tgs = vessel->GetThrusterGroup(thgt);
+	return (tgs && tgs->ts.size());
 }
 
 void VESSEL::SetThrusterGroupLevel (THGROUP_HANDLE thg, double level) const

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -308,7 +308,7 @@ void Vessel::SetDefaultState ()
 	nosewheeldir        = 0.0;
 	bGroundProximity    = false;
 	sp.is_in_atm        = false;
-	bThrustEngaged      = false;
+	m_bThrustEngaged    = false;
 	bForceActive        = false;
 	rpressure           = g_pOrbiter->Cfg()->CfgPhysicsPrm.bRadiationPressure;
 	Lift = Drag         = 0.0;
@@ -344,7 +344,7 @@ void Vessel::DefaultGenericCaps ()
 	clipradius         = 0.0; // flag for clipradius=size
 	vislimit           = spotlimit = 1e-3;
 	emass              = 1e3;
-	isp_default        = 5e4;
+	m_defaultIsp       = 5e4;
 	cog_elev           = 5.0;
 	CWz[0]             = 0.1;
 	CWz[1]             = 0.3;
@@ -391,7 +391,6 @@ void Vessel::DefaultGenericCaps ()
 	attach             = 0;
 	enablefocus        = true;
 	extpassmesh        = false;
-	nthruster          = 0;
 	nexhaust           = 0;
 	noexhaust          = 0;
 	ncontrail          = 0;
@@ -491,7 +490,7 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 		else       CreatePropellantResource (d);
 	}
 
-	GetItemReal   (ifs, "Isp", isp_default);
+	GetItemReal   (ifs, "Isp", m_defaultIsp);
 
 	if (GetItemReal (ifs, "MaxMainThrust", d))
 		SetMaxThrust_old (ENGINE_MAIN, d);
@@ -536,146 +535,146 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 
 
 	// main engine exhaust refs
-	if (thruster_grp_default[0].ts.size()) {
+	if (m_thrusterGroupDef[0].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "MEngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[0].ts[0], NULL, &tmp, NULL, 16.0, 1.0, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[0].ts[0], NULL, &tmp, NULL, 16.0, 1.0, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	// retro engine exhaust refs
-	if (thruster_grp_default[1].ts.size()) {
+	if (m_thrusterGroupDef[1].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "REngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[1].ts[0], NULL, &tmp, NULL, 8.0, 0.5, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[1].ts[0], NULL, &tmp, NULL, 8.0, 0.5, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	// hover engine exhaust refs
-	if (thruster_grp_default[2].ts.size()) {
+	if (m_thrusterGroupDef[2].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "HEngineRef%d", i+1);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[2].ts[0], NULL, &tmp, NULL, 12.0, 1.0, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[2].ts[0], NULL, &tmp, NULL, 12.0, 1.0, 0.0, 0.0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	// attitude thruster exhaust refs
 	if (GetItemVECTOR (ifs, "AttRefX00", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHUP].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHUP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_PITCHUP].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_PITCHUP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_UP].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_UP].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX01", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHUP].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHUP].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_PITCHUP].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_PITCHUP].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_DOWN].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_DOWN].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX10", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_PITCHDOWN].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_PITCHDOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_DOWN].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_DOWN].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_DOWN].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefX11", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_PITCHDOWN].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_PITCHDOWN].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_PITCHDOWN].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_UP].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_UP].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_UP].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY01", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_YAWLEFT].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_YAWLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_LEFT].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_LEFT].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY00", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWLEFT].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_YAWLEFT].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_YAWLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_RIGHT].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_RIGHT].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY11", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_YAWRIGHT].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_YAWRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_RIGHT].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_RIGHT].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_RIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefY10", tmp)) {
-		if (thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_YAWRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_YAWRIGHT].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_YAWRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-		if (thruster_grp_default[THGROUP_ATT_LEFT].ts.size()) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_LEFT].ts.size()) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_LEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
 	if (GetItemVECTOR (ifs, "AttRefZ00", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_BANKRIGHT].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_BANKRIGHT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ01", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_BANKRIGHT].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_BANKRIGHT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ11", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].ts.size() >= 1) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_BANKLEFT].ts.size() >= 1) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_BANKLEFT].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	if (GetItemVECTOR (ifs, "AttRefZ10", tmp))
-		if (thruster_grp_default[THGROUP_ATT_BANKLEFT].ts.size() >= 2) {
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BANKLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+		if (m_thrusterGroupDef[THGROUP_ATT_BANKLEFT].ts.size() >= 2) {
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_BANKLEFT].ts[1], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
-	if (thruster_grp_default[THGROUP_ATT_BACK].ts.size()) {
+	if (m_thrusterGroupDef[THGROUP_ATT_BACK].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "LongAttRef0%d", i);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_BACK].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_BACK].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
-	if (thruster_grp_default[THGROUP_ATT_FORWARD].ts.size()) {
+	if (m_thrusterGroupDef[THGROUP_ATT_FORWARD].ts.size()) {
 		for (i = 0;; i++) {
 			sprintf (cbuf, "LongAttRef1%d", i);
 			if (!GetItemVECTOR (ifs, cbuf, tmp)) break;
-			EXHAUSTSPEC es = {(THRUSTER_HANDLE)thruster_grp_default[THGROUP_ATT_FORWARD].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
+			EXHAUSTSPEC es = {(THRUSTER_HANDLE)m_thrusterGroupDef[THGROUP_ATT_FORWARD].ts[0], NULL, &tmp, NULL, 3, 0.39, 0, 0, NULL, EXHAUST_CONSTANTPOS};
 			AddExhaust (&es);
 		}
 	}
@@ -1229,9 +1228,9 @@ bool Vessel::GetWeightVector (Vector &G) const
 
 bool Vessel::GetThrustVector (Vector &T) const
 {
-	if (bThrustEngaged) T.Set (Thrust);
-	else                T.Set (0,0,0);
-	return bThrustEngaged;
+	if (m_bThrustEngaged) T.Set (Thrust);
+	else                  T.Set (0,0,0);
+	return m_bThrustEngaged;
 }
 
 // ==============================================================
@@ -1292,23 +1291,20 @@ bool Vessel::GetTorqueVector (Vector &M) const
 ThrustSpec *Vessel::CreateThruster (const Vector &pos, const Vector &dir, double maxth0,
 	TankSpec *ts, double isp0, double isp_ref, double p_ref)
 {
-	ThrustSpec **tmp = new ThrustSpec*[nthruster+1]; TRACENEW
-	if (nthruster) {
-		memcpy (tmp, thruster, nthruster*sizeof(ThrustSpec*));
-		delete []thruster;
-	}
-	thruster = tmp;
-	thruster[nthruster] = new ThrustSpec; TRACENEW
-	thruster[nthruster]->ref    = MakeVECTOR3(pos);
-	thruster[nthruster]->dir    = MakeVECTOR3(dir.unit());
-	thruster[nthruster]->maxth0 = maxth0;
-	thruster[nthruster]->tank   = ts;
-	thruster[nthruster]->isp0   = (isp0 > 0.0 ? isp0 : isp_default);
-	thruster[nthruster]->pfac   = (isp_ref > 0.0 ? (isp0-isp_ref)/(p_ref*isp0) : 0.0);
-	thruster[nthruster]->level  = 
-	thruster[nthruster]->level_permanent =
-	thruster[nthruster]->level_override = 0.0;
-	return thruster[nthruster++];
+	ThrustSpec* thruster = new ThrustSpec;
+	thruster->ref = MakeVECTOR3(pos);
+	thruster->dir = MakeVECTOR3(dir.unit());
+	thruster->maxth0 = maxth0;
+	thruster->tank = ts;
+	thruster->isp0 = (isp0 > 0.0 ? isp0 : m_defaultIsp);
+	thruster->pfac = (isp_ref > 0.0 ? (isp0 - isp_ref) / (p_ref * isp0) : 0.0);
+	thruster->level = 0.0;
+	thruster->level_permanent = 0.0;
+	thruster->level_override = 0.0;
+
+	m_thruster.push_back(thruster);
+
+	return thruster;
 }
 
 // ==============================================================
@@ -1331,7 +1327,7 @@ bool Vessel::DelThruster (ThrustSpec *ts)
 	}
 
 	// remove from default thruster group lists
-	for (auto it = thruster_grp_default.begin(); it != thruster_grp_default.end(); it++) {
+	for (auto it = m_thrusterGroupDef.begin(); it != m_thrusterGroupDef.end(); it++) {
 		ThrustGroupSpec* tgs = &(*it);
 		for (auto its = tgs->ts.begin(); its != tgs->ts.end(); its++) {
 			if (*its == ts)
@@ -1339,7 +1335,7 @@ bool Vessel::DelThruster (ThrustSpec *ts)
 		}
 	}
 	// remove from user thruster group lists
-	for (auto it = thruster_grp_user.begin(); it != thruster_grp_user.end(); it++) {
+	for (auto it = m_thrusterGroupUsr.begin(); it != m_thrusterGroupUsr.end(); it++) {
 		ThrustGroupSpec* tgs = *it;
 		for (auto its = tgs->ts.begin(); its != tgs->ts.end(); its++) {
 			if (*its == ts)
@@ -1347,21 +1343,11 @@ bool Vessel::DelThruster (ThrustSpec *ts)
 		}
 	}
 	// remove from full thruster list
-	for (i = 0; i < nthruster; i++) {
-		if (thruster[i] == ts) {
-			delete thruster[i];
-			if (nthruster > 1) {
-				tmp = new ThrustSpec*[nthruster-1]; TRACENEW
-				for (j = k = 0; j < nthruster; j++)
-					if (j != i) tmp[k++] = thruster[j];
-			} else {
-				tmp = 0;
-			}
-			delete []thruster;
-			thruster = tmp;
-			nthruster--;
-			return true;
-		}
+	auto it = std::find(m_thruster.begin(), m_thruster.end(), ts);
+	if (it != m_thruster.end()) {
+		delete *it;
+		m_thruster.erase(it);
+		return true;
 	}
 	return false;
 }
@@ -1370,10 +1356,8 @@ bool Vessel::DelThruster (ThrustSpec *ts)
 
 void Vessel::ShiftThrusters (const Vector &shift)
 {
-	DWORD i;
-	for (i = 0; i < nthruster; i++) {
-		thruster[i]->ref += MakeVECTOR3(shift);
-	}
+	for (auto it = m_thruster.begin(); it != m_thruster.end(); it++)
+		(*it)->ref += MakeVECTOR3(shift);
 }
 
 // ==============================================================
@@ -1417,26 +1401,23 @@ void Vessel::ClearThrusterDefinitions ()
 	ClearExhaustStreamDefinitions();
 
 	// delete the default group definitions
-	for (auto it = thruster_grp_default.begin(); it != thruster_grp_default.end(); it++) {
+	for (auto it = m_thrusterGroupDef.begin(); it != m_thrusterGroupDef.end(); it++) {
 		ThrustGroupSpec* tgs = &(*it);
 		tgs->ts.clear();
 		tgs->maxth_sum = 0.0;
 	}
 	// delete the user group definitions
-	for (auto it = thruster_grp_user.begin(); it != thruster_grp_user.end(); it++) {
+	for (auto it = m_thrusterGroupUsr.begin(); it != m_thrusterGroupUsr.end(); it++) {
 		ThrustGroupSpec* tgs = *it;
 		delete tgs;
 	}
-	thruster_grp_user.clear();
+	m_thrusterGroupUsr.clear();
 
 	// delete thrusters
-	if (nthruster) {
-		for (DWORD i = 0; i < nthruster; i++)
-			delete thruster[i];
-		delete []thruster;
-		thruster = NULL;
-		nthruster = 0;
-	}
+	for (auto it = m_thruster.begin(); it != m_thruster.end(); it++)
+		delete *it;
+	m_thruster.clear();
+
 	ResetMass(); // bring fuel mass up to date
 }
 
@@ -1488,12 +1469,12 @@ void Vessel::SetThrusterMax0 (ThrustSpec *ts, double maxth0)
 		ts->maxth0 = maxth0;
 
 		// re-calculate max group thrusts
-		for (auto it = thruster_grp_default.begin(); it != thruster_grp_default.end(); it++) {
+		for (auto it = m_thrusterGroupDef.begin(); it != m_thrusterGroupDef.end(); it++) {
 			ThrustGroupSpec& tgs = *it;
 			if (IsGroupThruster(&tgs, ts))
 				tgs.maxth_sum += dth;
 		}
-		for (auto it = thruster_grp_user.begin(); it != thruster_grp_user.end(); it++) {
+		for (auto it = m_thrusterGroupUsr.begin(); it != m_thrusterGroupUsr.end(); it++) {
 			ThrustGroupSpec* tgs = *it;
 			if (IsGroupThruster (tgs, ts))
 				tgs->maxth_sum += dth;
@@ -1509,9 +1490,9 @@ ThrustGroupSpec *Vessel::CreateThrusterGroup (ThrustSpec **ts, DWORD nts, THGROU
 	ThrustGroupSpec* tgs = GetThrusterGroup(thgt);
 	if (!tgs && thgt >= THGROUP_USER) { // new user-defined group requested
 		i = thgt - THGROUP_USER;
-		if (i >= thruster_grp_user.size())
-			thruster_grp_user.resize(i + 1);
-		tgs = thruster_grp_user[i] = new ThrustGroupSpec;
+		if (i >= m_thrusterGroupUsr.size())
+			m_thrusterGroupUsr.resize(i + 1);
+		tgs = m_thrusterGroupUsr[i] = new ThrustGroupSpec;
 	}
 	dCHECK(tgs, "Invalid THGROUP_TYPE")
 
@@ -1542,13 +1523,13 @@ bool Vessel::DeleteThrusterGroup (ThrustGroupSpec *tgs, bool delth)
 	if (!tgs) return false;
 
 	// Check if default group type
-	for (i = 0; i < thruster_grp_default.size(); i++)
-		if (tgs == &thruster_grp_default[i])
+	for (i = 0; i < m_thrusterGroupDef.size(); i++)
+		if (tgs == &m_thrusterGroupDef[i])
 			return DeleteThrusterGroup((THGROUP_TYPE)i, delth);
 
 	// Check if user-defined group
-	for (i = 0; i < thruster_grp_user.size(); i++)
-		if (tgs == thruster_grp_user[i])
+	for (i = 0; i < m_thrusterGroupUsr.size(); i++)
+		if (tgs == m_thrusterGroupUsr[i])
 			return DeleteThrusterGroup((THGROUP_TYPE)(THGROUP_USER + i), delth);
 
 	return false;
@@ -1572,7 +1553,7 @@ bool Vessel::DeleteThrusterGroup (THGROUP_TYPE thgt, bool delth)
 
 	if (thgt >= THGROUP_USER) {
 		delete tgs;
-		thruster_grp_user[thgt - THGROUP_USER] = nullptr;
+		m_thrusterGroupUsr[thgt - THGROUP_USER] = nullptr;
 	}
 
 	// If the group was user-defined, the user-defined list is not shrunk here even if the
@@ -1587,9 +1568,9 @@ ThrustGroupSpec* Vessel::GetThrusterGroup(THGROUP_TYPE thgt)
 {
 	ThrustGroupSpec* tgs = nullptr;
 	if (thgt < THGROUP_USER)
-		tgs = &thruster_grp_default[thgt];
-	else if (thgt - THGROUP_USER < thruster_grp_user.size())
-		tgs = thruster_grp_user[thgt - THGROUP_USER];
+		tgs = &m_thrusterGroupDef[thgt];
+	else if (thgt - THGROUP_USER < m_thrusterGroupUsr.size())
+		tgs = m_thrusterGroupUsr[thgt - THGROUP_USER];
 	return tgs;
 }
 
@@ -1599,9 +1580,9 @@ const ThrustGroupSpec* Vessel::GetThrusterGroup(THGROUP_TYPE thgt) const
 {
 	const ThrustGroupSpec* tgs = nullptr;
 	if (thgt < THGROUP_USER)
-		tgs = &thruster_grp_default[thgt];
-	else if (thgt - THGROUP_USER < thruster_grp_user.size())
-		tgs = thruster_grp_user[thgt - THGROUP_USER];
+		tgs = &m_thrusterGroupDef[thgt];
+	else if (thgt - THGROUP_USER < m_thrusterGroupUsr.size())
+		tgs = m_thrusterGroupUsr[thgt - THGROUP_USER];
 	return tgs;
 }
 
@@ -2060,33 +2041,33 @@ bool Vessel::SetMaxThrust_old (ENGINETYPE eng, double maxth)
 
 	switch (eng) {
 	case ENGINE_MAIN:
-		if (!thruster_grp_default[THGROUP_MAIN].ts.size()) {
-			ts = CreateThruster (Vector(0,0,0), Vector(0,0,1), maxth, tnk, isp_default);
+		if (!m_thrusterGroupDef[THGROUP_MAIN].ts.size()) {
+			ts = CreateThruster (Vector(0,0,0), Vector(0,0,1), maxth, tnk, m_defaultIsp);
 			CreateThrusterGroup (&ts, 1, THGROUP_MAIN);
 			return true;
-		} else if (thruster_grp_default[THGROUP_MAIN].ts.size() == 1) {
-			thruster_grp_default[THGROUP_MAIN].ts[0]->maxth0 = 
-			thruster_grp_default[THGROUP_MAIN].maxth_sum = maxth;
+		} else if (m_thrusterGroupDef[THGROUP_MAIN].ts.size() == 1) {
+			m_thrusterGroupDef[THGROUP_MAIN].ts[0]->maxth0 = 
+			m_thrusterGroupDef[THGROUP_MAIN].maxth_sum = maxth;
 			return true;
 		} else return false;
 	case ENGINE_RETRO:
-		if (!thruster_grp_default[THGROUP_RETRO].ts.size()) {
-			ts = CreateThruster (Vector(0,0,0), Vector(0,0,-1), maxth, tnk, isp_default);
+		if (!m_thrusterGroupDef[THGROUP_RETRO].ts.size()) {
+			ts = CreateThruster (Vector(0,0,0), Vector(0,0,-1), maxth, tnk, m_defaultIsp);
 			CreateThrusterGroup (&ts, 1, THGROUP_RETRO);
 			return true;
-		} else if (thruster_grp_default[THGROUP_RETRO].ts.size() == 1) {
-			thruster_grp_default[THGROUP_RETRO].ts[0]->maxth0 = 
-			thruster_grp_default[THGROUP_RETRO].maxth_sum = maxth;
+		} else if (m_thrusterGroupDef[THGROUP_RETRO].ts.size() == 1) {
+			m_thrusterGroupDef[THGROUP_RETRO].ts[0]->maxth0 = 
+			m_thrusterGroupDef[THGROUP_RETRO].maxth_sum = maxth;
 			return true;
 		} else return false;
 	case ENGINE_HOVER:
-		if (!thruster_grp_default[THGROUP_HOVER].ts.size()) {
-			ts = CreateThruster (Vector(0,0,0), Vector(0,1,0), maxth, tnk, isp_default);
+		if (!m_thrusterGroupDef[THGROUP_HOVER].ts.size()) {
+			ts = CreateThruster (Vector(0,0,0), Vector(0,1,0), maxth, tnk, m_defaultIsp);
 			CreateThrusterGroup (&ts, 1, THGROUP_HOVER);
 			return true;
-		} else if (thruster_grp_default[THGROUP_HOVER].ts.size() == 1) {
-			thruster_grp_default[THGROUP_HOVER].ts[0]->maxth0 = 
-			thruster_grp_default[THGROUP_HOVER].maxth_sum = maxth;
+		} else if (m_thrusterGroupDef[THGROUP_HOVER].ts.size() == 1) {
+			m_thrusterGroupDef[THGROUP_HOVER].ts[0]->maxth0 = 
+			m_thrusterGroupDef[THGROUP_HOVER].maxth_sum = maxth;
 			return true;
 		} else return false;
 	}
@@ -2101,38 +2082,38 @@ void Vessel::CreateDefaultAttitudeSet (double maxth)
 	TankSpec *tnk = (ntank ? tank[0] : 0);
 
 	// linear groups
-	ts_lin = CreateThruster (Vector (0,0,0), Vector (0, 1,0), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector (0, 1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_UP);
-	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,-1,0), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,-1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_DOWN);
-	ts_lin = CreateThruster (Vector (0,0,0), Vector (-1,0,0), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector (-1,0,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_LEFT);
-	ts_lin = CreateThruster (Vector (0,0,0), Vector ( 1,0,0), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector ( 1,0,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_RIGHT);
-	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,0, 1), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,0, 1), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_FORWARD);
-	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,0,-1), maxth, tnk, isp_default);
+	ts_lin = CreateThruster (Vector (0,0,0), Vector (0,0,-1), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (&ts_lin, 1, THGROUP_ATT_BACK);
 
 	// rotational groups
 	maxth *= 0.5; // since each group has 2 thrusters
-	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(0, 1,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(0,-1,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(0, 1,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(0,-1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_PITCHUP);
-	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(0,-1,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(0, 1,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(0,-1,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(0, 1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_PITCHDOWN);
-	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(-1,0,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector( 1,0,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector(-1,0,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector( 1,0,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_YAWLEFT);
-	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector( 1,0,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(-1,0,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector(0,0, size), Vector( 1,0,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector(0,0,-size), Vector(-1,0,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_YAWRIGHT);
-	ts_rot[0] = CreateThruster (Vector( size,0,0), Vector(0, 1,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector(-size,0,0), Vector(0,-1,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector( size,0,0), Vector(0, 1,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector(-size,0,0), Vector(0,-1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_BANKLEFT);
-	ts_rot[0] = CreateThruster (Vector(-size,0,0), Vector(0, 1,0), maxth, tnk, isp_default);
-	ts_rot[1] = CreateThruster (Vector( size,0,0), Vector(0,-1,0), maxth, tnk, isp_default);
+	ts_rot[0] = CreateThruster (Vector(-size,0,0), Vector(0, 1,0), maxth, tnk, m_defaultIsp);
+	ts_rot[1] = CreateThruster (Vector( size,0,0), Vector(0,-1,0), maxth, tnk, m_defaultIsp);
 	CreateThrusterGroup (ts_rot, 2, THGROUP_ATT_BANKRIGHT);
 }
 
@@ -2476,8 +2457,8 @@ void Vessel::DelPropellantResource (TankSpec *ts)
 	DWORD i, j, k;
 
 	// unlink thrusters which refer to ts
-	for (i = 0; i < nthruster; i++)
-		if (thruster[i]->tank == ts) thruster[i]->tank = 0;
+	for (auto it = m_thruster.begin(); it != m_thruster.end(); it++)
+		if ((*it)->tank == ts) (*it)->tank = nullptr;
 
 	// if we delete the default tank, reset
 	if (def_tank == ts) def_tank = 0;
@@ -2502,15 +2483,13 @@ void Vessel::DelPropellantResource (TankSpec *ts)
 
 void Vessel::ClearPropellantResources ()
 {
-	DWORD i;
-
 	// unlink all thrusters from their fuel resources
-	for (i = 0; i < nthruster; i++)
-		thruster[i]->tank = 0;
+	for (auto it = m_thruster.begin(); it != m_thruster.end(); it++)
+		(*it)->tank = nullptr;
 
 	// remove all fuel resources
 	if (ntank) {
-		for (i = 0; i < ntank; i++)
+		for (DWORD i = 0; i < ntank; i++)
 			delete tank[i];
 		delete []tank;
 		tank = NULL;
@@ -3721,7 +3700,7 @@ double Vessel::MaxAngularMoment (int axis) const
 	Vector vcg;
 	VECTOR3 M = {0,0,0};
 	supervessel->GetCG (this, vcg);
-	const ThrustGroupSpec *tgs = &thruster_grp_default[THGROUP_ATT_PITCHUP+axis];
+	const ThrustGroupSpec *tgs = &m_thrusterGroupDef[THGROUP_ATT_PITCHUP+axis];
 	for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
 		M += crossp ((*it)->dir * (*it)->maxth0, (*it)->ref-MakeVECTOR3(vcg));
 	return length (M);
@@ -3752,7 +3731,7 @@ void Vessel::UpdateBodyForces ()
 {
 	Lift = Drag = 0.0;
 
-	if (nthruster) UpdateThrustForces ();
+	if (m_thruster.size()) UpdateThrustForces ();
 	if (CtrlSurfSyncMode) ApplyControlSurfaceLevels ();
 	if (fstatus != FLIGHTSTATUS_LANDED) {
 		if (sp.is_in_atm) UpdateAerodynamicForces ();
@@ -3909,27 +3888,28 @@ void Vessel::UpdateThrustForces ()
 	for (j = 0; j < ntank; j++) tank[j]->pmass = tank[j]->mass;
 
 	// update thruster-induced forces
-	bThrustEngaged = false;
+	m_bThrustEngaged = false;
 	Thrust.Set (0,0,0);
-	for (j = 0; j < nthruster; j++) {
-		if (thruster[j]->level = max (0.0, min (1.0, thruster[j]->level_permanent + thruster[j]->level_override))) {
-			if ((ts = thruster[j]->tank) && ts->mass) {        // fuel available?
-				th = thruster[j]->maxth0 * thruster[j]->level; // vacuum thrust
-				if (burnfuel) {                                // consume fuel
-					ts->mass -= th/(ts->efficiency * thruster[j]->isp0) * td.SimDT;
+	for (auto it = m_thruster.begin(); it != m_thruster.end(); it++) {
+		ThrustSpec* thruster = *it;
+		if (thruster->level = max (0.0, min (1.0, thruster->level_permanent + thruster->level_override))) {
+			if ((ts = thruster->tank) && ts->mass) {     // fuel available?
+				th = thruster->maxth0 * thruster->level; // vacuum thrust
+				if (burnfuel) {                          // consume fuel
+					ts->mass -= th/(ts->efficiency * thruster->isp0) * td.SimDT;
 					if (ts->mass < 0.0) ts->mass = 0.0;
 				}
-				th *= ThrusterAtmScale (thruster[j], sp.atmp);  // atmospheric thrust scaling
-				F = MakeVector(thruster[j]->dir * th);
+				th *= ThrusterAtmScale (thruster, sp.atmp);  // atmospheric thrust scaling
+				F = MakeVector(thruster->dir * th);
 				Thrust += F;
-				Amom_add += crossp (F, MakeVector(thruster[j]->ref));
-				bThrustEngaged = true;
-			} else thruster[j]->level = thruster[j]->level_permanent = 0.0; // no fuel
+				Amom_add += crossp (F, MakeVector(thruster->ref));
+				m_bThrustEngaged = true;
+			} else thruster->level = thruster->level_permanent = 0.0; // no fuel
 		}
-		thruster[j]->level_override = 0.0; // reset temporary thruster level
-		//thruster[j]->level = thruster[j]->level_permanent;
+		thruster->level_override = 0.0; // reset temporary thruster level
+		//thruster->level = thruster->level_permanent;
 	}
-	if (bThrustEngaged) Flin_add += Thrust;
+	if (m_bThrustEngaged) Flin_add += Thrust;
 }
 
 // =======================================================================
@@ -6059,10 +6039,10 @@ void Vessel::WriteDefault (ostream &ofs) const
 	}
 	if (!needlabel) ofs << endl;
 
-	for (i = 0, needlabel = true; i < nthruster; i++)
-		if (thruster[i]->level_permanent) {
+	for (i = 0, needlabel = true; i < m_thruster.size(); i++)
+		if (m_thruster[i]->level_permanent) {
 			if (needlabel) { ofs << "  THLEVEL"; needlabel = false; }
-			ofs << ' ' << i << ':' << thruster[i]->level_permanent;
+			ofs << ' ' << i << ':' << m_thruster[i]->level_permanent;
 		}
 	if (!needlabel) ofs << endl;
 
@@ -6201,7 +6181,7 @@ double VESSEL::GetFuelRate () const
 
 double VESSEL::GetISP () const
 {
-	return vessel->isp_default;
+	return vessel->m_defaultIsp;
 }
 
 double VESSEL::GetMaxThrust (ENGINETYPE eng) const
@@ -6897,7 +6877,7 @@ double VESSEL::GetGravityGradientDamping () const
 
 void VESSEL::SetISP (double isp) const
 {
-	vessel->isp_default = isp;
+	vessel->m_defaultIsp = isp;
 }
 
 void VESSEL::SetMaxThrust (ENGINETYPE eng, double th) const
@@ -7570,16 +7550,16 @@ UINT VESSEL::AddExhaustRef (EXHAUSTTYPE exh, VECTOR3 &pos, double lscale, double
 
 	switch (exh) {
 	case EXHAUST_MAIN:
-		if (!vessel->thruster_grp_default[THGROUP_MAIN].ts.size()) return 0; // not defined
-		th = vessel->thruster_grp_default[THGROUP_MAIN].ts[0];
+		if (!vessel->m_thrusterGroupDef[THGROUP_MAIN].ts.size()) return 0; // not defined
+		th = vessel->m_thrusterGroupDef[THGROUP_MAIN].ts[0];
 		break;
 	case EXHAUST_RETRO:
-		if (!vessel->thruster_grp_default[THGROUP_RETRO].ts.size()) return 0; // not defined
-		th = vessel->thruster_grp_default[THGROUP_RETRO].ts[0];
+		if (!vessel->m_thrusterGroupDef[THGROUP_RETRO].ts.size()) return 0; // not defined
+		th = vessel->m_thrusterGroupDef[THGROUP_RETRO].ts[0];
 		break;
 	case EXHAUST_HOVER:
-		if (!vessel->thruster_grp_default[THGROUP_HOVER].ts.size()) return 0; // not defined
-		th = vessel->thruster_grp_default[THGROUP_HOVER].ts[0];
+		if (!vessel->m_thrusterGroupDef[THGROUP_HOVER].ts.size()) return 0; // not defined
+		th = vessel->m_thrusterGroupDef[THGROUP_HOVER].ts[0];
 		break;
 	default: return 0;
 	}
@@ -7664,26 +7644,26 @@ void VESSEL::AddAttExhaustMode (UINT idx, ATTITUDEMODE mode, int axis, int dir) 
 	case ATTMODE_ROT:
 		switch (axis) {
 		case 0:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_PITCHDOWN : THGROUP_ATT_PITCHUP];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_PITCHDOWN : THGROUP_ATT_PITCHUP];
 			break;
 		case 1:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_YAWRIGHT : THGROUP_ATT_YAWLEFT];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_YAWRIGHT : THGROUP_ATT_YAWLEFT];
 			break;
 		case 2:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_BANKLEFT : THGROUP_ATT_BANKRIGHT];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_BANKLEFT : THGROUP_ATT_BANKRIGHT];
 			break;
 		}
 		break;
 	case ATTMODE_LIN:
 		switch (axis) {
 		case 0:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_LEFT : THGROUP_ATT_RIGHT];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_LEFT : THGROUP_ATT_RIGHT];
 			break;
 		case 1:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_DOWN : THGROUP_ATT_UP];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_DOWN : THGROUP_ATT_UP];
 			break;
 		case 2:
-			tgs = &vessel->thruster_grp_default[dir ? THGROUP_ATT_BACK : THGROUP_ATT_FORWARD];
+			tgs = &vessel->m_thrusterGroupDef[dir ? THGROUP_ATT_BACK : THGROUP_ATT_FORWARD];
 			break;
 		}
 		break;
@@ -8004,13 +7984,12 @@ void VESSEL::ClearThrusterDefinitions () const
 
 THRUSTER_HANDLE VESSEL::GetThrusterHandleByIndex (DWORD idx) const
 {
-	if (idx >= vessel->nthruster) return 0;
-	return (THRUSTER_HANDLE)vessel->thruster[idx];
+	return (THRUSTER_HANDLE)(idx < vessel->m_thruster.size() ? vessel->m_thruster[idx] : nullptr);
 }
 
 DWORD VESSEL::GetThrusterCount (void) const
 {
-	return vessel->nthruster;
+	return (DWORD)vessel->m_thruster.size();
 }
 
 void VESSEL::SetThrusterRef (THRUSTER_HANDLE th, const VECTOR3 &pos) const
@@ -8183,8 +8162,8 @@ THGROUP_HANDLE VESSEL::GetThrusterGroupHandle (THGROUP_TYPE thgt) const
 
 THGROUP_HANDLE VESSEL::GetUserThrusterGroupHandleByIndex (DWORD idx) const
 {
-	if (idx >= vessel->thruster_grp_user.size()) return 0;
-	return (THGROUP_HANDLE)vessel->thruster_grp_user[idx];
+	if (idx >= vessel->m_thrusterGroupUsr.size()) return 0;
+	return (THGROUP_HANDLE)vessel->m_thrusterGroupUsr[idx];
 }
 
 DWORD VESSEL::GetGroupThrusterCount (THGROUP_HANDLE thg) const
@@ -8213,7 +8192,7 @@ THRUSTER_HANDLE VESSEL::GetGroupThruster (THGROUP_TYPE thgt, DWORD idx) const
 
 DWORD VESSEL::GetUserThrusterGroupCount () const
 {
-	return vessel->thruster_grp_user.size();
+	return vessel->m_thrusterGroupUsr.size();
 }
 
 bool VESSEL::ThrusterGroupDefined (THGROUP_TYPE thgt) const

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -96,10 +96,9 @@ typedef struct {      // logical thruster definition
 } ThrustSpec;
 
 struct ThrustGroupSpec {      // thruster group definition
-	ThrustSpec **ts;        // list of thrusters
-	DWORD nts;              // number of thrusters
-	double maxth_sum;       // sum of maxth of all components
-	ThrustGroupSpec() { ts = nullptr;  nts = 0; maxth_sum = 0.0; }
+	std::vector<ThrustSpec*> ts; // list of thrusters
+	double maxth_sum;            // sum of maxth of all components
+	ThrustGroupSpec() { maxth_sum = 0.0; }
 };
 
 typedef struct {      // obsolete exhaust render definition
@@ -508,16 +507,21 @@ public:
 	ThrustGroupSpec* GetThrusterGroup(THGROUP_TYPE thgt);
 	const ThrustGroupSpec* GetThrusterGroup(THGROUP_TYPE thgt) const;
 
-	inline DWORD NumThrusters (THGROUP_TYPE thg) const
-	{ return thruster_grp_default[thg].nts; }
-	// number of thrusters in thruster group thg
+	/**
+	 * \brief Return the number of thrusters in a group.
+	 * \param thgt Thruster group ID (see \ref THGROUP_TYPE). This can be one of the
+	 *    default types or a user-defined type (THGROUP_USER+x)
+	 * \return Number of thrusters assigned to the group
+	 */
+	DWORD NumThrusters(THGROUP_TYPE thgt) const;
 
-	inline bool IsGroupThruster (ThrustGroupSpec *tgs, ThrustSpec *ts)
-	{ for (DWORD i = 0; i < tgs->nts; i++)
-	      if (tgs->ts[i] == ts) return true;
-	  return false;
-	}
-	// returns true if ts is a member of tgs, false otherwise
+	/**
+	 * \brief Check if a thruster is member of a thruster group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \param ts Pointer to thruster object
+	 * \return True if ts is a member of group tgs, false otherwise.
+	 */
+	bool IsGroupThruster(ThrustGroupSpec* tgs, ThrustSpec* ts) const;
 
 	/**
 	 * \brief Set the permanent thruster level for all thrusters in a group
@@ -527,8 +531,9 @@ public:
 	inline void SetThrusterGroupLevel (ThrustGroupSpec *tgs, double level)
 	{
 		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
-		for (DWORD i = 0; i < tgs->nts; i++)
-			SetThrusterLevel (tgs->ts[i], level);
+
+		for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+			SetThrusterLevel(*it, level);
 	}
 
 	/**
@@ -549,8 +554,9 @@ public:
 	inline void SetThrusterGroupOverride(ThrustGroupSpec* tgs, double level)
 	{
 		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
-		for (DWORD i = 0; i < tgs->nts; i++)
-			SetThrusterOverride(tgs->ts[i], level);
+
+		for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+			SetThrusterOverride(*it, level);
 	}
 
 	/**
@@ -597,8 +603,9 @@ public:
 	inline void IncThrusterGroupOverride (ThrustGroupSpec *tgs, double dlevel)
 	{
 		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
-		for (DWORD i = 0; i < tgs->nts; i++)
-			IncThrusterOverride (tgs->ts[i], dlevel);
+
+		for (auto it = tgs->ts.begin(); it != tgs->ts.end(); it++)
+			IncThrusterOverride (*it, dlevel);
 	}
 
 	/**

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -22,10 +22,13 @@
 #define __VESSEL_H
 
 #include "Vesselbase.h"
+#include "Vesselbase.h"
 #include "elevmgr.h"
+#include <array>
 #include <fstream>
 #include "Orbitersdk.h"
 #include "GraphicsAPI.h"
+#include "Log.h"
 
 class Elements;
 class CelestialBody;
@@ -92,11 +95,12 @@ typedef struct {      // logical thruster definition
 	TankSpec *tank;         // propellant resource for this thruster
 } ThrustSpec;
 
-typedef struct {      // thruster group definition
+struct ThrustGroupSpec {      // thruster group definition
 	ThrustSpec **ts;        // list of thrusters
 	DWORD nts;              // number of thrusters
 	double maxth_sum;       // sum of maxth of all components
-} ThrustGroupSpec;
+	ThrustGroupSpec() { ts = nullptr;  nts = 0; maxth_sum = 0.0; }
+};
 
 typedef struct {      // obsolete exhaust render definition
 	Vector ref;             // exhaust reference pos
@@ -463,21 +467,46 @@ public:
 	// ========================================================================
 	// thruster group management
 
+	/**
+	 * \brief Assemble a set of thrusters into a logical group
+	 * \param ts Array of thruster specifications to be grouped
+	 * \param nts Length of the thruster array
+	 * \param thgt Thruster group ID (see \ref THGROUP_TYPE). This can be one of the
+	 *    default types or a user-defined type (THGROUP_USER+x)
+	 * \note Multiple user-defined groups can be created (x >= 0)
+	 * \note If the type ID refers to a group already previously created (default or
+	 *    user-defined), the previous definition is overwritten.
+	 */
 	ThrustGroupSpec *CreateThrusterGroup (ThrustSpec **ts, DWORD nts, THGROUP_TYPE thgt);
-	// assemble a set of thrusters into a logical group
 
-	bool DeleteThrusterGroup (ThrustGroupSpec *tgs, THGROUP_TYPE thgt, bool delth = false);
-	// OBSOLETE
-	// remove a thruster group definition
-	// If delth==true, the associated thrusters are also destroyed
-
+	/**
+	 * \brief Remove a thruster group definition
+	 * \param tgs Pointer to thruster group object
+	 * \param delth If true, the associated thrusters are also destroyed
+	 * \return True if successful, false if group had not previously been created by the
+	 *    vessel or didn't contain any thrusters
+	 */
 	bool DeleteThrusterGroup (ThrustGroupSpec *tgs, bool delth = false);
-	// remove a thruster group definition
-	// If delth==true, the associated thrusters are also destroyed
 
+	/**
+	 * \brief Remove a thruster group definition
+	 * \param thgt Thruster group ID (see \ref THGROUP_TYPE). This can be one of the
+	 *    default types or a user-defined type (THGROUP_USER+x)
+	 * \param delth If true, the associated thrusters are also destroyed
+	 * \return True if successful, false if group had not previously been created by the vessel
+	 */
 	bool DeleteThrusterGroup (THGROUP_TYPE thgt, bool delth = false);
-	// Remove a default thruster group definition.
-	// If delth==true, the associated thrusters are also destroyed
+
+	/**
+	 * \brief Return the thruster group object pointer for a thruster group type.
+	 * \param thgt Thruster group ID (see \ref THGROUP_TYPE). This can be one of the
+	 *    default types or a user-defined type (THGROUP_USER+x)
+	 * \return Thruster group object pointer, or 0 if not defined.
+	 * \note For a default group (< THGROUP_USER), this always returns a valid pointer,
+	 *    even if the vessel hasn't created that group.
+	 */
+	ThrustGroupSpec* GetThrusterGroup(THGROUP_TYPE thgt);
+	const ThrustGroupSpec* GetThrusterGroup(THGROUP_TYPE thgt) const;
 
 	inline DWORD NumThrusters (THGROUP_TYPE thg) const
 	{ return thruster_grp_default[thg].nts; }
@@ -490,77 +519,153 @@ public:
 	}
 	// returns true if ts is a member of tgs, false otherwise
 
+	/**
+	 * \brief Set the permanent thruster level for all thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \param level Thruster level to be applied to all thrusters in the group (0-1)
+	 */
 	inline void SetThrusterGroupLevel (ThrustGroupSpec *tgs, double level)
 	{
+		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 		for (DWORD i = 0; i < tgs->nts; i++)
 			SetThrusterLevel (tgs->ts[i], level);
 	}
-	// set permanent thruster level for all thrusters in group 'tgs'
 
-	inline void SetThrusterGroupOverride (ThrustGroupSpec *tgs, double level)
+	/**
+	 * \brief Set the permanent thruster level for all thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \param level Thruster level to be applied to all thrusters in the group (0-1)
+	 */
+	void SetThrusterGroupLevel(THGROUP_TYPE thgt, double level);
+
+	/**
+	 * \brief Set the single-step thruster level for all thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \param level Thruster level to be applied to all thrusters in the group (0-1)
+	 * \note This thrust level is only applied for the current time step, after which it
+	 *    reverts to the permanent level.
+	 */
+	inline void SetThrusterGroupOverride(ThrustGroupSpec* tgs, double level)
 	{
+		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 		for (DWORD i = 0; i < tgs->nts; i++)
-			SetThrusterOverride (tgs->ts[i], level);
-	}
-	// set single-step level for all thrusters in group 'tgs'
-
-	inline void SetThrusterGroupLevel (THGROUP_TYPE thg, double level)
-	{
-		SetThrusterGroupLevel (thruster_grp_default+thg, level);
-	}
-	// set permanent thruster level for all thrusters in default group thg (excluding THGROUP_USER)
-
-	inline void SetThrusterGroupOverride (THGROUP_TYPE thg, double level)
-	{
-		SetThrusterGroupOverride (thruster_grp_default+thg, level);
+			SetThrusterOverride(tgs->ts[i], level);
 	}
 
+	/**
+	 * \brief Set the single-step thruster level for all thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \param level Thruster level to be applied to all thrusters in the group (0-1)
+	 * \note This thrust level is only applied for the current time step, after which it
+	 *    reverts to the permanent level.
+	 */
+	void SetThrusterGroupOverride(THGROUP_TYPE thgt, double level);
+
+	/**
+	 * \brief Add a differential to the level of all thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \param dlevel thrust group differential (can be negative)
+	 * \note The resulting level is clamped to range 0-1.
+	 * \note If the initial thrust levels were different, they will still be different
+	 *    after this call.
+	 */
 	void IncThrusterGroupLevel (ThrustGroupSpec *tgs, double dlevel);
-	// add 'dlevel' to all thruster levels in group 'tgs'
 
-	inline void IncThrusterGroupLevel (THGROUP_TYPE thg, double dlevel)
-	{
-		IncThrusterGroupLevel (thruster_grp_default+thg, dlevel);
-	}
-	// add 'dlevel' to all thruster levels in the default group thg (excluding THGROUP_USER)
+	/**
+	 * \brief Add a differential to the level of all thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \param dlevel thrust group differential (can be negative)
+	 * \note The resulting level is clamped to range 0-1.
+	 * \note If the initial thrust levels were different, they will still be different
+	 *    after this call.
+	 */
+	void IncThrusterGroupLevel(THGROUP_TYPE thgt, double dlevel);
 
+	/**
+	 * \brief Add a differential to the single-step level of all thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \param dlevel thrust group differential (can be negative)
+	 * \note The resulting level is clamped to range 0-1.
+	 * \note If the initial thrust levels were different, they will still be different
+	 *    after this call.
+	 * \note The thrust level is increased only for the current time step, after which it
+	 *    reverts to the permanent level.
+	 */
 	inline void IncThrusterGroupOverride (ThrustGroupSpec *tgs, double dlevel)
 	{
+		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
 		for (DWORD i = 0; i < tgs->nts; i++)
 			IncThrusterOverride (tgs->ts[i], dlevel);
 	}
-	// add 'dlevel' to the temporary settings of all thrusters in group 'tgs'
-	// note that this method doesn't clamp to [0..1]
 
-	inline void IncThrusterGroupOverride (THGROUP_TYPE thg, double dlevel)
-	{
-		IncThrusterGroupOverride (thruster_grp_default+thg, dlevel);
-	}
+	/**
+	 * \brief Add a differential to the single-step level of all thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \param dlevel thrust group differential (can be negative)
+	 * \note The resulting level is clamped to range 0-1.
+	 * \note If the initial thrust levels were different, they will still be different
+	 *    after this call.
+	 * \note The thrust level is increased only for the current time step, after which it
+	 *    reverts to the permanent level.
+	 */
+	void IncThrusterGroupOverride(THGROUP_TYPE thgt, double dlevel);
 
-	inline double GetThrusterGroupLevel (const ThrustGroupSpec *tgs) const
-	{
-		double level = 0.0;
-		for (DWORD i = 0; i < tgs->nts; i++)
-			level += tgs->ts[i]->level;
-		return (tgs->nts ? level/tgs->nts : 0.0);
-	}
-	// return the average thrust level for a thruster group
+	/**
+	 * \brief Return the average thrust level of a thruster group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \return Average current thrust level (0-1)
+	 */
+	double GetThrusterGroupLevel(const ThrustGroupSpec* tgs) const;
 
-	inline double GetThrusterGroupLevel (THGROUP_TYPE thg) const
-	{ return GetThrusterGroupLevel (thruster_grp_default+thg); }
-	// return average thrust level for a group defined by a group identifier
+	/**
+	 * \brief Return the average thrust level of a thruster group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \return Average current thrust level (0-1)
+	 */
+	double GetThrusterGroupLevel(THGROUP_TYPE thgt) const;
 
+	/**
+	 * \brief Return sum of vaccum thrust ratings of the thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \return Sum of vacuum thrust ratings [N]
+	 * \note The returned value is not necessarily the effective total thrust rating of
+	 *    the group, because the thrusters may not be aligned.
+	 */
 	inline double GetThrusterGroupMaxth (const ThrustGroupSpec *tgs) const
-	{ return tgs->maxth_sum; }
-	// return the sum of max thrust ratings (vacuum) for all thrusters in a group
-	// (not necessarily the max total thrust, since thrusters may not be parallel)
+	{
+		dCHECK(tgs, "Zero ThrustGroupSpec pointer not permitted.")
+		return tgs->maxth_sum;
+	}
 
-	inline double GetThrusterGroupMaxth (THGROUP_TYPE thg) const
-	{ return thruster_grp_default[thg].maxth_sum; }
+	/**
+	 * \brief Return sum of vaccum thrust ratings of the thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \return Sum of vacuum thrust ratings [N]
+	 * \note The returned value is not necessarily the effective total thrust rating of
+	 *    the group, because the thrusters may not be aligned.
+	 */
+	double GetThrusterGroupMaxth(THGROUP_TYPE thgt) const;
 
+	/**
+	 * \brief Return the linear force vector currently produced by all thrusters in a group
+	 * \param thgt Thruster group specifier. This can be a default group (see \ref THGROUP_TYPE)
+	 *    or a user-defined type (THGROUP_USER+x)
+	 * \return Current linear force vector generated by the group [N]
+	 */
 	Vector GetThrusterGroupForce (THGROUP_TYPE thgt) const;
+
+	/**
+	 * \brief Return the linear force vector currently produced by all thrusters in a group
+	 * \param tgs Pointer to thruster group object (must not be 0)
+	 * \return Current linear force vector generated by the group [N]
+	 */
 	Vector GetThrusterGroupForce (const ThrustGroupSpec *tgs) const;
-	// returns linear force F currently produced by all thrusters in group tgs
 
 	void IncMainRetroLevel (double dlevel);
 	// This is a special treatment of the main/retro groups: increase forward thrust by
@@ -1191,10 +1296,13 @@ protected:
 	// given a force vector F and attack point r, this updates the linear and angular force
 	// vectors Flin and Amom for the rigid-body model
 
+	/**
+	 * \brief Return the magnitude of the maximum vacuum angular moment produced by all thrusters of a given RCS attitude group
+	 * \param axis Rotation axis index (0-5). The index is related to the thruster group by THGROUP_ATT_PITCHUP + axis
+	 * \return Magnitude of max. angular moment [Nm]
+	 * \note This also works if the vessel is part of a super-structure.
+	 */
 	double MaxAngularMoment (int axis) const;
-	// Return the maximum (vacuum) angular moment produced by all thrusters of
-	// a given attitude thruster group. This also works if the vessel is part
-	// of a super-structure
 
 	inline void SetDefaultPropellant (TankSpec *ts)
 	{ def_tank = ts; }
@@ -1377,9 +1485,12 @@ private:
 	bool bThrustEngaged;                         // true if any thrusters are engaged at current time step
 
 	// thruster group specs
-	ThrustGroupSpec thruster_grp_default[15];    // list of default thruster groups (see THGROUP_TYPE in Orbitersdk.h)
-	ThrustGroupSpec **thruster_grp_user;         // list of user-defined groups
-	DWORD nthruster_grp_user;                    // length of thruster_grp_user
+	std::array<ThrustGroupSpec, 15> thruster_grp_default; ///< list of default user groups (see THGROUP_TYPE in OrbiterAPI.h)
+	std::vector<ThrustGroupSpec*> thruster_grp_user;      ///< list of user-defined groups
+
+	//ThrustGroupSpec thruster_grp_default[15];    // list of default thruster groups (see THGROUP_TYPE in Orbitersdk.h)
+	//ThrustGroupSpec **thruster_grp_user;         // list of user-defined groups
+	//DWORD nthruster_grp_user;                    // length of thruster_grp_user
 
 	// exhaust specs
 	EXHAUSTSPEC **exhaust;                       // list of exhaust definitions

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -1290,7 +1290,7 @@ protected:
 	// Returns true if any part of the vessel is in contact with a planet surface
 	// Should be called only after update phase, and assumes that sp is up to date.
 
-	bool ThrustEngaged () const { return bThrustEngaged; }
+	bool ThrustEngaged () const { return m_bThrustEngaged; }
 
 	bool IsComponent () const { return supervessel != 0 || attach; }
 	const VesselBase *GetSuperStructure () const;
@@ -1486,18 +1486,13 @@ private:
 	// check for mesh parameters
 
 	// thruster specs
-	ThrustSpec **thruster;                       // list of thruster definitions
-	DWORD nthruster;                             // length of thruster list
-	double isp_default;                          // default fuel specific impulse [m/s] for new thrusters
-	bool bThrustEngaged;                         // true if any thrusters are engaged at current time step
+	std::vector<ThrustSpec*> m_thruster;         ///< list of thruster definitions
+	double m_defaultIsp;                         ///< default fuel specific impulse [m/s] for new thrusters
+	bool m_bThrustEngaged;                       ///< true if any thrusters are engaged at current time step
 
 	// thruster group specs
-	std::array<ThrustGroupSpec, 15> thruster_grp_default; ///< list of default user groups (see THGROUP_TYPE in OrbiterAPI.h)
-	std::vector<ThrustGroupSpec*> thruster_grp_user;      ///< list of user-defined groups
-
-	//ThrustGroupSpec thruster_grp_default[15];    // list of default thruster groups (see THGROUP_TYPE in Orbitersdk.h)
-	//ThrustGroupSpec **thruster_grp_user;         // list of user-defined groups
-	//DWORD nthruster_grp_user;                    // length of thruster_grp_user
+	std::array<ThrustGroupSpec, 15> m_thrusterGroupDef; ///< list of default thruster groups (see THGROUP_TYPE in OrbiterAPI.h)
+	std::vector<ThrustGroupSpec*> m_thrusterGroupUsr;   ///< list of user-defined groups
 
 	// exhaust specs
 	EXHAUSTSPEC **exhaust;                       // list of exhaust definitions

--- a/Src/Orbiter/Vesselstatus.cpp
+++ b/Src/Orbiter/Vesselstatus.cpp
@@ -244,10 +244,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 
 		if (sscanf (line+11, "%lf", &lvl)) {
 			if (lvl > 0) {
-				for (n = 0; n < thruster_grp_default[THGROUP_MAIN].nts; n++) {
-					ThrustSpec *ts = thruster_grp_default[THGROUP_MAIN].ts[n];
+				ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_MAIN];
+				for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
 					for (nn = 0; nn < nthruster; nn++) {
-						if (thruster[nn] == ts) {
+						if (thruster[nn] == *it) {
 							VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 							if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 							tmp[vs->nthruster].idx = nn;
@@ -258,10 +258,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 					}
 				}
 			} else if (lvl < 0) {
-				for (n = 0; n < thruster_grp_default[THGROUP_RETRO].nts; n++) {
-					ThrustSpec *ts = thruster_grp_default[THGROUP_RETRO].ts[n];
+				ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_RETRO];
+				for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
 					for (nn = 0; nn < nthruster; nn++) {
-						if (thruster[nn] == ts) {
+						if (thruster[nn] == *it) {
 							VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 							if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 							tmp[vs->nthruster].idx = nn;
@@ -276,10 +276,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 	} else if (!_strnicmp (line, "ENGINE_HOVR", 11)) { // old style hover thruster status
 
 		if (sscanf (line+11, "%lf", &lvl) && lvl > 0) {
-			for (n = 0; n < thruster_grp_default[THGROUP_HOVER].nts; n++) {
-				ThrustSpec *ts = thruster_grp_default[THGROUP_HOVER].ts[n];
+			ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_HOVER];
+			for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
 				for (nn = 0; nn < nthruster; nn++) {
-					if (thruster[nn] == ts) {
+					if (thruster[nn] == *it) {
 						VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 						if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 						tmp[vs->nthruster].idx = nn;

--- a/Src/Orbiter/Vesselstatus.cpp
+++ b/Src/Orbiter/Vesselstatus.cpp
@@ -102,9 +102,9 @@ bool Vessel::ParseScenarioLine (char *line, VESSELSTATUS &vs)
 				if (n < ntank && tank[n] == def_tank) vs.fuel = lvl;
 	} else if (!_strnicmp (line, "THLEVEL", 7)) {
 		for (pd = strtok (line+7, " "); pd; pd = strtok (NULL, " ")) {
-			if (sscanf (pd, "%d%c%lf", &n, &c, &lvl) == 3 && n < nthruster) {
-				thruster[n]->level = thruster[n]->level_permanent = lvl;
-				thruster[n]->level_override = 0.0;
+			if (sscanf (pd, "%d%c%lf", &n, &c, &lvl) == 3 && n < m_thruster.size()) {
+				m_thruster[n]->level = m_thruster[n]->level_permanent = lvl;
+				m_thruster[n]->level_override = 0.0;
 			}
 		}
 	} else if (!_strnicmp (line, "IDS", 3)) {
@@ -244,10 +244,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 
 		if (sscanf (line+11, "%lf", &lvl)) {
 			if (lvl > 0) {
-				ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_MAIN];
+				ThrustGroupSpec& tgs = m_thrusterGroupDef[THGROUP_MAIN];
 				for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
-					for (nn = 0; nn < nthruster; nn++) {
-						if (thruster[nn] == *it) {
+					for (nn = 0; nn < m_thruster.size(); nn++) {
+						if (m_thruster[nn] == *it) {
 							VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 							if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 							tmp[vs->nthruster].idx = nn;
@@ -258,10 +258,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 					}
 				}
 			} else if (lvl < 0) {
-				ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_RETRO];
+				ThrustGroupSpec& tgs = m_thrusterGroupDef[THGROUP_RETRO];
 				for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
-					for (nn = 0; nn < nthruster; nn++) {
-						if (thruster[nn] == *it) {
+					for (nn = 0; nn < m_thruster.size(); nn++) {
+						if (m_thruster[nn] == *it) {
 							VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 							if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 							tmp[vs->nthruster].idx = nn;
@@ -276,10 +276,10 @@ bool Vessel::ParseScenarioLine2 (char *line, void *status)
 	} else if (!_strnicmp (line, "ENGINE_HOVR", 11)) { // old style hover thruster status
 
 		if (sscanf (line+11, "%lf", &lvl) && lvl > 0) {
-			ThrustGroupSpec& tgs = thruster_grp_default[THGROUP_HOVER];
+			ThrustGroupSpec& tgs = m_thrusterGroupDef[THGROUP_HOVER];
 			for (auto it = tgs.ts.begin(); it != tgs.ts.end(); it++) {
-				for (nn = 0; nn < nthruster; nn++) {
-					if (thruster[nn] == *it) {
+				for (nn = 0; nn < m_thruster.size(); nn++) {
+					if (m_thruster[nn] == *it) {
 						VESSELSTATUS2::THRUSTSPEC *tmp = new VESSELSTATUS2::THRUSTSPEC[vs->nthruster+1]; TRACENEW
 						if (vs->nthruster) { memcpy (tmp, vs->thruster, vs->nthruster*sizeof (VESSELSTATUS2::THRUSTSPEC)); delete []vs->thruster; }
 						tmp[vs->nthruster].idx = nn;
@@ -534,15 +534,15 @@ void Vessel::SetState2 (const void *status)
 
 	// set thruster status
 	if (vs->flag & VS_THRUSTRESET)
-		for (idx = 0; idx < nthruster; idx++)
-			thruster[idx]->level_permanent = 0;
+		for (auto it = m_thruster.begin(); it != m_thruster.end(); it++)
+			(*it)->level_permanent = 0;
 	if (vs->flag & VS_THRUSTLIST) {
 		for (i = 0; i < vs->nthruster; i++) {
 			idx = vs->thruster[i].idx;
 			lvl = vs->thruster[i].level;
-			if (idx < nthruster) {
-				thruster[idx]->level_permanent = lvl;
-				thruster[idx]->level = min (1.0, lvl+thruster[idx]->level_override);
+			if (idx < m_thruster.size()) {
+				m_thruster[idx]->level_permanent = lvl;
+				m_thruster[idx]->level = min (1.0, lvl + m_thruster[idx]->level_override);
 			}
 		}
 	}
@@ -683,11 +683,11 @@ void Vessel::GetState2 (void *status)
 		}
 	}
 	if (vs->flag & VS_THRUSTLIST) {
-		vs->nthruster = nthruster;
-		if (!vs->thruster) { vs->thruster = new VESSELSTATUS2::THRUSTSPEC[nthruster]; TRACENEW }
-		for (i = 0; i < nthruster; i++) {
+		vs->nthruster = m_thruster.size();
+		if (!vs->thruster) { vs->thruster = new VESSELSTATUS2::THRUSTSPEC[m_thruster.size()]; TRACENEW }
+		for (i = 0; i < m_thruster.size(); i++) {
 			vs->thruster[i].idx = i;
-			vs->thruster[i].level = thruster[i]->level;
+			vs->thruster[i].level = m_thruster[i]->level;
 		}
 	}
 	if (vs->flag & VS_DOCKINFOLIST) {


### PR DESCRIPTION
- User-defined thruster groups (THGROUP_USER+x with x >= 0) should now be fully supported by Vessel class methods and thruster-group related API functions.
- Some cleanup of code in Vessel class; converted thruster and thruster-group related lists to std::vector and std::array
- GetThrusterGroupLevel called with THGROUP_USER should no longer crash (see #235)

Closes #246