### PR TITLE
#234: Fix artefact output as debug build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,15 +66,15 @@ jobs:
 
     - name: Configure
       working-directory: ${{ github.workspace }}/out/build
-      run: cmake -G Ninja ../.. -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
+      run: cmake -G Ninja ../.. -DCMAKE_BUILD_TYPE=Release -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
 
     - name: Build
       working-directory: ${{ github.workspace }}/out/build
-      run: cmake --build . --config RelWithDebInfo
+      run: cmake --build . --config Release
 
     - name: Test
       working-directory: ${{ github.workspace }}/out/build
-      run: ctest --config RelWithDebInfo .
+      run: ctest --config Release .
 
     - name: Install
       working-directory: ${{ github.workspace }}/out/build


### PR DESCRIPTION
build.yml: Added -DCMAKE_BUILD_TYPE=Release to Ninja configuration step and replaced RelWithDebInfo with Release for all config settings, to see if that fixes output artefacts being emitted as debug builds.