### PR TITLE
228 video tab update on client change

### DIFF
--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -235,6 +235,10 @@ void VideoTab::SelectDevice (D3D7Enum_DeviceInfo *dev)
 void VideoTab::SelectDispmode (D3D7Enum_DeviceInfo *dev, BOOL bWindow)
 {
 	DWORD i;
+	if ((SendDlgItemMessage(hTab, IDC_VID_WINDOW, BM_GETCHECK, 0, 0) == BST_CHECKED) != (bWindow != 0)) {
+		SendDlgItemMessage(hTab, IDC_VID_WINDOW, BM_SETCHECK, bWindow ? BST_CHECKED : BST_UNCHECKED, 0);
+		SendDlgItemMessage(hTab, IDC_VID_FULL, BM_SETCHECK, bWindow ? BST_UNCHECKED : BST_CHECKED, 0);
+	}
 	for (i = 0; i < 6; i++)
 		EnableWindow (GetDlgItem (hTab, IDC_VID_STATIC5+i), !bWindow);
 	for (i = 0; i < 9; i++)

--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -144,6 +144,8 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	EnableWindow(GetDlgItem(hTab, IDC_VID_ENUM), true);
 	SetWindowText(GetDlgItem(hTab, IDC_VID_STENCIL), "Try stencil buffer");
 	EnableWindow(GetDlgItem(hTab, IDC_VID_STENCIL), true);
+	SetWindowText(GetDlgItem(hTab, IDC_VID_PAGEFLIP), "Hardware pageflip");
+	SetWindowText(GetDlgItem(hTab, IDC_VID_INFO), "Info");
 
 	SendDlgItemMessage (hTab, IDC_VID_DEVICE, CB_RESETCONTENT, 0, 0);
 	for (i = 0; i < ndev; i++) {

--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -145,7 +145,6 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	SetWindowText(GetDlgItem(hTab, IDC_VID_STENCIL), "Try stencil buffer");
 	EnableWindow(GetDlgItem(hTab, IDC_VID_STENCIL), true);
 	SetWindowText(GetDlgItem(hTab, IDC_VID_PAGEFLIP), "Hardware pageflip");
-	SetWindowText(GetDlgItem(hTab, IDC_VID_INFO), "Info");
 
 	SendDlgItemMessage (hTab, IDC_VID_DEVICE, CB_RESETCONTENT, 0, 0);
 	for (i = 0; i < ndev; i++) {

--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -138,6 +138,13 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	DWORD i, ndev, idx;
 	D3D7Enum_GetDevices (&devlist, &ndev);
 
+	// Make sure all controls are reset to default configurations in case another client
+	// modified them
+	SetWindowText(GetDlgItem(hTab, IDC_VID_ENUM), "Always enumerate devices");
+	EnableWindow(GetDlgItem(hTab, IDC_VID_ENUM), true);
+	SetWindowText(GetDlgItem(hTab, IDC_VID_STENCIL), "Try stencil buffer");
+	EnableWindow(GetDlgItem(hTab, IDC_VID_STENCIL), true);
+
 	SendDlgItemMessage (hTab, IDC_VID_DEVICE, CB_RESETCONTENT, 0, 0);
 	for (i = 0; i < ndev; i++) {
 		SendMessage (GetDlgItem (hTab, IDC_VID_DEVICE), CB_ADDSTRING, 0,

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -240,6 +240,8 @@ void orbiter::DefVideoTab::ScanDir(HWND hTab, const PSTR dir)
 
 void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 {
+	ShowInterface(hTab, idx > 0);
+
 	char name[256];
 	if (idxClient) { // unload the current client
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
@@ -253,8 +255,6 @@ void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 	}
 	else
 		SetInfoString(strInfo_Default);
-
-	ShowInterface(hTab, idx > 0);
 }
 
 void orbiter::DefVideoTab::SetInfoString(PSTR str)

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -247,6 +247,7 @@ void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
 		pCfg->DelModule(name);
 		pLp->App()->UnloadModule(name);
+		pCfg->CfgDevPrm.Device_idx = -1;
 	}
 	if (idx) { // load the new client
 		const char* path = "Modules\\Plugin";

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -105,7 +105,9 @@ void orbiter::DefVideoTab::OnGraphicsClientLoaded(oapi::GraphicsClient* gc, cons
 	int newIdx = SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_FINDSTRING, -1, (LPARAM)fname);
 	if (newIdx != oldIdx) {
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_SETCURSEL, newIdx, 0);
-		SelectClientIndex(newIdx);
+		ShowInterface(hTab, newIdx > 0);
+		pCfg->AddModule(fname); // make the graphics client "active" so it is loaded on next app start
+		idxClient = newIdx;
 	}
 
 	HMODULE hMod = LoadLibraryEx(moduleName, 0, LOAD_LIBRARY_AS_DATAFILE);
@@ -240,15 +242,14 @@ void orbiter::DefVideoTab::ScanDir(HWND hTab, const PSTR dir)
 void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 {
 	char name[256];
-	if (idxClient) {
+	if (idxClient) { // unload the current client
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
 		pCfg->DelModule(name);
 		pLp->App()->UnloadModule(name);
 	}
-	if (idxClient = idx) {
+	if (idxClient = idx) { // load the new client
 		const char* path = "Modules\\Plugin";
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
-		pCfg->AddModule(name);
 		pLp->App()->LoadModule(path, name);
 	}
 	else

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -101,9 +101,8 @@ void orbiter::DefVideoTab::OnGraphicsClientLoaded(oapi::GraphicsClient* gc, cons
 	char fname[256];
 	_splitpath(moduleName, NULL, NULL, fname, NULL);
 
-	int oldIdx = SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETCURSEL, 0, 0);
 	int newIdx = SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_FINDSTRING, -1, (LPARAM)fname);
-	if (newIdx != oldIdx) {
+	if (newIdx != idxClient) {
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_SETCURSEL, newIdx, 0);
 		ShowInterface(hTab, newIdx > 0);
 		pCfg->AddModule(fname); // make the graphics client "active" so it is loaded on next app start
@@ -247,9 +246,9 @@ void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 		pCfg->DelModule(name);
 		pLp->App()->UnloadModule(name);
 	}
-	if (idxClient = idx) { // load the new client
+	if (idx) { // load the new client
 		const char* path = "Modules\\Plugin";
-		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
+		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idx, (LPARAM)name);
 		pLp->App()->LoadModule(path, name);
 	}
 	else


### PR DESCRIPTION
Fix switching between graphics clients in video tab.
- Update video tab dialog elements to reflect selected client.
- Rescan video devices on switch.

Closes #228.