### PR TITLE
fixed type for FindFirst / FindNext

### DIFF
--- a/Src/Orbiter/DlgVishelper.cpp
+++ b/Src/Orbiter/DlgVishelper.cpp
@@ -234,7 +234,7 @@ void TabPlanetarium::RescanMarkerList(HWND hTab)
 
 	char cbuf[256];
 	_finddata_t fdata;
-	long fh = g_psys->FindFirst(FILETYPE_MARKER, &fdata, cbuf);
+	intptr_t fh = g_psys->FindFirst(FILETYPE_MARKER, &fdata, cbuf);
 	if (fh >= 0) {
 		int n = 0;
 		do {


### PR DESCRIPTION
...to intptr_t. The wrong type lead to exception in _findnext(...) call on x64 builds.