### PR TITLE
Replace non standard _itoa

### DIFF
--- a/Src/Orbiter/D3d7enum.cpp
+++ b/Src/Orbiter/D3d7enum.cpp
@@ -114,10 +114,9 @@ static HRESULT WINAPI DeviceEnumCallback (TCHAR* strDesc, TCHAR* strName,
         for (i=0; i < 20; i++) {  // 20-loop-limit is for a sanity check in case of a bug
             strcpy(tempBuf, cbuf);  // working copy
             if (dupeIDCount > 1) {
-                char idStr[4];
                 // this is the newest device name
-                strcat(cbuf, " #");
-                strcat(cbuf, _itoa(dupeIDCount, idStr, 10));
+                snprintf(cbuf, sizeof(cbuf), "%s #%d", tempBuf, dupeIDCount);
+                cbuf[sizeof(cbuf)] = '\0';
             }
             // check whether we have a duplicate of this name
             UINT j;  // we need this outside the for loop

--- a/Src/Orbiter/DlgCapture.cpp
+++ b/Src/Orbiter/DlgCapture.cpp
@@ -54,8 +54,10 @@ BOOL DlgCapture::OnInitDialog (HWND hDlg, WPARAM wParam, LPARAM lParam)
 	EnableWindow (GetDlgItem (hDlg, IDC_COMBO2), prm.ImageFormat == 2 ? TRUE:FALSE);
 
 	SendDlgItemMessage (hDlg, IDC_COMBO2, CB_RESETCONTENT, 0, 0);
-	for (i = 1; i <= 10; i++)
-	SendDlgItemMessage (hDlg, IDC_COMBO2, CB_INSERTSTRING, -1, (LPARAM)itoa(i, cbuf, 10));
+	for (i = 1; i <= 10; i++) {
+		sprintf(cbuf, "%d", i);
+		SendDlgItemMessage(hDlg, IDC_COMBO2, CB_INSERTSTRING, -1, (LPARAM)cbuf);
+	}
 	SendDlgItemMessage (hDlg, IDC_COMBO2, CB_SETCURSEL, prm.ImageQuality-1, 0);
 
 	return TRUE;

--- a/Src/Orbiter/DlgCapture.cpp
+++ b/Src/Orbiter/DlgCapture.cpp
@@ -12,6 +12,7 @@
 #include "Orbiter.h"
 #include "Resource.h"
 #include "Resource2.h"
+#include <string>
 
 extern Orbiter *g_pOrbiter;
 extern HELPCONTEXT DefHelpContext;
@@ -55,8 +56,7 @@ BOOL DlgCapture::OnInitDialog (HWND hDlg, WPARAM wParam, LPARAM lParam)
 
 	SendDlgItemMessage (hDlg, IDC_COMBO2, CB_RESETCONTENT, 0, 0);
 	for (i = 1; i <= 10; i++) {
-		sprintf(cbuf, "%d", i);
-		SendDlgItemMessage(hDlg, IDC_COMBO2, CB_INSERTSTRING, -1, (LPARAM)cbuf);
+		SendDlgItemMessage(hDlg, IDC_COMBO2, CB_INSERTSTRING, -1, (LPARAM)std::to_string(i).data());
 	}
 	SendDlgItemMessage (hDlg, IDC_COMBO2, CB_SETCURSEL, prm.ImageQuality-1, 0);
 

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -20,6 +20,7 @@
 #include <io.h>
 #include <direct.h>
 #include <errno.h>
+#include <string>
 
 using namespace std;
 
@@ -315,9 +316,7 @@ void Vessel::FRecorder_SaveEvent (const char *event_type, const char *event)
 
 void Vessel::FRecorder_SaveEventInt (const char *event_type, int event)
 {
-	static char cbuf[24];
-	sprintf(cbuf, "%d", event);
-	FRecorder_SaveEvent (event_type, cbuf);
+	FRecorder_SaveEvent(event_type, std::to_string(event).data());
 }
 
 void Vessel::FRecorder_SaveEventFloat (const char *event_type, double event)

--- a/Src/Orbiter/FlightRecorder.cpp
+++ b/Src/Orbiter/FlightRecorder.cpp
@@ -316,7 +316,8 @@ void Vessel::FRecorder_SaveEvent (const char *event_type, const char *event)
 void Vessel::FRecorder_SaveEventInt (const char *event_type, int event)
 {
 	static char cbuf[24];
-	FRecorder_SaveEvent (event_type, _itoa (event, cbuf, 10));
+	sprintf(cbuf, "%d", event);
+	FRecorder_SaveEvent (event_type, cbuf);
 }
 
 void Vessel::FRecorder_SaveEventFloat (const char *event_type, double event)

--- a/Src/Orbiter/Mfd.cpp
+++ b/Src/Orbiter/Mfd.cpp
@@ -1148,7 +1148,7 @@ bool Instrument::FindScnHeader (ifstream &ifs) const
 	switch (id) {
 	case 0: strcpy (header+10, "Left"); break;
 	case 1: strcpy (header+10, "Right"); break;
-	default: _itoa (id+1, header+10, 10); break;
+	default: sprintf (header+10, "%lld", id + 1); break;
 	}
 	return FindLine (ifs, header);
 }

--- a/Src/Orbiter/MfdLanding.cpp
+++ b/Src/Orbiter/MfdLanding.cpp
@@ -221,7 +221,7 @@ void Instrument_Landing::UpdateDraw (oapi::Sketchpad *skp)
 	for (i = 0; i <= 4; i++) {
 		dy = (barh*i)/4;
 		skp->Line (dx, bar0-dy, dx+barw+2, bar0-dy);
-		_itoa (i-1, cbuf, 10);
+		sprintf(cbuf, "%d", i-1);
 		skp->Text (dx+barw+3, bar0-dy-ch/2, cbuf, strlen(cbuf));
 	}
 

--- a/Src/Orbiter/OGraphics.cpp
+++ b/Src/Orbiter/OGraphics.cpp
@@ -59,8 +59,10 @@ void VideoTab::Init ()
 	}
 	SendDlgItemMessage (hVid, IDC_VID_DEVICE, CB_SELECTSTRING, -1, (LPARAM)dev->strDesc);
 	w = cfg->CfgDevPrm.WinW, h = cfg->CfgDevPrm.WinH;
-	SetWindowText (GetDlgItem (hVid, IDC_VID_WIDTH),  _itoa (w, cbuf, 10));
-	SetWindowText (GetDlgItem (hVid, IDC_VID_HEIGHT), _itoa (h, cbuf, 10));
+	sprintf(cbuf, "%d", w);
+	SetWindowText (GetDlgItem (hVid, IDC_VID_WIDTH),  cbuf);
+	sprintf(cbuf, "%d", h);
+	SetWindowText (GetDlgItem (hVid, IDC_VID_HEIGHT), cbuf);
 	if (w == (4*h)/3 || h == (3*w)/4)
 		aspect_idx = 1;
 	else if (w == (16*h)/10 || h == (10*w)/16)
@@ -150,8 +152,9 @@ void VideoTab::ModeChanged (D3D7Enum_DeviceInfo *dev, DWORD idx)
 	// if a bpp change was required, notify the bpp control
 	if (bpp != usebpp) {
 		char cbuf[20];
+		sprintf(cbuf, "%d", usebpp);
 		SendDlgItemMessage (hVid, IDC_VID_BPP, CB_SELECTSTRING, -1,
-			(LPARAM)_itoa (usebpp, cbuf, 10));
+			(LPARAM)cbuf);
 	}
 }
 
@@ -181,8 +184,9 @@ void VideoTab::BPPChanged (D3D7Enum_DeviceInfo *dev, DWORD idx)
 	// at this bit depth (shouldn't happen)
 	bpp = dev->pddsdModes[dev->dwCurrentMode].ddpfPixelFormat.dwRGBBitCount;
 	char cbuf[20];
+	sprintf(cbuf, "%d", bpp);
 	SendDlgItemMessage (hVid, IDC_VID_BPP, CB_SELECTSTRING, -1,
-		(LPARAM)_itoa (bpp, cbuf, 10));
+		(LPARAM)cbuf);
 
 	// If we get here, then we've screwed up big time
 	// and leave quietly
@@ -245,7 +249,8 @@ void VideoTab::WidthChanged ()
 		if (res != 1) h = 0;
 		if (w != (wfac*h)/hfac) {
 			h = (hfac*w)/wfac;
-			SetWindowText (GetDlgItem (hVid, IDC_VID_HEIGHT), _itoa (h, cbuf, 10));
+			sprintf(cbuf, "%d", h);
+			SetWindowText (GetDlgItem (hVid, IDC_VID_HEIGHT), cbuf);
 		}
 	}
 }
@@ -265,7 +270,8 @@ void VideoTab::HeightChanged ()
 		if (res != 1) w = 0;
 		if (h != (hfac*w)/wfac) {
 			w = (wfac*h)/hfac;
-			SetWindowText (GetDlgItem (hVid, IDC_VID_WIDTH), _itoa (w, cbuf, 10));
+			sprintf(cbuf, "%d", w);
+			SetWindowText (GetDlgItem (hVid, IDC_VID_WIDTH), cbuf);
 		}
 	}
 }
@@ -536,13 +542,15 @@ void OrbiterGraphics::clbkRefreshVideoData ()
 	res = sscanf (cbuf, "%d", &vd->winw);
 	if (res != 1 || vd->winw < 400) {
 		vd->winw = 400;
-		SetWindowText (GetDlgItem (hVT, IDC_VID_WIDTH), _itoa(vd->winw, cbuf, 10));
+		sprintf(cbuf, "%d", vd->winw);
+		SetWindowText (GetDlgItem (hVT, IDC_VID_WIDTH), cbuf);
 	}
 	GetWindowText (GetDlgItem (hVT, IDC_VID_HEIGHT), cbuf, 127); 
 	res = sscanf (cbuf, "%d", &vd->winh);
 	if (res != 1 || vd->winh < 300) {
 		vd->winh = 300;
-		SetWindowText (GetDlgItem (hVT, IDC_VID_HEIGHT), _itoa(vd->winh, cbuf, 10));
+		sprintf(cbuf, "%d", vd->winh);
+		SetWindowText (GetDlgItem (hVT, IDC_VID_HEIGHT), cbuf);
 	}
 }
 

--- a/Src/Orbiter/OptionsPages.cpp
+++ b/Src/Orbiter/OptionsPages.cpp
@@ -456,7 +456,8 @@ void OptionsPage_Visual::UpdateControls(HWND hPage)
 	SendDlgItemMessage(hPage, IDC_OPT_VIS_ELEV, BM_SETCHECK,
 		Cfg()->CfgVisualPrm.ElevMode ? BST_CHECKED : BST_UNCHECKED, 0);
 	SendDlgItemMessage(hPage, IDC_OPT_VIS_ELEVMODE, CB_SETCURSEL, Cfg()->CfgVisualPrm.ElevMode < 2 ? 0 : 1, 0);
-	SetWindowText(GetDlgItem(hPage, IDC_OPT_VIS_MAXLEVEL), _itoa(Cfg()->CfgVisualPrm.PlanetMaxLevel, cbuf, 10));
+	sprintf(cbuf, "%d", Cfg()->CfgVisualPrm.PlanetMaxLevel);
+	SetWindowText(GetDlgItem(hPage, IDC_OPT_VIS_MAXLEVEL), cbuf);
 	SendDlgItemMessage(hPage, IDC_OPT_VIS_VSHADOW, BM_SETCHECK,
 		Cfg()->CfgVisualPrm.bVesselShadows ? BST_CHECKED : BST_UNCHECKED, 0);
 	SendDlgItemMessage(hPage, IDC_OPT_VIS_REENTRY, BM_SETCHECK,
@@ -469,7 +470,8 @@ void OptionsPage_Visual::UpdateControls(HWND hPage)
 		Cfg()->CfgVisualPrm.bSpecular ? BST_CHECKED : BST_UNCHECKED, 0);
 	SendDlgItemMessage(hPage, IDC_OPT_VIS_LOCALLIGHT, BM_SETCHECK,
 		Cfg()->CfgVisualPrm.bLocalLight ? BST_CHECKED : BST_UNCHECKED, 0);
-	SetWindowText(GetDlgItem(hPage, IDC_OPT_VIS_AMBIENT), _itoa(Cfg()->CfgVisualPrm.AmbientLevel, cbuf, 10));
+	sprintf(cbuf, "%d", Cfg()->CfgVisualPrm.AmbientLevel);
+	SetWindowText(GetDlgItem(hPage, IDC_OPT_VIS_AMBIENT), cbuf);
 
 	VisualsChanged(hPage);
 }

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -41,6 +41,7 @@
 #include <iomanip>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 
 #ifdef INLINEGRAPHICS
 #include "VVessel.h"
@@ -2706,15 +2707,9 @@ bool Vessel::Undock (UINT did, const Vessel *exclude, double vsep)
 		}
 	}
 	if (bFRrecord && undocked) { // record undock event
-		char cbuf[256] = "\0";
-		int len = 0;
-		for (n = n0; n < n1; n++) {
-			if (len >= 255) break;
-			if (n > n0) cbuf[len++] = ' ';
-			sprintf(cbuf+len, "%d", n);
-			len += (n < 10 ? 1 : n < 100 ? 2 : 3);
-		}
-		FRecorder_SaveEvent ("UNDOCK", cbuf);
+		std::string buf;
+		for (n = n0; n < n1; ++n) buf += ' ' + std::to_string(n);
+		FRecorder_SaveEvent("UNDOCK", buf.substr(1).data());
 	}
 	return undocked;
 }

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -2711,7 +2711,7 @@ bool Vessel::Undock (UINT did, const Vessel *exclude, double vsep)
 		for (n = n0; n < n1; n++) {
 			if (len >= 255) break;
 			if (n > n0) cbuf[len++] = ' ';
-			_itoa (n, cbuf+len, 10);
+			sprintf(cbuf+len, "%d", n);
 			len += (n < 10 ? 1 : n < 100 ? 2 : 3);
 		}
 		FRecorder_SaveEvent ("UNDOCK", cbuf);
@@ -2733,7 +2733,7 @@ bool Vessel::ClbkSelect_Undock (Select *menu, int item, char *str, void *data)
 	DWORD i;
 	char cbuf[16] = "Dock ";
 	for (i = 0; i < us->vessel->ndock; i++) {
-		_itoa (i+1, cbuf+5, 10);
+		sprintf(cbuf + 5, "%d", i + 1);
 		menu->Append (cbuf, us->vessel->dock[i]->mate ? 0 : ITEM_NOHILIGHT);
 	}
 	return true;

--- a/Src/Orbiter/console_ng.cpp
+++ b/Src/Orbiter/console_ng.cpp
@@ -162,7 +162,7 @@ bool orbiter::ConsoleNG::ParseCmd()
 			return true;
 		}
 		else if (!_strnicmp(pc, "count", 5)) {
-			_itoa(g_psys->nVessel(), cbuf, 10);
+			sprintf(cbuf, "%zu", g_psys->nVessel());
 			Echo(cbuf);
 		}
 		else if (!_strnicmp(pc, "focus", 5)) {

--- a/Src/Orbiter/hud.cpp
+++ b/Src/Orbiter/hud.cpp
@@ -1128,7 +1128,7 @@ void HUD::DrawTiltedRibbon (oapi::Sketchpad *skp, double phi, double alpha)
 	int    dtx = (int)(0.5*s*sina);
 	int    dty = (int)(0.5*s*cosa);
 	int x0, y0, iphin;
-	char cbuf[4];
+	char cbuf[16];
 	
 	skp->SetTextAlign (oapi::Sketchpad::CENTER);
 	double d1;
@@ -1147,7 +1147,7 @@ void HUD::DrawTiltedRibbon (oapi::Sketchpad *skp, double phi, double alpha)
 			skp->Line (x0-dtx, y0+dty, x0+dtx, y0-dty);
 		} else {
 			skp->Line (x0-dsx, y0+dsy, x0+dsx, y0-dsy);
-			_itoa (iphin, cbuf, 10);
+			sprintf(cbuf, "%d", iphin);
 			skp->Text (x0+dsx*2, y0-dsy*2-fH/2, cbuf, strlen(cbuf));
 		}
 	}
@@ -1161,7 +1161,7 @@ void HUD::DrawTiltedRibbon (oapi::Sketchpad *skp, double phi, double alpha)
 			skp->Line (x0-dtx, y0+dty, x0+dtx, y0-dty);
 		} else {
 			skp->Line (x0-dsx, y0+dsy, x0+dsx, y0-dsy);
-			_itoa (iphin, cbuf, 10);
+			sprintf(cbuf, "%d", iphin);
 			skp->Text (x0+dsx*2, y0-dsy*2-fH/2, cbuf, strlen(cbuf));
 		}
 	}


### PR DESCRIPTION
This PR replaces MSVC specific _itoa with standard sprintf.
Rational for not using std::to_string or equivalent : _itoa is usually used in C strings heavy contexts, mixing C++ strings in there would only clutter the code for no good reason. Feel free to disagree, I can change my mind if necessary.
Integer formating is size limited so I used snprintf only where a buffer overflow was possible.
Code in OVP/D3D* was not modified since it will obviously needs MSVC to compile anyway.