### PR TITLE
fix pointer truncation caused by LONG vs LONG_PTR in SetWindowLongPtr call

### DIFF
--- a/Src/Plugin/LaunchpadExtensions/AtmConfig/AtmConfig.cpp
+++ b/Src/Plugin/LaunchpadExtensions/AtmConfig/AtmConfig.cpp
@@ -280,7 +280,7 @@ INT_PTR CALLBACK AtmConfig::DlgProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
 {
 	switch (uMsg) {
 	case WM_INITDIALOG:
-		SetWindowLongPtr (hWnd, DWLP_USER, (LONG)lParam); // store class instance for later reference
+		SetWindowLongPtr (hWnd, DWLP_USER, (LONG_PTR)lParam); // store class instance for later reference
 		((AtmConfig*)lParam)->InitDialog (hWnd);
 		break;
 	case WM_COMMAND:


### PR DESCRIPTION
Fixes #244 