### PR TITLE
Use std::hypot instead of _hypot

### DIFF
--- a/OVP/D3D7Client/Camera.cpp
+++ b/OVP/D3D7Client/Camera.cpp
@@ -96,7 +96,7 @@ bool Camera::Direction2Viewport(const VECTOR3 &dir, int &x, int &y)
 	D3DVECTOR idir = {(D3DVALUE)-dir.x, (D3DVALUE)-dir.y, (D3DVALUE)-dir.z};
 	D3DMAT_VectorMatrixMultiply (&homog, &idir, &mProjView);
 	if (homog.x >= -1.0f && homog.y <= 1.0f && homog.z >= 0.0) {
-		if (_hypot(homog.x, homog.y) < 1e-6) {
+		if (std::hypot(homog.x, homog.y) < 1e-6) {
 			x = viewW/2, y = viewH/2;
 		} else {
 			x = (int)(viewW*0.5f*(1.0f+homog.x));

--- a/OVP/D3D7Client/VObject.cpp
+++ b/OVP/D3D7Client/VObject.cpp
@@ -160,7 +160,7 @@ void vObject::RenderSpot (LPDIRECT3DDEVICE7 dev, const VECTOR3 *ofs, float size,
 	double dist = length (pos);
 	VECTOR3 bdir (pos/dist);
 	const VECTOR3 &camp = *scn->GetCamera()->GetGPos();
-	double hz = _hypot (bdir.x, bdir.z);
+	double hz = std::hypot (bdir.x, bdir.z);
 	double phi = atan2 (bdir.z, bdir.x);
 	float sphi = (float)sin(phi), cphi = (float)cos(phi);
 

--- a/OVP/D3D7Client/VStar.cpp
+++ b/OVP/D3D7Client/VStar.cpp
@@ -84,7 +84,7 @@ bool vStar::Update ()
 	FLOAT rad_scale = (FLOAT)size;
 	FLOAT size_hack; // make star look bigger at distance
 	VECTOR3 bdir (unit(cpos));
-	double hz = _hypot (bdir.x, bdir.z);
+	double hz = std::hypot (bdir.x, bdir.z);
 	double phi = atan2 (bdir.z, bdir.x);
 	FLOAT sphi = (FLOAT)sin(phi), cphi = (FLOAT)cos(phi);
 	FLOAT tx = (FLOAT)cpos.x, ty = (FLOAT)cpos.y, tz = (FLOAT)cpos.z;

--- a/OVP/D3D9Client/CelSphere.cpp
+++ b/OVP/D3D9Client/CelSphere.cpp
@@ -636,7 +636,7 @@ bool D3D9CelestialSphere::EclDir2WindowPos(const VECTOR3& dir, int& x, int& y) c
 		homog.y >= -1.0f && homog.y <= 1.0f &&
 		homog.z < 1.0f) {
 
-		if (_hypot(homog.x, homog.y) < 1e-6) {
+		if (std::hypot(homog.x, homog.y) < 1e-6) {
 			x = m_scene->ViewW() / 2;
 			y = m_scene->ViewH() / 2;
 		}

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -2994,7 +2994,7 @@ bool Scene::WorldToScreenSpace(const VECTOR3 &wpos, oapi::IVECTOR2 *pt, D3DXMATR
 	bool bClip = false;
 	if (homog.x < -clip || homog.x > clip || homog.y < -clip || homog.y > clip) bClip = true;
 
-	if (_hypot(homog.x, homog.y) < 1e-6) {
+	if (std::hypot(homog.x, homog.y) < 1e-6) {
 		pt->x = viewW / 2;
 		pt->y = viewH / 2;
 	}
@@ -3024,7 +3024,7 @@ bool Scene::WorldToScreenSpace2(const VECTOR3& wpos, oapi::FVECTOR2* pt, D3DXMAT
 	if (homog.w < 0.0f) bClip = true;
 	if (homog.x < -clip || homog.x > clip || homog.y < -clip || homog.y > clip) bClip = true;
 
-	if (_hypot(homog.x, homog.y) < 1e-6) {
+	if (std::hypot(homog.x, homog.y) < 1e-6) {
 		pt->x = viewW / 2;
 		pt->y = viewH / 2;
 	}
@@ -3707,7 +3707,7 @@ bool Scene::CameraDirection2Viewport(const VECTOR3 &dir, int &x, int &y)
 	D3DXVECTOR3 idir = D3DXVECTOR3( -float(dir.x), -float(dir.y), -float(dir.z) );
 	D3DMAT_VectorMatrixMultiply(&homog, &idir, &Camera.mProjView);
 	if (homog.x >= -1.0f && homog.y <= 1.0f && homog.z >= 0.0) {
-		if (_hypot(homog.x, homog.y) < 1e-6) {
+		if (std::hypot(homog.x, homog.y) < 1e-6) {
 			x = viewW / 2, y = viewH / 2;
 		} else {
 			x = (int)(viewW*0.5f*(1.0f + homog.x));

--- a/OVP/D3D9Client/VStar.cpp
+++ b/OVP/D3D9Client/VStar.cpp
@@ -57,7 +57,7 @@ bool vStar::Render(LPDIRECT3DDEVICE9 dev)
 	float size_hack; // make star look bigger at distance
 
 	VECTOR3 bdir (unit(cpos));
-	double hz = _hypot (bdir.x, bdir.z);
+	double hz = std::hypot (bdir.x, bdir.z);
 	// double phi = atan2 (bdir.z, bdir.x);
 	// FLOAT sphi = (FLOAT)sin(phi), cphi = (FLOAT)cos(phi);
 	// FLOAT tx = (FLOAT)cpos.x, ty = (FLOAT)cpos.y, tz = (FLOAT)cpos.z;

--- a/OVP/D3D9Client/samples/DrawOrbits/Draw.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Draw.cpp
@@ -374,7 +374,7 @@ bool Orbits::WorldToScreenSpace(const VECTOR3& wpos, oapi::IVECTOR2* pt, const F
 	bool bVis = true;
 	if (homog.x < -clip || homog.x > clip || homog.y < -clip || homog.y > clip) bVis = false;
 
-	if (_hypot(homog.x, homog.y) < 1e-6) {
+	if (std::hypot(homog.x, homog.y) < 1e-6) {
 		pt->x = s.cx / 2;
 		pt->y = s.cy / 2;
 	}

--- a/Src/Orbiter/Baseobj.cpp
+++ b/Src/Orbiter/Baseobj.cpp
@@ -2063,7 +2063,7 @@ void Runway::Activate ()
 	D3DVALUE x, z, step;
 	D3DVALUE dx = end2.x - end1.x;
 	D3DVALUE dz = end2.z - end1.z;
-	D3DVALUE len = D3DVAL(_hypot (dx, dz));
+	D3DVALUE len = D3DVAL(std::hypot (dx, dz));
 	D3DVALUE dwx = (width/len) * dz;
 	D3DVALUE dwz = (width/len) * dx;
 	D3DVALUE s0, x0, z0, ddx, ddz;

--- a/Src/Orbiter/Camera.cpp
+++ b/Src/Orbiter/Camera.cpp
@@ -417,7 +417,7 @@ bool Camera::Direction2Viewport(const Vector &dir, int &x, int &y)
 	D3DVECTOR homog;
 	D3DMath_VectorMatrixMultiply (homog, D3DMath_Vector(dir.x, dir.y, dir.z), *D3D_ProjViewMatrix());
 	if (homog.x >= -1.0f && homog.y <= 1.0f && homog.z <= 1.0f) {
-		if (_hypot(homog.x, homog.y) < 1e-6) {
+		if (std::hypot(homog.x, homog.y) < 1e-6) {
 			x = (int)w05, y = (int)h05;
 		} else {
 			x = (int)(w05*(1.0f+homog.x));
@@ -1254,7 +1254,7 @@ void Camera::Update ()
 		Vector cp(planet_proxy->GPos()-gpos);
 		double alt = cp.length()-planet_proxy->Size();
 		double az = acos (dotp (gd, cp.unit()));
-		double a = atan (tan_ap*_hypot(w05,h05)/h05);
+		double a = atan (tan_ap*std::hypot(w05,h05)/h05);
 		double tht = az-a;
 		if (tht < Pi05)
 			np = min (np, alt*cos(a)/cos(tht));

--- a/Src/Orbiter/Element.cpp
+++ b/Src/Orbiter/Element.cpp
@@ -424,7 +424,7 @@ void Elements::Calculate (const Vector &R, const Vector &V, double simt)
 
 	// longitude of ascending node
 	if (i > I_NOINC_LIMIT) {
-		double tmp = 1.0/_hypot (priv_H.z, priv_H.x);
+		double tmp = 1.0/std::hypot(priv_H.z, priv_H.x);
 		priv_N.Set (-priv_H.z*tmp, 0.0, priv_H.x*tmp); // unit vector
 		theta = acos (priv_N.x);
 		if (priv_N.z < 0.0) theta = Pi2-theta;

--- a/Src/Orbiter/MfdDocking.cpp
+++ b/Src/Orbiter/MfdDocking.cpp
@@ -348,7 +348,7 @@ void Instrument_Docking::UpdateDraw (oapi::Sketchpad *skp)
 		double s = (adockref.z - adpos.z) / addir.z;
 		Vector Z (adpos - adockref + addir*s);
 
-		double z = _hypot (Z.x, Z.y);
+		double z = std::hypot(Z.x, Z.y);
 		double lz = (log10(z)+1.0+scale) * 0.25;
 		if (lz < 0.0) {
 			x = y = 0;
@@ -395,7 +395,7 @@ void Instrument_Docking::UpdateDraw (oapi::Sketchpad *skp)
 		// Ship's relative velocity projected into ship's approach xy plane
 		double dvx = (adposold.x-adpos.x)/dt;
 		double dvy = (adposold.y-adpos.y)/dt;
-		r = _hypot(dvx, dvy);
+		r = std::hypot(dvx, dvy);
 
 		sprintf(cbuf, "hV %s", DistStr(fabs(dvx), 5));
 		x0 = cw / 2;

--- a/Src/Orbiter/MfdLanding.cpp
+++ b/Src/Orbiter/MfdLanding.cpp
@@ -171,7 +171,7 @@ void Instrument_Landing::UpdateDraw (oapi::Sketchpad *skp)
 	}
 	Vector hvel (tmul (sp->ref->GRot(), sp->groundvel_glob));
 	hvel.Set (mul (sp->L2H, hvel));
-	hspd = _hypot (hvel.x, hvel.z);
+	hspd = std::hypot (hvel.x, hvel.z);
 	vdir = atan2 (hvel.x, hvel.z) - sp->dir;
 	if      (vdir <= -Pi) vdir += Pi2;
 	else if (vdir >=  Pi) vdir -= Pi2;

--- a/Src/Orbiter/MfdMap_old.cpp
+++ b/Src/Orbiter/MfdMap_old.cpp
@@ -559,7 +559,7 @@ void Instrument_MapOld::CalcOrbitProj (const Elements *el, const Planet *planet,
 		rl.Set (mul (R, Vector(cosp[i],0,sinp[i])));
 		x = rl.x, y = rl.y, z = rl.z;
 		lng = atan2 (z,x) + Pi;  // maps start at -Pi (180°W)
-		lat = atan(y/_hypot(x,z));
+		lat = atan(y/std::hypot(x,z));
 		sp[i].x = (int)(lng*f1);
 		if ((sp[i+npt05].x = sp[i].x + mapw05) >= mapw) sp[i+npt05].x -= mapw;
 		ilat = (int)(lat*f1);

--- a/Src/Orbiter/MfdTransfer.cpp
+++ b/Src/Orbiter/MfdTransfer.cpp
@@ -163,7 +163,7 @@ void Instrument_Transfer::UpdateDraw (oapi::Sketchpad *skp)
 	if (src != vessel) {
 		int x, y;
 		Vector dp (mul (irot, vessel->GPos() - src->GPos()));
-		double r = _hypot (dp.x, dp.z);
+		double r = std::hypot (dp.x, dp.z);
 		x = (int)(IW*0.1/r*dp.x);
 		y = (int)(IW*0.1/r*dp.z);
 		MapScreen (ICNTX, ICNTY, scale, mul (irot, shpel->RVec()), &p0);

--- a/Src/Orbiter/VectorMap.cpp
+++ b/Src/Orbiter/VectorMap.cpp
@@ -1622,7 +1622,7 @@ double Groundtrack::VtxDst (const VPointGT &vp1, const VPointGT &vp2)
 	double dlat = fabs(vp1.lat - vp2.lat);
 	double dlng = fabs(vp1.lng - vp2.lng);
 	if (dlng > Pi) dlng = Pi2-dlng;
-	return _hypot (dlng, dlat);
+	return std::hypot (dlng, dlat);
 }
 
 void Groundtrack::Update ()

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -1254,7 +1254,7 @@ bool Vessel::GetLiftVector (Vector &L) const
 		L.Set (0, 0, 0);
 		return false;
 	} else {
-		double v0 = _hypot (sp.airvel_ship.y, sp.airvel_ship.z);
+		double v0 = std::hypot (sp.airvel_ship.y, sp.airvel_ship.z);
 		double scale = (v0 ? Lift/v0 : 0.0);
 		L.Set (0, sp.airvel_ship.z*scale, -sp.airvel_ship.y*scale);
 		return true;
@@ -4134,7 +4134,7 @@ void Vessel::UpdateAerodynamicForces_OLD ()
 	if (LiftCoeff && (Cl = LiftCoeff (aoa))) {
 		Lift = Cl * sp.dynp * cs.y;    // lift magnitude
 		Vector L (0, sp.airvel_ship.z, -sp.airvel_ship.y); // lift direction
-		double lnorm = _hypot (sp.airvel_ship.z, sp.airvel_ship.y);
+		double lnorm = std::hypot (sp.airvel_ship.z, sp.airvel_ship.y);
 		if (lnorm) {
 			L *= Lift / lnorm;
 			Flin_add += L;

--- a/Src/Orbiter/Vobject.cpp
+++ b/Src/Orbiter/Vobject.cpp
@@ -183,7 +183,7 @@ void VObject::RenderAsPixel (LPDIRECT3DDEVICE7 dev)
 		RECT r;
 		int x, y;
 		DWORD viewW = g_pOrbiter->ViewW(), viewH = g_pOrbiter->ViewH();
-		if (_hypot (homog.x, homog.y) < 1e-6) {
+		if (std::hypot (homog.x, homog.y) < 1e-6) {
 			x = viewW/2, y = viewH/2;
 		} else {
 			x = (int)(viewW*0.5*(1.0f+homog.x));
@@ -268,7 +268,7 @@ void VObject::RenderSpot (LPDIRECT3DDEVICE7 dev, const Vector *ofs, float size, 
 	}
 
 	Vector bdir(pos/dist);
-	double hz = _hypot (bdir.x, bdir.z);
+	double hz = std::hypot (bdir.x, bdir.z);
 	double phi = atan2 (bdir.z, bdir.x);
 	float sphi = (float)sin(phi), cphi = (float)cos(phi);
 	DWORD alphamode;

--- a/Src/Orbiter/Vstar.cpp
+++ b/Src/Orbiter/Vstar.cpp
@@ -70,7 +70,7 @@ void VStar::Update (bool moving, bool force)
 	VObject::Update (moving, force);
 
 	Vector bdir (cpos.unit());
-	double hz = _hypot (bdir.x, bdir.z);
+	double hz = std::hypot (bdir.x, bdir.z);
 	double phi = atan2 (bdir.z, bdir.x);
 	FLOAT sphi = (FLOAT)sin(phi), cphi = (FLOAT)cos(phi);
 	FLOAT tx = (FLOAT)cpos.x, ty = (FLOAT)cpos.y, tz = (FLOAT)cpos.z;

--- a/Src/Orbiter/hud.cpp
+++ b/Src/Orbiter/hud.cpp
@@ -419,7 +419,7 @@ void HUD::AddMesh_DirectionMarker (int &ivtx, int &iidx, const Vector &dir, bool
 	Vector d;
 	if (bVC) d.Set (tmul (g_focusobj->GRot(), dir));
 	else     d.Set (tmul (g_camera->GRot(), dir));
-	double len = _hypot (d.x, d.y);
+	double len = std::hypot (d.x, d.y);
 	if (!len) return;
 	double cosa = d.y/len, sina = -d.x/len;
 
@@ -971,11 +971,11 @@ void HUD::AddMesh_DockApproachGates (int &ivtx, int &iidx, const Body *tgt, cons
 			if (need_setup) {
 				rx = x[3]-x[0];
 				ry = y[3]-y[0];
-				double d  = _hypot(rx,ry);
+				double d  = std::hypot(rx,ry);
 				dx1 = rx*linew/d, dy1 = ry*linew/d;
 				rx = x[1]-x[0];
 				ry = y[1]-y[0];
-				d = _hypot(rx,ry);
+				d = std::hypot(rx,ry);
 				dx2 = rx*linew/d, dy2 = ry*linew/d;
 				need_setup = false;
 			}
@@ -1234,7 +1234,7 @@ oapi::IVECTOR2 *HUD::OffscreenDirMarker (const Vector &dir) const
 	} else {
 		d.Set (tmul (g_camera->GRot(), dir));
 	}
-	double len = _hypot (d.y, d.x);
+	double len = std::hypot (d.y, d.x);
 	double scale = spec.Markersize * 0.6;
 	double dx = d.x/len*scale;
 	double dy = d.y/len*scale;

--- a/Src/Plugin/ScnEditor/Editor.cpp
+++ b/Src/Plugin/ScnEditor/Editor.cpp
@@ -1942,7 +1942,7 @@ void EditorTab_Statevec::Refresh (OBJHANDLE hV)
 		if (crd) {
 			vel.data[1] -= 360.0/T;
 		} else { // map back to cartesian
-			double r   = _hypot (pos.x, pos.z);
+			double r   = std::hypot (pos.x, pos.z);
 			double phi = atan2 (pos.z, pos.x);
 			double v   = 2.0*PI*r/T;
 			vel.x     += v*sin(phi);
@@ -1989,7 +1989,7 @@ void EditorTab_Statevec::Apply ()
 			if (crd) {
 				vel.data[1] += 360.0/T;
 			} else { // map back to cartesian
-				double r   = _hypot (pos.x, pos.z);
+				double r   = std::hypot (pos.x, pos.z);
 				double phi = atan2 (pos.z, pos.x);
 				double v   = 2.0*PI*r/T;
 				vel.x     -= v*sin(phi);


### PR DESCRIPTION
This PR replaces calls to MSVC specific _hypot with standard std::hypot function