### PR TITLE
#269: Address build failures on dual inline graphics/server builds

### DIFF
--- a/Src/Orbiter/CMakeLists.txt
+++ b/Src/Orbiter/CMakeLists.txt
@@ -233,6 +233,15 @@ if(BUILD_ORBITER_DX7)
 		DESTINATION ${ORBITER_INSTALL_SDK_DIR}/lib
 	)
 	
+	if(BUILD_ORBITER_SERVER)
+		add_dependencies(Orbiter
+			Orbiter_server
+		)
+		add_custom_command(TARGET Orbiter
+			PRE_LINK
+			COMMAND del Orbiter.lib Orbiter.exp
+		)
+	endif()
 endif()
 
 # Orbiter executable (graphics server version)


### PR DESCRIPTION
Enforce sequential build of Orbiter inline and server. Delete Orbiter.lib and Orbiter.exp after first pass.

Closes #269 .