### PR TITLE
#260: Fix exception on surface label types not in legend

### DIFF
--- a/OVP/D3D7Client/tilelabel.cpp
+++ b/OVP/D3D7Client/tilelabel.cpp
@@ -236,6 +236,7 @@ void TileLabel::Render(oapi::Sketchpad *skp, oapi::Font **labelfont, int *fontid
 			dir = unit(sp);
 			if (cam->Direction2Viewport(dir, x, y)) {
 
+				active = false; // default for label types not listed in the legend
 				symbol = 0; // undefined
 				if (nl = tile->smgr->GClient()->GetSurfaceMarkerLegend(hPlanet, &lspec)) {
 					for (int j = 0; j < nl; j++) {

--- a/OVP/D3D9Client/TileLabel.cpp
+++ b/OVP/D3D9Client/TileLabel.cpp
@@ -297,6 +297,7 @@ void TileLabel::Render (D3D9Pad *skp, oapi::Font **labelfont, int *fontidx)
 			dir = unit(sp);
 			if (pScene->CameraDirection2Viewport(dir, x, y)) {
 
+				active = false; // default for label types not listed in the legend
 				symbol = 0; // undefined
 				if (nl = tile->smgr->Client()->GetSurfaceMarkerLegend(hPlanet, &lspec)) {
 					for (int j = 0; j < nl; ++j) {

--- a/Src/Orbiter/tilelabel.cpp
+++ b/Src/Orbiter/tilelabel.cpp
@@ -230,6 +230,7 @@ void TileLabel::Render(oapi::Sketchpad *skp, oapi::Font **labelfont, int *fontid
 			dir = sp.unit();
 			if (g_camera->Direction2Viewport(dir, x, y)) {
 
+				active = false; // default for label types not listed in the legend
 				symbol = 0; // undefined
 				if (nl = pl->NumLabelLegend()) {
 					const oapi::GraphicsClient::LABELTYPE *lspec = pl->LabelLegend();


### PR DESCRIPTION
An exception occurs if a planet's label layer contains label types not listed in its legend file.
The reason is the used of an uninitialised variable ('active').

Solution: All graphics clients: TileLabel::Render: initialised 'active' flag to false before scanning label legend.

Closes #260.