### PR TITLE
#275: D3D9Client: Fix elevation artefacts for elev_mod tiles

### DIFF
--- a/OVP/D3D9Client/Surfmgr2.cpp
+++ b/OVP/D3D9Client/Surfmgr2.cpp
@@ -307,8 +307,8 @@ INT16 *SurfTile::ReadElevationFile (const char *name, int lvl, int ilat, int iln
 #ifdef ORBITER2016
 				hdr.scale = 1.0;
 #endif
-				rescale = (do_rescale = (hdr.scale != 1.0)) ? hdr.scale : 1.0;
-				offset = (do_shift = (hdr.offset != 0.0)) ? INT16(hdr.offset) : 0;
+				rescale = (do_rescale = (hdr.scale != tgt_res)) ? hdr.scale/tgt_res : 1.0;
+				offset = (do_shift = (hdr.offset != 0.0)) ? INT16(hdr.offset/tgt_res) : 0;
 
 				switch (hdr.dtype) {
 				case 0: // overwrite the entire tile with a flat offset


### PR DESCRIPTION
D3D9Client: apply tgt_res to the rescale and offset values of elevation mod tiles.
This should fix the elevation artefacts at Edwards and Mojave spaceport (Antelope Valley texture pack)