### PR TITLE
Deal with missing gridlabel.dds texture file

### DIFF
--- a/OVP/D3D7Client/CelSphere.cpp
+++ b/OVP/D3D7Client/CelSphere.cpp
@@ -51,9 +51,12 @@ D3D7CelestialSphere::D3D7CelestialSphere (D3D7Client* gc, Scene* scene)
 	char cpath[256];
 	m_gc->TexturePath("gridlabel.dds", cpath);
 	if (FILE* f = fopen(cpath, "rb")) {
-		m_gc->GetTexMgr()->ReadTexture(f, &m_GridLabelTex, 0);
+		if (FAILED(m_gc->GetTexMgr()->ReadTexture(f, &m_GridLabelTex, 0)))
+			m_GridLabelTex = nullptr;
 		fclose(f);
 	}
+	if (!m_GridLabelTex)
+		oapiWriteLogError("Failed to load texture %s", cpath);
 }
 
 // ==============================================================
@@ -549,6 +552,7 @@ void D3D7CelestialSphere::RenderGrid (LPDIRECT3DDEVICE7 dev, const FVECTOR4& bas
 
 void D3D7CelestialSphere::RenderGridLabels(LPDIRECT3DDEVICE7 dev, int az_idx, const oapi::FVECTOR4& baseCol, double dphi)
 {
+	if (!m_GridLabelTex) return;
 	if (az_idx >= m_azGridLabelVtx.size()) return;
 	if (!m_azGridLabelVtx[az_idx])
 		AllocGridLabels();

--- a/OVP/D3D9Client/CelSphere.cpp
+++ b/OVP/D3D9Client/CelSphere.cpp
@@ -52,7 +52,10 @@ D3D9CelestialSphere::D3D9CelestialSphere(D3D9Client *gc, Scene *scene)
 	m_textBlendAdditive = true;
 	m_mjdPrecessionChecked = -1e10;
 
-	m_GridLabelTex = SURFACE(m_gc->clbkLoadTexture("gridlabel.dds", 0));
+	SURFHANDLE hSurf = m_gc->clbkLoadTexture("gridlabel.dds", 0);
+	if (hSurf) m_GridLabelTex = SURFACE(hSurf);
+	if (!m_GridLabelTex)
+		oapiWriteLogError("Failed to load texture gridlabel.dds");
 }
 
 // ==============================================================
@@ -73,7 +76,8 @@ D3D9CelestialSphere::~D3D9CelestialSphere()
 		m_GridLabelIdx->Release();
 
 	delete m_bkgImgMgr;
-	DELETE_SURFACE(m_GridLabelTex);
+	if (m_GridLabelTex)
+		DELETE_SURFACE(m_GridLabelTex);
 }
 
 // ==============================================================
@@ -566,6 +570,7 @@ void D3D9CelestialSphere::RenderGrid(ID3DXEffect *FX, bool eqline)
 
 void D3D9CelestialSphere::RenderGridLabels(ID3DXEffect* FX, int az_idx, const oapi::FVECTOR4& baseCol, const MATRIX3& R, double dphi)
 {
+	if (!m_GridLabelTex) return;
 	if (az_idx >= m_azGridLabelVtx.size()) return;
 	if (!m_azGridLabelVtx[az_idx])
 		AllocGridLabels();

--- a/Src/Orbiter/CelSphere.cpp
+++ b/Src/Orbiter/CelSphere.cpp
@@ -45,9 +45,12 @@ OGCelestialSphere::OGCelestialSphere(OrbiterGraphics* gc, Scene* scene)
 	char cpath[256];
 	m_gc->TexturePath("gridlabel.dds", cpath);
 	if (FILE* f = fopen(cpath, "rb")) {
-		g_texmanager2->ReadTexture(f, &m_GridLabelTex);
+		if (FAILED(g_texmanager2->ReadTexture(f, &m_GridLabelTex)))
+			m_GridLabelTex = nullptr;
 		fclose(f);
 	}
+	if (!m_GridLabelTex)
+		LOGOUT_ERR("Failed to load texture %s", cpath);
 }
 
 // ==============================================================
@@ -596,6 +599,7 @@ void OGCelestialSphere::RenderGrid(LPDIRECT3DDEVICE7 dev, const oapi::FVECTOR4& 
 
 void OGCelestialSphere::RenderGridLabels(LPDIRECT3DDEVICE7 dev, int az_idx, const oapi::FVECTOR4& baseCol, double dphi)
 {
+	if (!m_GridLabelTex) return;
 	if (az_idx >= m_azGridLabelVtx.size()) return;
 	if (!m_azGridLabelVtx[az_idx])
 		AllocGridLabels();


### PR DESCRIPTION
#311: All clients: If gridlabel.dds texture is not found, an error message is written to the log, and grid labels are not displayed. D3D9 client no longer crashes.