### PR TITLE
Fix Date2Int() signature

### DIFF
--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -2560,7 +2560,7 @@ DLLEXPORT void InitLib (HINSTANCE hModule)
 
 		char *(*mdate)() = (char*(*)())GetProcAddress (hModule, "ModuleDate");
 		if (mdate) {
-			int Date2Int (const char *date);
+			int Date2Int (char *date);
 			sprintf (cbuf+strlen(cbuf), " [Build %06d", Date2Int(mdate()));
 		} else {
 			strcat (cbuf, " [Build ******");
@@ -2590,7 +2590,7 @@ DLLEXPORT void ExitLib (HINSTANCE hModule)
 	if (DLLExit) (*DLLExit)(hModule);
 }
 
-DLLEXPORT int Date2Int (const char *date)
+DLLEXPORT int Date2Int (char *date)
 {
 	static const char *mstr[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 	char ms[32];

--- a/Src/Orbitersdk/Orbitersdk.cpp
+++ b/Src/Orbitersdk/Orbitersdk.cpp
@@ -38,8 +38,8 @@ int oapiGetModuleVersion ()
 {
 	static int v = 0;
 	if (!v) {
-		OAPIFUNC int Date2Int (const char *date);
-		v = Date2Int (__DATE__);
+		OAPIFUNC int Date2Int (char *date);
+		v = Date2Int ((char*)__DATE__);
 	}
 	return v;
 }


### PR DESCRIPTION
This partially reverts commit 055f9666ff6d6803ccf75ffbb5e2fa8eb10a1987, which broke some of the precompiled binaries depending on Date2Int().