### PR TITLE
Use OAPI_KEY_* instead of DIK_*

### DIFF
--- a/Src/Orbiter/Launchpad.h
+++ b/Src/Orbiter/Launchpad.h
@@ -4,7 +4,6 @@
 #ifndef __LAUNCHPAD_H
 #define __LAUNCHPAD_H
 
-#include <dinput.h>
 #include <CommCtrl.h>
 #include "OrbiterAPI.h"
 #include "Config.h"

--- a/Src/Orbiter/Log.cpp
+++ b/Src/Orbiter/Log.cpp
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <dx7\ddraw.h>
 #include <dx7\dplay.h>
-#include <dinput.h>
 #include "Log.h"
 #include "Orbiter.h"
 

--- a/Src/Orbiter/Mfd.cpp
+++ b/Src/Orbiter/Mfd.cpp
@@ -3,7 +3,6 @@
 
 #define OAPI_IMPLEMENTATION
 
-#include <dinput.h>
 #include "Pane.h"
 #include "Orbiter.h"
 #include "Config.h"
@@ -199,28 +198,28 @@ void Instrument::GlobalExit (oapi::GraphicsClient *gc)
 void Instrument::RegisterBuiltinModes ()
 {
 	static MFDMODESPECEX def_mode[BUILTIN_MFD_MODES] = {
-		{"Orbit",        DIK_O, 0, 0},
-		{"Surface",      DIK_S, 0, 0},
-		{"Map",          DIK_M, 0, 0},
-		{"HSI",          DIK_H, 0, 0},
-		{"VOR/VTOL",     DIK_L, 0, 0},
-		{"Docking",      DIK_D, 0, 0},
-		{"Align Planes", DIK_A, 0, 0},
-		{"Sync Orbit",   DIK_Y, 0, 0},
-		{"Transfer",     DIK_X, 0, 0},
-		{"COM/NAV",      DIK_C, 0, 0}
+		{"Orbit",        OAPI_KEY_O, 0, 0},
+		{"Surface",      OAPI_KEY_S, 0, 0},
+		{"Map",          OAPI_KEY_M, 0, 0},
+		{"HSI",          OAPI_KEY_H, 0, 0},
+		{"VOR/VTOL",     OAPI_KEY_L, 0, 0},
+		{"Docking",      OAPI_KEY_D, 0, 0},
+		{"Align Planes", OAPI_KEY_A, 0, 0},
+		{"Sync Orbit",   OAPI_KEY_Y, 0, 0},
+		{"Transfer",     OAPI_KEY_X, 0, 0},
+		{"COM/NAV",      OAPI_KEY_C, 0, 0}
 	};
 	static MFDMODESPEC def_oldmode[BUILTIN_MFD_MODES] = { // obsolete
-		{"Orbit",        DIK_O, 0},
-		{"Surface",      DIK_S, 0},
-		{"Map",          DIK_M, 0},
-		{"HSI",          DIK_H, 0},
-		{"VOR/VTOL",     DIK_L, 0},
-		{"Docking",      DIK_D, 0},
-		{"Align Planes", DIK_A, 0},
-		{"Sync Orbit",   DIK_Y, 0},
-		{"Transfer",     DIK_X, 0},
-		{"COM/NAV",      DIK_C, 0}
+		{"Orbit",        OAPI_KEY_O, 0},
+		{"Surface",      OAPI_KEY_S, 0},
+		{"Map",          OAPI_KEY_M, 0},
+		{"HSI",          OAPI_KEY_H, 0},
+		{"VOR/VTOL",     OAPI_KEY_L, 0},
+		{"Docking",      OAPI_KEY_D, 0},
+		{"Align Planes", OAPI_KEY_A, 0},
+		{"Sync Orbit",   OAPI_KEY_Y, 0},
+		{"Transfer",     OAPI_KEY_X, 0},
+		{"COM/NAV",      OAPI_KEY_C, 0}
 	};
 
 	static int def_id[BUILTIN_MFD_MODES] = {
@@ -535,7 +534,7 @@ bool Instrument::ConsumeKeyBuffered (DWORD key)
 {
 	// part 1: global keys
 	switch (key) {
-	case DIK_F1:     // MFD mode selection
+	case OAPI_KEY_F1:     // MFD mode selection
 		if ((++modepage)*(nbtl+nbtr) < (int)(nGlobalModes+nVesselModes-nDisabledModes)) {
 			showmenu = false;
 			DisplayModes (modepage);
@@ -544,8 +543,8 @@ bool Instrument::ConsumeKeyBuffered (DWORD key)
 		}
 		pane->RepaintMFDButtons (id, this);
 		return true;
-	case DIK_F2: {   // next button page
-		if (modepage >= 0) return ConsumeKeyBuffered (DIK_F1); // page through mode pages
+	case OAPI_KEY_F2: {   // next button page
+		if (modepage >= 0) return ConsumeKeyBuffered (OAPI_KEY_F1); // page through mode pages
 		int nfunc = BtnMenu(0);
 		if (nfunc > 0 && nfunc > nbt) {
 			int npage = (nfunc+nbt-1)/nbt;
@@ -554,7 +553,7 @@ bool Instrument::ConsumeKeyBuffered (DWORD key)
 			if (showmenu) DrawMenu ();
 		}
 		} return true;
-	case DIK_GRAVE: // MFD menu
+	case OAPI_KEY_GRAVE: // MFD menu
 		if (!showmenu) {
 			showmenu = true;
 			if (modepage >= 0) {
@@ -564,7 +563,7 @@ bool Instrument::ConsumeKeyBuffered (DWORD key)
 		} else if (!pageonmenu) {
 			showmenu = false;
 		} else {
-			ConsumeKeyBuffered (DIK_F2);
+			ConsumeKeyBuffered(OAPI_KEY_F2);
 			if (!btnpage) showmenu = false;
 		}
 		if (showmenu) DrawMenu(); // draw the button menu

--- a/Src/Orbiter/MfdAlign.cpp
+++ b/Src/Orbiter/MfdAlign.cpp
@@ -7,7 +7,6 @@
 #include "Psys.h"
 #include "Log.h"
 #include "Select.h"
-#include <dinput.h>
 #include <iomanip>
 
 using namespace std;
@@ -487,19 +486,19 @@ bool Instrument_OPlaneAlign::GetTimingsFromSurface(double &Tan, double &Aan, dou
 bool Instrument_OPlaneAlign::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_A:  // auto reference
+	case OAPI_KEY_A:  // auto reference
 		SelectAutoRef ();
 		return true;
-	case DIK_E:  // custom elements
+	case OAPI_KEY_E:  // custom elements
 		g_input->Open ("Ecliptic inclination and longitude of asc. node [deg.]:", 0, 30, Instrument_OPlaneAlign::CallbackElements, (void*)this);
 		return true;
-	case DIK_R:  // select reference
+	case OAPI_KEY_R:  // select reference
 		OpenSelect_CelBody ("Align MFD: Reference", ClbkEnter_Ref);
 		return true;
-	case DIK_T:  // select target
+	case OAPI_KEY_T:  // select target
 		OpenSelect_Tgt ("Align MFD: Target", ClbkEnter_Tgt, elref, 0);
 		return true;
-	case DIK_M:  // mode selection
+	case OAPI_KEY_M:  // mode selection
 		CycleModes();
 		return true;
 	}
@@ -508,7 +507,7 @@ bool Instrument_OPlaneAlign::KeyBuffered (DWORD key)
 
 bool Instrument_OPlaneAlign::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[5] = { DIK_R, DIK_A, DIK_T, DIK_E, DIK_M };
+	static const DWORD btkey[5] = { OAPI_KEY_R, OAPI_KEY_A, OAPI_KEY_T, OAPI_KEY_E, OAPI_KEY_M };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 5) return KeyBuffered (btkey[bt]);
 	}

--- a/Src/Orbiter/MfdComms.cpp
+++ b/Src/Orbiter/MfdComms.cpp
@@ -4,7 +4,6 @@
 #include "MfdComms.h"
 #include "Nav.h"
 #include <stdio.h>
-#include <dinput.h>
 #include "Orbiter.h"
 
 using namespace std;
@@ -111,35 +110,35 @@ void Instrument_Comms::UpdateDraw (oapi::Sketchpad *skp)
 bool Instrument_Comms::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_COMMA: // select radio (up)
+	case OAPI_KEY_COMMA: // select radio (up)
 		scanning = 0;
 		if (sel) { sel--; Refresh(); }
 		return true;
-	case DIK_PERIOD:
+	case OAPI_KEY_PERIOD:
 		scanning = 0;
 		if (sel < nsel-1) { sel++; Refresh(); }
 		return true;
-	case DIK_MINUS:
+	case OAPI_KEY_MINUS:
 		scanning = 0;
 		SwitchFreq (sel, -20, false);
 		Refresh();
 		return true;
-	case DIK_EQUALS:
+	case OAPI_KEY_EQUALS:
 		scanning = 0;
 		SwitchFreq (sel, 20, false);
 		Refresh();
 		return true;
-	case DIK_LBRACKET:
+	case OAPI_KEY_LBRACKET:
 		scanning = 0;
 		SwitchFreq (sel, -1, true);
 		Refresh();
 		return true;
-	case DIK_RBRACKET:
+	case OAPI_KEY_RBRACKET:
 		scanning = 0;
 		SwitchFreq (sel, 1, true);
 		Refresh();
 		return true;
-	case DIK_Z:
+	case OAPI_KEY_Z:
 		if (sel < vessel->nnav) {
 			SwitchFreq (sel, -1, false);
 			scanning = -1;
@@ -147,7 +146,7 @@ bool Instrument_Comms::KeyBuffered (DWORD key)
 			Refresh();
 		}
 		return true;
-	case DIK_X:
+	case OAPI_KEY_X:
 		if (sel < vessel->nnav) {
 			SwitchFreq (sel, 1, false);
 			scanning = 1;
@@ -175,8 +174,8 @@ void Instrument_Comms::SwitchFreq (DWORD line, int step, bool minor)
 
 bool Instrument_Comms::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[8] = {DIK_COMMA, DIK_PERIOD, DIK_LBRACKET, DIK_MINUS,
-		DIK_RBRACKET, DIK_EQUALS, DIK_Z, DIK_X
+	static const DWORD btkey[8] = { OAPI_KEY_COMMA, OAPI_KEY_PERIOD, OAPI_KEY_LBRACKET, OAPI_KEY_MINUS,
+		OAPI_KEY_RBRACKET, OAPI_KEY_EQUALS, OAPI_KEY_Z, OAPI_KEY_X
 	};
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 8) return KeyBuffered (btkey[bt]);

--- a/Src/Orbiter/MfdDocking.cpp
+++ b/Src/Orbiter/MfdDocking.cpp
@@ -592,14 +592,14 @@ void Instrument_Docking::DrawArrow(int x0, int y0, int dir, oapi::Sketchpad *skp
 bool Instrument_Docking::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_D:  // docking port
+	case OAPI_KEY_D:  // docking port
 		SetReference (vessel, (refdock+1)%ndock);
 		Refresh();
 		return true;
-	case DIK_H:  // copy reference to HUD
+	case OAPI_KEY_H:  // copy reference to HUD
 		CopyToHUD ();
 		return true;
-	case DIK_N:  // NAV receiver select
+	case OAPI_KEY_N:  // NAV receiver select
 		if (smode == NAV) {
 			if (vessel->nnav) nv = (nv+1) % vessel->nnav;
 		} else {
@@ -607,15 +607,15 @@ bool Instrument_Docking::KeyBuffered (DWORD key)
 		}
 		Refresh();
 		return true;
-	case DIK_V: // visual mode
+	case OAPI_KEY_V: // visual mode
 		smode = VIS;
 		Refresh();
 		return true;
-	case DIK_S: // scale resolution
+	case OAPI_KEY_S: // scale resolution
 		scale = 1 - scale;
 		Refresh();
 		return true;
-	case DIK_T:  // select target - OBSOLETE
+	case OAPI_KEY_T:  // select target - OBSOLETE
 		g_select->Open ("Docking MFD: Target", ClbkSelection_Target, ClbkEnter_Target, (void*)this);
 		return true;
 	}
@@ -624,7 +624,7 @@ bool Instrument_Docking::KeyBuffered (DWORD key)
 
 bool Instrument_Docking::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[6] = { DIK_D, DIK_N, DIK_V, DIK_T, DIK_S, DIK_H };
+	static const DWORD btkey[6] = { OAPI_KEY_D, OAPI_KEY_N, OAPI_KEY_V, OAPI_KEY_T, OAPI_KEY_S, OAPI_KEY_H };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (ndock > 1) {
 			if (bt < 6) return KeyBuffered (btkey[bt]);

--- a/Src/Orbiter/MfdHsi.cpp
+++ b/Src/Orbiter/MfdHsi.cpp
@@ -8,7 +8,6 @@
 #include "Planet.h"
 #include "Config.h"
 #include <stdio.h>
-#include <dinput.h>
 
 using namespace std;
 
@@ -294,11 +293,11 @@ void Instrument_HSI::SetSize (const Spec &spec)
 bool Instrument_HSI::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_F:
+	case OAPI_KEY_F:
 		focus = 1-focus;
 		Refresh();
 		return true;
-	case DIK_N:
+	case OAPI_KEY_N:
 		if (vessel->nnav) hsi[focus].nv = (hsi[focus].nv+1) % vessel->nnav;
 		Refresh();
 		return true;
@@ -308,15 +307,15 @@ bool Instrument_HSI::KeyBuffered (DWORD key)
 
 bool Instrument_HSI::KeyImmediate (char *kstate)
 {
-	if (KEYDOWN (kstate, DIK_LBRACKET)) {
-		if (BufKey (DIK_LBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_LBRACKET)) {
+		if (BufKey (OAPI_KEY_LBRACKET, 0.05)) {
 			hsi[focus].obs = posangle (hsi[focus].obs-RAD);
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_RBRACKET)) {
-		if (BufKey (DIK_RBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_RBRACKET)) {
+		if (BufKey (OAPI_KEY_RBRACKET, 0.05)) {
 			hsi[focus].obs = posangle (hsi[focus].obs+RAD);
 			Refresh();
 		}
@@ -327,7 +326,7 @@ bool Instrument_HSI::KeyImmediate (char *kstate)
 
 bool Instrument_HSI::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[4] = { DIK_F, DIK_N, DIK_LBRACKET, DIK_RBRACKET };
+	static const DWORD btkey[4] = { OAPI_KEY_F, OAPI_KEY_N, OAPI_KEY_LBRACKET, OAPI_KEY_RBRACKET };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 2) return KeyBuffered (btkey[bt]);
 	} else if (event & PANEL_MOUSE_LBPRESSED) {

--- a/Src/Orbiter/MfdLanding.cpp
+++ b/Src/Orbiter/MfdLanding.cpp
@@ -7,7 +7,6 @@
 #include "Config.h"
 #include "Celbody.h"
 #include <stdio.h>
-#include <dinput.h>
 
 using namespace std;
 
@@ -61,7 +60,7 @@ HELPCONTEXT *Instrument_Landing::HelpTopic () const
 bool Instrument_Landing::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_N: // NAV receiver select
+	case OAPI_KEY_N: // NAV receiver select
 		if (vessel->nnav) nv = (nv+1) % vessel->nnav;
 		Refresh();
 		return true;
@@ -71,7 +70,7 @@ bool Instrument_Landing::KeyBuffered (DWORD key)
 
 bool Instrument_Landing::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[1] = { DIK_N };
+	static const DWORD btkey[1] = { OAPI_KEY_N };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 1) return KeyBuffered (btkey[bt]);
 	}

--- a/Src/Orbiter/MfdMap.cpp
+++ b/Src/Orbiter/MfdMap.cpp
@@ -7,7 +7,6 @@
 #include "Celbody.h"
 #include "Planet.h"
 #include "Base.h"
-#include <dinput.h>
 
 using namespace std;
 
@@ -120,49 +119,49 @@ bool Instrument_Map::KeyBuffered (DWORD key)
 	switch (disp_mode) {
 	case 0: // default display
 		switch (key) {
-		case DIK_R:  // select reference
+		case OAPI_KEY_R:  // select reference
 			OpenSelect_CelBody ("Map MFD: Reference", ClbkEnter_Map, 1);
 			return true;
-		case DIK_T:  // select target
+		case OAPI_KEY_T:  // select target
 			g_select->Open ("Map MFD: Target", ClbkSubmn_Target, ClbkEnter_Target, (void*)this);
 			return true;
-		case DIK_D:  // switch to display parameters page
+		case OAPI_KEY_D:  // switch to display parameters page
 			disp_mode = 1;
 			disp_sel = 0;
 			btnpage = 0;
 			RepaintButtons();
 			Refresh();
 			return true;
-		case DIK_K:
+		case OAPI_KEY_K:
 			ToggleTrack();
 			RepaintButtons();
 			return true;
-		case DIK_X:  ZoomOut(); return true;
-		case DIK_Z:  ZoomIn();  return true;
-		case DIK_LBRACKET:
-		case DIK_RBRACKET:
-		case DIK_MINUS:
-		case DIK_EQUALS:
+		case OAPI_KEY_X:  ZoomOut(); return true;
+		case OAPI_KEY_Z:  ZoomIn();  return true;
+		case OAPI_KEY_LBRACKET:
+		case OAPI_KEY_RBRACKET:
+		case OAPI_KEY_MINUS:
+		case OAPI_KEY_EQUALS:
 			scroll_t0 = scroll_tp = td.SysT0;
 			break;
 		}
 		break;
 	case 1: // display parameters
 		switch (key) {
-		case DIK_O:
+		case OAPI_KEY_O:
 			disp_mode = 0;
 			RepaintButtons();
 			Refresh();
 			return true;
-		case DIK_MINUS:
+		case OAPI_KEY_MINUS:
 			if (--disp_sel < 0) disp_sel = ndispprm-1;
 			Refresh();
 			return true;
-		case DIK_EQUALS:
+		case OAPI_KEY_EQUALS:
 			disp_sel = (disp_sel+1)%ndispprm;
 			Refresh();
 			return true;
-		case DIK_M:
+		case OAPI_KEY_M:
 			if (ToggleDispParam (disp_sel)) {
 				map->SetDisplayFlags (dispflag);
 				Refresh();
@@ -183,32 +182,32 @@ bool Instrument_Map::KeyImmediate (char *kstate)
 	double mag = min(dt*0.5, 8.0);
 	double step = (t-scroll_tp) * mag / zoom;
 
-	if (KEYDOWN (kstate, DIK_LBRACKET)) { // scroll left
-		if (!track && BufKey (DIK_LBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_LBRACKET)) { // scroll left
+		if (!track && BufKey (OAPI_KEY_LBRACKET, 0.05)) {
 			map->SetCenter (map->CntLng()-step, map->CntLat());
 			scroll_tp = t;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_RBRACKET)) { // scroll right
-		if (!track && BufKey (DIK_RBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_RBRACKET)) { // scroll right
+		if (!track && BufKey (OAPI_KEY_RBRACKET, 0.05)) {
 			map->SetCenter (map->CntLng()+step, map->CntLat());
 			scroll_tp = t;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_MINUS)) { // scroll down
-		if (!track && BufKey (DIK_MINUS, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_MINUS)) { // scroll down
+		if (!track && BufKey (OAPI_KEY_MINUS, 0.05)) {
 			map->SetCenter (map->CntLng(), min (Pi, map->CntLat()+step));
 			scroll_tp = t;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_EQUALS)) { // scroll up
-		if (!track && BufKey (DIK_EQUALS, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_EQUALS)) { // scroll up
+		if (!track && BufKey (OAPI_KEY_EQUALS, 0.05)) {
 			map->SetCenter (map->CntLng(), max (-Pi, map->CntLat()-step));
 			scroll_tp = t;
 			Refresh();
@@ -224,7 +223,7 @@ bool Instrument_Map::ProcessButton (int bt, int event)
 {
 	switch (disp_mode) {
 	case 0: {
-		static const DWORD btkey[10] = { DIK_R, DIK_T, DIK_X, DIK_Z, DIK_K, DIK_D, DIK_MINUS, DIK_EQUALS, DIK_LBRACKET, DIK_RBRACKET };
+		static const DWORD btkey[10] = { OAPI_KEY_R, OAPI_KEY_T, OAPI_KEY_X, OAPI_KEY_Z, OAPI_KEY_K, OAPI_KEY_D, OAPI_KEY_MINUS, OAPI_KEY_EQUALS, OAPI_KEY_LBRACKET, OAPI_KEY_RBRACKET };
 		if (event & PANEL_MOUSE_LBDOWN) {
 			if (bt < (track ? 6:10)) return KeyBuffered (btkey[bt]);
 		}
@@ -233,7 +232,7 @@ bool Instrument_Map::ProcessButton (int bt, int event)
 		}
 		} break;
 	case 1: {
-		static const DWORD btkey[4] = { DIK_MINUS, DIK_EQUALS, DIK_M, DIK_O };
+		static const DWORD btkey[4] = { OAPI_KEY_MINUS, OAPI_KEY_EQUALS, OAPI_KEY_M, OAPI_KEY_O };
 		if (event & PANEL_MOUSE_LBDOWN) {
 			if (bt < 4) return KeyBuffered (btkey[bt]);
 		}

--- a/Src/Orbiter/MfdMap_old.cpp
+++ b/Src/Orbiter/MfdMap_old.cpp
@@ -7,7 +7,6 @@
 #include "Celbody.h"
 #include "Planet.h"
 #include "Base.h"
-#include <dinput.h>
 
 using namespace std;
 
@@ -102,17 +101,17 @@ HELPCONTEXT *Instrument_MapOld::HelpTopic () const
 bool Instrument_MapOld::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_K:  // track mode on/off
+	case OAPI_KEY_K:  // track mode on/off
 		ToggleTrack ();
 		Refresh();
 		return true;
-	case DIK_R:  // select reference
+	case OAPI_KEY_R:  // select reference
 		OpenSelect_CelBody ("Map MFD: Reference", ClbkEnter_Map, 1);
 		return true;
-	case DIK_T:  // select target
+	case OAPI_KEY_T:  // select target
 		g_select->Open ("Map MFD: Target", ClbkSubmn_Target, ClbkEnter_Target, (void*)this);
 		return true;
-	case DIK_Z:  // zoom in/out
+	case OAPI_KEY_Z:  // zoom in/out
 		SetZoom (!zoom);
 		Refresh();
 		return true;
@@ -122,29 +121,29 @@ bool Instrument_MapOld::KeyBuffered (DWORD key)
 
 bool Instrument_MapOld::KeyImmediate (char *kstate)
 {
-	if (KEYDOWN (kstate, DIK_LBRACKET)) { // scroll left
-		if (!track && BufKey (DIK_LBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_LBRACKET)) { // scroll left
+		if (!track && BufKey (OAPI_KEY_LBRACKET, 0.05)) {
 			if ((mapx -= 1) < 0) mapx += mapw;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_RBRACKET)) { // scroll left
-		if (!track && BufKey (DIK_RBRACKET, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_RBRACKET)) { // scroll left
+		if (!track && BufKey (OAPI_KEY_RBRACKET, 0.05)) {
 			if ((mapx += 1) > mapw-IW) mapx -= mapw;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_MINUS)) { // scroll down
-		if (!track && BufKey (DIK_MINUS, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_MINUS)) { // scroll down
+		if (!track && BufKey (OAPI_KEY_MINUS, 0.05)) {
 			if ((mapy -= 1) < 0) mapy = 0;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_EQUALS)) { // scroll down
-		if (!track && BufKey (DIK_EQUALS, 0.05)) {
+	if (KEYDOWN (kstate, OAPI_KEY_EQUALS)) { // scroll down
+		if (!track && BufKey (OAPI_KEY_EQUALS, 0.05)) {
 			if ((mapy += 1) > maph-IW/2) mapy = maph-IW/2;
 			Refresh();
 		}
@@ -155,7 +154,7 @@ bool Instrument_MapOld::KeyImmediate (char *kstate)
 
 bool Instrument_MapOld::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[8] = { DIK_R, DIK_T, DIK_K, DIK_Z, DIK_LBRACKET, DIK_RBRACKET, DIK_MINUS, DIK_EQUALS };
+	static const DWORD btkey[8] = { OAPI_KEY_R, OAPI_KEY_T, OAPI_KEY_K, OAPI_KEY_Z, OAPI_KEY_LBRACKET, OAPI_KEY_RBRACKET, OAPI_KEY_MINUS, OAPI_KEY_EQUALS };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 4) return KeyBuffered (btkey[bt]);
 	} else if (event & PANEL_MOUSE_LBPRESSED) {

--- a/Src/Orbiter/MfdOrbit.cpp
+++ b/Src/Orbiter/MfdOrbit.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Martin Schweiger
 // Licensed under the MIT License
 
-#include <dinput.h>
 #include "MfdOrbit.h"
 #include "Pane.h"
 #include "Celbody.h"
@@ -95,36 +94,36 @@ HELPCONTEXT *Instrument_Orbit::HelpTopic () const
 bool Instrument_Orbit::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_A:  // auto reference
+	case OAPI_KEY_A:  // auto reference
 		SelectAutoRef ();
 		return true;
-	case DIK_D:  // toggle distance display mode
+	case OAPI_KEY_D:  // toggle distance display mode
 		dstmode = (dstmode == DIST_RAD ? DIST_ALT : DIST_RAD);
 		Refresh();
 		return true;
-	case DIK_F:  // reference frame
+	case OAPI_KEY_F:  // reference frame
 		frmmode = (frmmode == FRM_ECL ? FRM_EQU : FRM_ECL);
 		Refresh();
 		return true;
-	case DIK_H:  // copy reference to HUD
+	case OAPI_KEY_H:  // copy reference to HUD
 		CopyToHUD ();
 		return true;
-	case DIK_M:  // display mode
+	case OAPI_KEY_M:  // display mode
 		dispmode = (DisplayMode)((((int)dispmode)+1) % 3);
 		Refresh();
 		return true;
-	case DIK_N:  // deselect target
+	case OAPI_KEY_N:  // deselect target
 		UnselectTarget ();
 		return true;
-	case DIK_P:  // projection plane
+	case OAPI_KEY_P:  // projection plane
 		projmode = (ProjectionMode)((((int)projmode)+1) % 3);
 		if (projmode == PRJ_TGT && !tgt) projmode = PRJ_FRM;
 		Refresh();
 		return true;
-	case DIK_R:  // select reference
+	case OAPI_KEY_R:  // select reference
 		OpenSelect_CelBody ("Orbit MFD: Reference", ClbkEnter_Ref);
 		return true;
-	case DIK_T:  // select target
+	case OAPI_KEY_T:  // select target
 		OpenSelect_Tgt ("Orbit MFD: Target", ClbkEnter_Tgt, elref, 0);
 		return true;
 	}
@@ -133,7 +132,7 @@ bool Instrument_Orbit::KeyBuffered (DWORD key)
 
 bool Instrument_Orbit::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[9] = { DIK_R, DIK_A, DIK_T, DIK_N, DIK_M, DIK_F, DIK_P, DIK_D, DIK_H };
+	static const DWORD btkey[9] = { OAPI_KEY_R, OAPI_KEY_A, OAPI_KEY_T, OAPI_KEY_N, OAPI_KEY_M, OAPI_KEY_F, OAPI_KEY_P, OAPI_KEY_D, OAPI_KEY_H };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 9) return KeyBuffered (btkey[bt]);
 	}

--- a/Src/Orbiter/MfdSurface.cpp
+++ b/Src/Orbiter/MfdSurface.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Martin Schweiger
 // Licensed under the MIT License
 
-#include <dinput.h>
 #include "MfdSurface.h"
 #include "Orbiter.h"
 #include "Pane.h"
@@ -187,22 +186,22 @@ HELPCONTEXT *Instrument_Surface::HelpTopic () const
 bool Instrument_Surface::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_G: // ground-relative speed (GRS)
+	case OAPI_KEY_G: // ground-relative speed (GRS)
 		spdmode = 1;
 		Refresh();
 		return true;
-	case DIK_H: // copy data to HUD
+	case OAPI_KEY_H: // copy data to HUD
 		CopyToHUD ();
 		return true;
-	case DIK_I: // indicated airspeed (IAS)
+	case OAPI_KEY_I: // indicated airspeed (IAS)
 		spdmode = 3;
 		Refresh();
 		return true;
-	case DIK_O: // orbital speed (OS)
+	case OAPI_KEY_O: // orbital speed (OS)
 		spdmode = 4;
 		Refresh();
 		return true;
-	case DIK_T: // true airspeed (TAS)
+	case OAPI_KEY_T: // true airspeed (TAS)
 		spdmode = 2;
 		Refresh();
 		return true;
@@ -212,7 +211,7 @@ bool Instrument_Surface::KeyBuffered (DWORD key)
 
 bool Instrument_Surface::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[5] = { DIK_I, DIK_T, DIK_G, DIK_O, DIK_H };
+	static const DWORD btkey[5] = { OAPI_KEY_I, OAPI_KEY_T, OAPI_KEY_G, OAPI_KEY_O, OAPI_KEY_H };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 5) return KeyBuffered (btkey[bt]);
 	}

--- a/Src/Orbiter/MfdSync.cpp
+++ b/Src/Orbiter/MfdSync.cpp
@@ -7,7 +7,6 @@
 #include "Psys.h"
 #include "Select.h"
 #include <stdio.h>
-#include <dinput.h>
 
 using namespace std;
 
@@ -251,16 +250,16 @@ void Instrument_OSync::UpdateDraw (oapi::Sketchpad *skp)
 
 bool Instrument_OSync::KeyImmediate (char *kstate)
 {
-	if (KEYDOWN (kstate, DIK_COMMA)) { // rotate ref axis
-		if (BufKey (DIK_COMMA, 0.1) && mode == MODE_MANUAL) {
+	if (KEYDOWN (kstate, OAPI_KEY_COMMA)) { // rotate ref axis
+		if (BufKey (OAPI_KEY_COMMA, 0.1) && mode == MODE_MANUAL) {
 			man_rlng = posangle (man_rlng-RAD);
 			man_sinr = sin(man_rlng), man_cosr = cos(man_rlng);
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_PERIOD)) { // rotate ref axis
-		if (BufKey (DIK_PERIOD, 0.1) && mode == MODE_MANUAL) {
+	if (KEYDOWN (kstate, OAPI_KEY_PERIOD)) { // rotate ref axis
+		if (BufKey (OAPI_KEY_PERIOD, 0.1) && mode == MODE_MANUAL) {
 			man_rlng = posangle (man_rlng+RAD);
 			man_sinr = sin(man_rlng), man_cosr = cos(man_rlng);
 			Refresh();
@@ -273,14 +272,14 @@ bool Instrument_OSync::KeyImmediate (char *kstate)
 bool Instrument_OSync::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_M:  // switch mode
+	case OAPI_KEY_M:  // switch mode
 		mode = (Mode)(((int)mode+1)%7);
 		Refresh();
 		return true;
-	case DIK_N:  // number of transit times
+	case OAPI_KEY_N:  // number of transit times
 		g_input->Open ("Transit list length:", 0, 20, Instrument_OSync::CallbackNorbit, (void*)this);
 		return true;
-	case DIK_T:  // select target
+	case OAPI_KEY_T:  // select target
 		OpenSelect_Tgt ("Sync MFD: Target", ClbkEnter_Tgt, vessel->ElRef(), 2);
 		return true;
 	}
@@ -289,7 +288,7 @@ bool Instrument_OSync::KeyBuffered (DWORD key)
 
 bool Instrument_OSync::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[5] = { DIK_T, DIK_M, DIK_N, DIK_COMMA, DIK_PERIOD };
+	static const DWORD btkey[5] = { OAPI_KEY_T, OAPI_KEY_M, OAPI_KEY_N, OAPI_KEY_COMMA, OAPI_KEY_PERIOD };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 3) return KeyBuffered (btkey[bt]);
 	} else if (event & PANEL_MOUSE_LBPRESSED) {

--- a/Src/Orbiter/MfdTransfer.cpp
+++ b/Src/Orbiter/MfdTransfer.cpp
@@ -8,7 +8,6 @@
 #include "Log.h"
 #include "Select.h"
 #include "Orbiter.h"
-#include <dinput.h>
 
 using namespace std;
 
@@ -420,40 +419,40 @@ bool Instrument_Transfer::InitNumTrajectory (const Elements *el)
 bool Instrument_Transfer::KeyBuffered (DWORD key)
 {
 	switch (key) {
-	case DIK_F:  // decrease step scale for numerical trajectory
+	case OAPI_KEY_F:  // decrease step scale for numerical trajectory
 		step_scale *= 0.5;
 		return true;
-	case DIK_G:  // increase step scale for numerical trajectory
+	case OAPI_KEY_G:  // increase step scale for numerical trajectory
 		step_scale *= 2.0;
 		return true;
-	case DIK_M:  // toggle numerical trajectory
+	case OAPI_KEY_M:  // toggle numerical trajectory
 		enable_num = !enable_num;
 		if (enable_num) InitNumTrajectory (enable_hyp ? shpel2 : shpel);
 		Refresh();
 		return true;
-	case DIK_N:  // deselect target
+	case OAPI_KEY_N:  // deselect target
 		tgt = 0;
 		Refresh();
 		return true;
-	case DIK_R:  // select reference
+	case OAPI_KEY_R:  // select reference
 		OpenSelect_CelBody ("Transfer MFD: Reference", ClbkEnter_Ref);
 		return true;
-	case DIK_S:  // select source
+	case OAPI_KEY_S:  // select source
 		OpenSelect_Tgt ("Transfer MFD: Source", ClbkEnter_Src, elref, 0);
 		//g_input->Open ("Enter source orbit body:", 0, 20, Instrument_Transfer::ClbkName_Src, (void*)this);
 		return true;
-	case DIK_T:  // select target
+	case OAPI_KEY_T:  // select target
 		OpenSelect_Tgt ("Transfer MFD: Target", ClbkEnter_Tgt, elref, 0);
 		return true;
-	case DIK_U:  // update numerical trajectory
+	case OAPI_KEY_U:  // update numerical trajectory
 		if (enable_num) InitNumTrajectory (enable_hyp ? shpel2 : shpel);
 		Refresh();
 		return true;
-	case DIK_X:  // toggle HTO orbit
+	case OAPI_KEY_X:  // toggle HTO orbit
 		enable_hyp = !enable_hyp;
 		Refresh();
 		return true;
-	case DIK_Z:  // change number of trajectory steps
+	case OAPI_KEY_Z:  // change number of trajectory steps
 		g_input->Open ("Enter # time steps:", 0, 20, Instrument_Transfer::ClbkNstep, (void*)this);
 		return true;
 	}
@@ -462,24 +461,24 @@ bool Instrument_Transfer::KeyBuffered (DWORD key)
 
 bool Instrument_Transfer::KeyImmediate (char *kstate)
 {
-	if (KEYDOWN (kstate, DIK_COMMA)) {
-		if (BufKey (DIK_COMMA, 0.1)) {
+	if (KEYDOWN (kstate, OAPI_KEY_COMMA)) {
+		if (BufKey (OAPI_KEY_COMMA, 0.1)) {
 			l_eject = posangle (l_eject-RAD);
 			dv_manip = true;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_PERIOD)) {
-		if (BufKey (DIK_PERIOD, 0.1)) {
+	if (KEYDOWN (kstate, OAPI_KEY_PERIOD)) {
+		if (BufKey (OAPI_KEY_PERIOD, 0.1)) {
 			l_eject = posangle (l_eject+RAD);
 			dv_manip = true;
 			Refresh();
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_MINUS)) {
-		if (BufKey (DIK_MINUS, 0.1)) {
+	if (KEYDOWN (kstate, OAPI_KEY_MINUS)) {
+		if (BufKey (OAPI_KEY_MINUS, 0.1)) {
 			double da = 1.0;
 			if (td.SysT0-tbpress < 0.2)
 				da = (td.SysT0-tbdown < 1.0 ? 1.0:10.0);
@@ -492,8 +491,8 @@ bool Instrument_Transfer::KeyImmediate (char *kstate)
 		}
 		return true;
 	}
-	if (KEYDOWN (kstate, DIK_EQUALS)) {
-		if (BufKey (DIK_EQUALS, 0.1)) {
+	if (KEYDOWN (kstate, OAPI_KEY_EQUALS)) {
+		if (BufKey (OAPI_KEY_EQUALS, 0.1)) {
 			double da = 1.0;
 			if (td.SysT0-tbpress < 0.2)
 				da = (td.SysT0-tbdown < 1.0 ? 1.0:10.0);
@@ -511,8 +510,8 @@ bool Instrument_Transfer::KeyImmediate (char *kstate)
 
 bool Instrument_Transfer::ProcessButton (int bt, int event)
 {
-	static const DWORD btkey[14] = { DIK_R, DIK_S, DIK_T, DIK_N, DIK_X, DIK_M, DIK_U, DIK_Z,
-		DIK_COMMA, DIK_PERIOD, DIK_MINUS, DIK_EQUALS, DIK_F, DIK_G };
+	static const DWORD btkey[14] = { OAPI_KEY_R, OAPI_KEY_S, OAPI_KEY_T, OAPI_KEY_N, OAPI_KEY_X, OAPI_KEY_M, OAPI_KEY_U, OAPI_KEY_Z,
+		OAPI_KEY_COMMA, OAPI_KEY_PERIOD, OAPI_KEY_MINUS, OAPI_KEY_EQUALS, OAPI_KEY_F, OAPI_KEY_G };
 	if (event & PANEL_MOUSE_LBDOWN) {
 		if (bt < 8 || bt >= 12) return KeyBuffered (btkey[bt]);
 	} else if (event & PANEL_MOUSE_LBPRESSED) {

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2517,7 +2517,7 @@ void Orbiter::KbdInputBuffered_OnRunning (char *kstate, DIDEVICEOBJECTDATA *dod,
 			continue;
 		if (!bdown) // only process key down events
 			continue;
-		if (key == DIK_LSHIFT || key == DIK_RSHIFT) continue;    // we don't process modifier keys
+		if (key == OAPI_KEY_LSHIFT || key == OAPI_KEY_RSHIFT) continue;    // we don't process modifier keys
 
 		// simulation speed control
 		if      (keymap.IsLogicalKey (key, kstate, OAPI_LKEY_IncSimSpeed)) IncWarpFactor ();
@@ -2526,7 +2526,7 @@ void Orbiter::KbdInputBuffered_OnRunning (char *kstate, DIDEVICEOBJECTDATA *dod,
 		if (KEYMOD_CONTROL (kstate)) {    // CTRL-Key combinations
 
 			//switch (key) {
-			//case DIK_F3:    // switch focus to previous vessel
+			//case OAPI_KEY_F3:    // switch focus to previous vessel
 			//	if (g_pfocusobj) SetFocusObject (g_pfocusobj);
 			//	break;
 			//}

--- a/Src/Orbiter/Pane.cpp
+++ b/Src/Orbiter/Pane.cpp
@@ -140,7 +140,7 @@ void Pane::DelVessel (const Vessel *vessel)
 
 bool Pane::MFDConsumeKeyBuffered (int id, DWORD key)
 {
-	if (key == DIK_ESCAPE) {
+	if (key == OAPI_KEY_ESCAPE) {
 		ToggleMFD_on (id);
 		return true;
 	} else if (mfd[id].instr) {

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -3669,7 +3669,7 @@ int Vessel::ConsumeBufferedKey (DWORD key, bool down, char *kstate)
 	if (KEYMOD_CONTROL (kstate)) {  // CTRL-Key combinations
 
 		switch (key) {
-		case DIK_C:        // landing/takeoff clearance request
+		case OAPI_KEY_C:        // landing/takeoff clearance request
 			IssueClearanceRequest ();
 			return 1;
 		}
@@ -3678,7 +3678,7 @@ int Vessel::ConsumeBufferedKey (DWORD key, bool down, char *kstate)
 	} else if (KEYMOD_ALT (kstate)) {   // ALT-Key combinations
 
 		switch (key) {
-		case DIK_DIVIDE:   // connect/disconnect user input to aerodynamic control surfaces
+		case OAPI_KEY_DIVIDE:   // connect/disconnect user input to aerodynamic control surfaces
 			ToggleADCtrlMode ();
 			return 1;
 		}


### PR DESCRIPTION
Key consumers should consume OAPI_KEY codes and not DirectInput keycodes.
This limits the coupling between the internal MFDs and DirectInput