### PR TITLE
Wrap std::min/max calls in parens

### DIFF
--- a/Orbitersdk/include/DrawAPI.h
+++ b/Orbitersdk/include/DrawAPI.h
@@ -226,12 +226,12 @@ namespace oapi {
 #endif
 		float MaxRGB() const
 		{
-			return std::max( r, std::max(g, b));
+			return (std::max)(r, (std::max)(g, b));
 		}
 
 		float MinRGB() const
 		{
-			return std::min( r, std::min(g, b));
+			return (std::min)(r, (std::min)(g, b));
 		}
 
 		float sql() const
@@ -359,10 +359,10 @@ namespace oapi {
 	{
 		DWORD dword_abgr() const
 		{
-			DWORD dr = DWORD(std::max(0.0f, r) * 255.0f + 0.5f);
-			DWORD dg = DWORD(std::max(0.0f, g) * 255.0f + 0.5f);
-			DWORD db = DWORD(std::max(0.0f, b) * 255.0f + 0.5f);
-			DWORD da = DWORD(std::max(0.0f, a) * 255.0f + 0.5f);
+			DWORD dr = DWORD((std::max)(0.0f, r) * 255.0f + 0.5f);
+			DWORD dg = DWORD((std::max)(0.0f, g) * 255.0f + 0.5f);
+			DWORD db = DWORD((std::max)(0.0f, b) * 255.0f + 0.5f);
+			DWORD da = DWORD((std::max)(0.0f, a) * 255.0f + 0.5f);
 			if (dr > 0xFF) dr = 0xFF;
 			if (dg > 0xFF) dg = 0xFF;
 			if (db > 0xFF) db = 0xFF;
@@ -372,10 +372,10 @@ namespace oapi {
 
 		DWORD dword_argb() const
 		{
-			DWORD dr = DWORD(std::max(0.0f, r) * 255.0f + 0.5f);
-			DWORD dg = DWORD(std::max(0.0f, g) * 255.0f + 0.5f);
-			DWORD db = DWORD(std::max(0.0f, b) * 255.0f + 0.5f);
-			DWORD da = DWORD(std::max(0.0f, a) * 255.0f + 0.5f);
+			DWORD dr = DWORD((std::max)(0.0f, r) * 255.0f + 0.5f);
+			DWORD dg = DWORD((std::max)(0.0f, g) * 255.0f + 0.5f);
+			DWORD db = DWORD((std::max)(0.0f, b) * 255.0f + 0.5f);
+			DWORD da = DWORD((std::max)(0.0f, a) * 255.0f + 0.5f);
 			if (dr > 0xFF) dr = 0xFF;
 			if (dg > 0xFF) dg = 0xFF;
 			if (db > 0xFF) db = 0xFF;
@@ -391,7 +391,7 @@ namespace oapi {
 
 		float MaxRGB() const
 		{
-			return std::max( r, std::max(g, b));
+			return (std::max)(r, (std::max)(g, b));
 		}
 
 		FVECTOR4()

--- a/Orbitersdk/include/VesselAPI.h
+++ b/Orbitersdk/include/VesselAPI.h
@@ -6377,9 +6377,9 @@ public:
 	bool Move (double dp) {
 		if (!Moving()) return false;
 		if (Closing()) {
-			if ((pos = std::max (0.0, pos-dp)) == 0.0) action = CLOSED;
+			if ((pos = (std::max)(0.0, pos - dp)) == 0.0) action = CLOSED;
 		} else {
-			if ((pos = std::min (1.0, pos+dp)) == 1.0) action = OPEN;
+			if ((pos = (std::min)(1.0, pos + dp)) == 1.0) action = OPEN;
 		}
 		return true;
 	}


### PR DESCRIPTION
This keeps Windows min/max macros from kicking in and causing errors.