### PR TITLE
Clean-up patches

### DIFF
--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -2560,7 +2560,7 @@ DLLEXPORT void InitLib (HINSTANCE hModule)
 
 		char *(*mdate)() = (char*(*)())GetProcAddress (hModule, "ModuleDate");
 		if (mdate) {
-			int Date2Int (char *date);
+			int Date2Int (const char *date);
 			sprintf (cbuf+strlen(cbuf), " [Build %06d", Date2Int(mdate()));
 		} else {
 			strcat (cbuf, " [Build ******");
@@ -2590,9 +2590,9 @@ DLLEXPORT void ExitLib (HINSTANCE hModule)
 	if (DLLExit) (*DLLExit)(hModule);
 }
 
-DLLEXPORT int Date2Int (char *date)
+DLLEXPORT int Date2Int (const char *date)
 {
-	static char *mstr[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+	static const char *mstr[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 	char ms[32];
 	int day, month, year, v;
 	sscanf (date, "%s%d%d", ms, &day, &year);

--- a/Src/Orbiter/ZTreeMgr.h
+++ b/Src/Orbiter/ZTreeMgr.h
@@ -35,8 +35,8 @@ class TreeFileHeader {
 
 public:
 	TreeFileHeader();
-	size_t TreeFileHeader::fwrite(FILE *f);
-	bool TreeFileHeader::fread(FILE *f);
+	size_t fwrite(FILE *f);
+	bool fread(FILE *f);
 
 private:
 	BYTE magic[4];      // file ID and version

--- a/Src/Orbiter/elevmgr.h
+++ b/Src/Orbiter/elevmgr.h
@@ -51,7 +51,7 @@ public:
 protected:
 	bool TileIdx (double lat, double lng, int lvl, int *ilat, int *ilng) const;
 	INT16 *LoadElevationTile (int lvl, int ilat, int ilng, double tgt_res) const;
-	bool ElevationManager::LoadElevationTile_mod (int lvl, int ilat, int ilng, double tgt_res, INT16 *elev) const;
+	bool LoadElevationTile_mod (int lvl, int ilat, int ilng, double tgt_res, INT16 *elev) const;
 
 private:
 	const CelestialBody *cbody;

--- a/Src/Orbitersdk/Orbitersdk.cpp
+++ b/Src/Orbitersdk/Orbitersdk.cpp
@@ -38,7 +38,7 @@ int oapiGetModuleVersion ()
 {
 	static int v = 0;
 	if (!v) {
-		OAPIFUNC int Date2Int (char *date);
+		OAPIFUNC int Date2Int (const char *date);
 		v = Date2Int (__DATE__);
 	}
 	return v;

--- a/Utils/scramble/scramble.cpp
+++ b/Utils/scramble/scramble.cpp
@@ -19,7 +19,7 @@ char versionstr[64];
 
 void Setup ()
 {
-	char *monstr[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+	const char *monstr[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 	char cbuf[256];
 	int mon, day, year;
 


### PR DESCRIPTION
This is a first batch of clean-up patches discussed in #338 to enable C++20 standard conformance.

The purpose of these patches is to enable C++20 conformance of the existing code with minimal changes, so that further clean-up can be done as the next step.

The patches were purposely made very small and easy to review/accept, and will also aid any further bisects if necessary to find bugs.