### PR TITLE
297 d3d7client hangup on launch

### DIFF
--- a/Src/Orbiter/Config.h
+++ b/Src/Orbiter/Config.h
@@ -401,11 +401,27 @@ public:
 	CFG_WINDOWPOS CfgWindowPos;         // subwindow positions
 	CFG_CMDLINEPRM CfgCmdlinePrm;       // Populated by command line parameters. Overrides interactive settings
 
-	// module parameters
-	int nactmod;                 // number of active modules
-	char **actmod;               // list of active modules
-	void AddModule (char *cbuf); // add a module to the list
-	void DelModule (char *cbuf); // delete module from the list
+	/**
+	 * \brief Returns a list of active plugin module names
+	 */
+	const std::list<std::string>& GetActiveModules() const { return m_activeModules; }
+
+	/**
+	 * \brief Checks if a module is in the active list.
+	 * \param name Module name
+	 * \return true if name is in the list, false otherwise
+	 */
+	bool IsActiveModule(const std::string& name);
+
+	/**
+	 * \brief Add a module to the active list.
+	 */
+	void AddActiveModule (const std::string& name);
+
+	/**
+	 * \brief Delete a module from the active list.
+	 */
+	void DelActiveModule (const std::string& name);
 
 	inline void SetAmbientLevel (DWORD lvl)
 	{ AmbientColour = (CfgVisualPrm.AmbientLevel = min (lvl, 0xff)) * 0x01010101; }
@@ -437,6 +453,8 @@ private:
 	char scnpath[256];
 	int cfglen, mshlen, texlen, htxlen, ptxlen, scnlen; // string length
 	bool found_config_file;
+
+	std::list<std::string> m_activeModules; ///< list of active modules
 };
 
 // =============================================================

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -353,6 +353,7 @@ Orbiter::Orbiter ()
 	ncustomcmd      = 0;
 	D3DMathSetup();
 	script          = NULL;
+	memstat = nullptr;
 
 	simheapsize     = 0;
 
@@ -441,19 +442,6 @@ HRESULT Orbiter::Create (HINSTANCE hInstance)
 
 	script = new ScriptInterface (this); TRACENEW
 
-	{
-		BOOL cleartype, ok;
-		ok = SystemParametersInfo (SPI_GETFONTSMOOTHING, 0, &cleartype, 0);
-		bSysClearType = (ok && cleartype);
-		//if (pConfig->CfgDebugPrm.bForceReenableSmoothFont) bSysClearType = true;
-	}
-	if (pConfig->CfgDebugPrm.bDisableSmoothFont)
-		ActivateRoughType();
-
-	// preload fixed plugin modules
-	LoadFixedModules ();
-	memstat = new MemStat;
-
 	// preload modules from command line requests
 	for (auto it = pConfig->CfgCmdlinePrm.LoadPlugins.begin(); it != pConfig->CfgCmdlinePrm.LoadPlugins.end(); it++)
 		LoadModule("Modules\\Plugin", it->c_str());
@@ -462,7 +450,21 @@ HRESULT Orbiter::Create (HINSTANCE hInstance)
 	for (int i = 0; i < pConfig->nactmod; i++)
 		LoadModule ("Modules\\Plugin", pConfig->actmod[i]);
 
-    return S_OK;
+	// preload fixed plugin modules
+	LoadFixedModules();
+
+	{
+		BOOL cleartype, ok;
+		ok = SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &cleartype, 0);
+		bSysClearType = (ok && cleartype);
+		//if (pConfig->CfgDebugPrm.bForceReenableSmoothFont) bSysClearType = true;
+	}
+	if (pConfig->CfgDebugPrm.bDisableSmoothFont)
+		ActivateRoughType();
+
+	memstat = new MemStat;
+	
+	return S_OK;
 }
 
 //-----------------------------------------------------------------------------

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -440,18 +440,16 @@ HRESULT Orbiter::Create (HINSTANCE hInstance)
 
 	Instrument::RegisterBuiltinModes();
 
-	script = new ScriptInterface (this); TRACENEW
+	script = new ScriptInterface(this); TRACENEW
 
 	// preload modules from command line requests
-	for (auto it = pConfig->CfgCmdlinePrm.LoadPlugins.begin(); it != pConfig->CfgCmdlinePrm.LoadPlugins.end(); it++)
-		LoadModule("Modules\\Plugin", it->c_str());
+	LoadModules("Modules\\Plugin", pConfig->CfgCmdlinePrm.LoadPlugins);
 
 	// preload active plugin modules
-	for (int i = 0; i < pConfig->nactmod; i++)
-		LoadModule ("Modules\\Plugin", pConfig->actmod[i]);
+	LoadModules("Modules\\Plugin", pConfig->GetActiveModules());
 
-	// preload fixed plugin modules
-	LoadFixedModules();
+	// preload startup plugin modules
+	LoadStartupModules();
 
 	{
 		BOOL cleartype, ok;
@@ -537,25 +535,6 @@ int Orbiter::GetVersion () const
 	return v;
 }
 
-//-----------------------------------------------------------------------------
-// Name: LoadFixedModules()
-// Desc: Load all plugin modules from the "startup" directory
-//-----------------------------------------------------------------------------
-void Orbiter::LoadFixedModules ()
-{
-	char cbuf[256];
-	char *path = "Modules\\Startup";
-	struct _finddata_t fdata;
-	intptr_t fh = _findfirst ("Modules\\Startup\\*.dll", &fdata);
-	if (fh == -1) return; // no files found
-	do {
-		strcpy (cbuf, fdata.name);
-		cbuf[(strlen(cbuf)-4)] = '\0'; // cut off extension
-		LoadModule (path, cbuf);
-	} while (!_findnext (fh, &fdata));
-	_findclose (fh);
-}
-
 static bool FileExists(const char* path)
 {
 	return access(path, 0) != -1;
@@ -577,6 +556,36 @@ static bool FindDllInPluginFolder(const char *path, const char *name, char* cbuf
 {
 	sprintf(cbufOut, "%s\\%s\\%s.dll", path, name, name);
 	return FileExists(cbufOut);
+}
+
+void Orbiter::LoadModules(const std::string& path, const std::list<std::string>& names)
+{
+	for (auto name : names)
+		LoadModule(path.c_str(), name.c_str());
+}
+
+
+void Orbiter::LoadModules(const std::string& path)
+{
+	struct _finddata_t fdata;
+	intptr_t fh = _findfirst((path + std::string("\\*.dll")).c_str(), &fdata);
+	if (fh == -1) return; // no files found
+	do {
+		if (strlen(fdata.name) > 4) {
+			fdata.name[strlen(fdata.name) - 4] = '\0'; // cut off extension
+			LoadModule(path.c_str(), fdata.name);
+		}
+	} while (!_findnext(fh, &fdata));
+	_findclose(fh);
+}
+
+//-----------------------------------------------------------------------------
+// Name: LoadStartupModules()
+// Desc: Load all plugin modules from the "startup" directory
+//-----------------------------------------------------------------------------
+void Orbiter::LoadStartupModules()
+{
+	LoadModules("Modules\\Startup");
 }
 
 //-----------------------------------------------------------------------------

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -482,7 +482,23 @@ private:
 	oapi::Module *register_module;  // used during module registration
 	friend OAPIFUNC void oapiRegisterModule (oapi::Module* module);
 
-	void LoadFixedModules ();                   // load all startup plugins
+	/**
+	 * \brief Load a list of plugin modules from a specific directory.
+	 * \param path Module directory
+	 * \param names List of module file names
+	 */
+	void LoadModules(const std::string& path, const std::list<std::string>& names);
+
+	/**
+	 * \brief Load all DLLs in a specific directory as plugin modules.
+	 * \param Module directory
+	 */
+	void LoadModules(const std::string& path);
+
+	/**
+	 * \brief Load all plugins located in the Modules/Startup folder
+	 */
+	void LoadStartupModules();
 
 	OPC_Proc FindModuleProc (HINSTANCE hDLL, const char *procname);
 	// returns address of a procedure in a plugin module, or NULL if procedure not found

--- a/Src/Orbiter/TabModule.cpp
+++ b/Src/Orbiter/TabModule.cpp
@@ -175,18 +175,13 @@ void orbiter::ModuleTab::RefreshLists ()
 		rec->locked = false;
 
 		// check if module is set active in config
-		for (idx = pCfg->nactmod-1; idx >= 0; idx--)
-			if (!_stricmp (rec->name, pCfg->actmod[idx])) {
-				rec->active = true;
-				break;
-			}
+		if (pCfg->IsActiveModule(rec->name))
+			rec->active = true;
 
 		// check if module is set active in command line
-		std::string modname(rec->name);
-		auto idx = std::find(pLp->Cfg()->CfgCmdlinePrm.LoadPlugins.begin(), pLp->Cfg()->CfgCmdlinePrm.LoadPlugins.end(), modname);
-		if (idx != pLp->Cfg()->CfgCmdlinePrm.LoadPlugins.end()) {
+		if (std::find(pCfg->CfgCmdlinePrm.LoadPlugins.begin(), pCfg->CfgCmdlinePrm.LoadPlugins.end(), rec->name) != pCfg->CfgCmdlinePrm.LoadPlugins.end()) {
 			rec->active = true;
-			rec->locked = true;
+			rec->locked = true; // modules activated from the command line are not to be unloaded
 		}
 
 		sprintf (cbuf, "Modules\\Plugin\\%s", fdata.name);
@@ -315,11 +310,11 @@ void orbiter::ModuleTab::ActivateFromList ()
 				if (!rec->locked) {
 					rec->active = checked;
 					if (checked) {
-						pCfg->AddModule(rec->name);
+						pCfg->AddActiveModule(rec->name);
 						pLp->App()->LoadModule(path, rec->name);
 					}
 					else {
-						pCfg->DelModule(rec->name);
+						pCfg->DelActiveModule(rec->name);
 						pLp->App()->UnloadModule(rec->name);
 					}
 				}

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -105,7 +105,7 @@ void orbiter::DefVideoTab::OnGraphicsClientLoaded(oapi::GraphicsClient* gc, cons
 	if (newIdx != idxClient) {
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_SETCURSEL, newIdx, 0);
 		ShowInterface(hTab, newIdx > 0);
-		pCfg->AddModule(fname); // make the graphics client "active" so it is loaded on next app start
+		pCfg->AddActiveModule(fname);
 		idxClient = newIdx;
 	}
 
@@ -245,7 +245,7 @@ void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 	char name[256];
 	if (idxClient) { // unload the current client
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
-		pCfg->DelModule(name);
+		pCfg->DelActiveModule(name);
 		pLp->App()->UnloadModule(name);
 		pCfg->CfgDevPrm.Device_idx = -1;
 	}


### PR DESCRIPTION
- Rearranged module load sequence to an order that doesn't appear to exhibit the D3D7 client hangups, although the actual cause of the problem isn't really addressed.
- Cleaned up some of the code for manipulating the active module list in Config.

Closes #297.