### PR TITLE
Replace itoa with std::to_string

### DIFF
--- a/OVP/D3D7Client/D3D7Enum.cpp
+++ b/OVP/D3D7Client/D3D7Enum.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include "D3D7Enum.h"
 #include "D3D7Util.h"
+#include <string>
 
 char D3Ddevicename[256];
 char g_buf[256];
@@ -122,10 +123,9 @@ static HRESULT WINAPI DeviceEnumCallback (TCHAR* strDesc, TCHAR* strName,
         for (int i=0; i < 20; i++) {  // 20-loop-limit is for a sanity check in case of a bug
             strcpy(tempBuf, cbuf);  // working copy
             if (dupeIDCount > 1) {
-                char idStr[4];
                 // this is the newest device name
                 strcat(cbuf, " #");
-                strcat(cbuf, _itoa(dupeIDCount, idStr, 10));
+                strcat(cbuf, std::to_string(dupeIDCount).c_str());
             }
             // check whether we have a duplicate of this name
             UINT j;  // we need this outside the for loop

--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -19,6 +19,7 @@
 #include "resource.h"
 #include "resource_video.h"
 #include <stdio.h>
+#include <string>
 
 using namespace oapi;
 
@@ -134,7 +135,6 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	GraphicsClient::VIDEODATA *data = gclient->GetVideoData();
 	
 	D3D7Enum_DeviceInfo *devlist;
-	char cbuf[20];
 	DWORD i, ndev, idx;
 	D3D7Enum_GetDevices (&devlist, &ndev);
 
@@ -161,8 +161,8 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	SendDlgItemMessage (hTab, IDC_VID_VSYNC, BM_SETCHECK, data->novsync ? BST_CHECKED : BST_UNCHECKED, 0);
 	SendDlgItemMessage (hTab, IDC_VID_PAGEFLIP, BM_SETCHECK, data->pageflip ? BST_UNCHECKED : BST_CHECKED, 0);
 
-	SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), _itoa (data->winw, cbuf, 10));
-	SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), _itoa (data->winh, cbuf, 10));
+	SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), std::to_string(data->winw).c_str());
+	SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), std::to_string(data->winh).c_str());
 
 	if (data->winw == (4*data->winh)/3 || data->winh == (3*data->winw)/4)
 		aspect_idx = 1;
@@ -279,9 +279,8 @@ void VideoTab::SelectMode (D3D7Enum_DeviceInfo *dev, DWORD idx)
 	dev->ddsdFullscreenMode = dev->pddsdModes[dev->dwCurrentMode];
 	// if a bpp change was required, notify the bpp control
 	if (bpp != usebpp) {
-		char cbuf[20];
 		SendDlgItemMessage (hTab, IDC_VID_BPP, CB_SELECTSTRING, -1,
-			(LPARAM)_itoa (usebpp, cbuf, 10));
+			(LPARAM)std::to_string(usebpp).c_str());
 	}
 }
 
@@ -311,9 +310,8 @@ void VideoTab::SelectBPP (D3D7Enum_DeviceInfo *dev, DWORD idx)
 	// If we get here, the selected screen resolution isn't supported
 	// at this bit depth (shouldn't happen)
 	bpp = dev->pddsdModes[dev->dwCurrentMode].ddpfPixelFormat.dwRGBBitCount;
-	char cbuf[20];
 	SendDlgItemMessage (hTab, IDC_VID_BPP, CB_SELECTSTRING, -1,
-		(LPARAM)_itoa (bpp, cbuf, 10));
+		(LPARAM)std::to_string(bpp).c_str());
 
 	// If we get here, then we've screwed up big time
 	// and leave quietly
@@ -342,7 +340,7 @@ void VideoTab::SelectWidth ()
 		GetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), cbuf, 127); h = atoi(cbuf);
 		if (w != (wfac*h)/hfac) {
 			h = (hfac*w)/wfac;
-			SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), itoa (h, cbuf, 10));
+			SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), std::to_string(h).c_str());
 		}
 	}
 }
@@ -359,7 +357,7 @@ void VideoTab::SelectHeight ()
 		GetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), cbuf, 127); h = atoi(cbuf);
 		if (h != (hfac*w)/wfac) {
 			w = (wfac*h)/hfac;
-			SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), itoa (w, cbuf, 10));
+			SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), std::to_string(w).c_str());
 		}
 	}
 }

--- a/OVP/D3D9Client/VideoTab.cpp
+++ b/OVP/D3D9Client/VideoTab.cpp
@@ -222,10 +222,8 @@ void VideoTab::Initialise()
 		SendDlgItemMessage(hTab, IDC_VID_MODE, CB_SETCURSEL, data->modeidx&0xFF, 0);
 		SendDlgItemMessage(hTab, IDC_VID_VSYNC, BM_SETCHECK, data->novsync ? BST_CHECKED : BST_UNCHECKED, 0);
 		
-		if (_itoa_s(data->winw, cbuf, 32, 10)) return;
-		SetWindowText(GetDlgItem(hTab, IDC_VID_WIDTH), cbuf);
-		if (_itoa_s(data->winh, cbuf, 32, 10)) return;
-		SetWindowText(GetDlgItem(hTab, IDC_VID_HEIGHT), cbuf);
+		SetWindowText(GetDlgItem(hTab, IDC_VID_WIDTH), std::to_string(data->winw).c_str());
+		SetWindowText(GetDlgItem(hTab, IDC_VID_HEIGHT), std::to_string(data->winh).c_str());
 
 		aspect_idx = 0;
 		
@@ -363,8 +361,7 @@ void VideoTab::SelectWidth ()
 		GetWindowText(GetDlgItem(hTab, IDC_VID_HEIGHT), cbuf, 32); h = atoi(cbuf);
 		if (w != (wfac*h)/hfac) {
 			h = (hfac*w)/wfac;
-			if (_itoa_s (h, cbuf, 32, 10)) return;
-			SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), cbuf);
+			SetWindowText (GetDlgItem (hTab, IDC_VID_HEIGHT), std::to_string(h).c_str());
 		}
 	}
 }
@@ -381,8 +378,7 @@ void VideoTab::SelectHeight ()
 		GetWindowText(GetDlgItem(hTab, IDC_VID_HEIGHT), cbuf, 32); h = atoi(cbuf);
 		if (h != (hfac*w)/wfac) {
 			w = (wfac*h)/hfac;
-			if (_itoa_s (w, cbuf, 32, 10)) return;
-			SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), cbuf);
+			SetWindowText (GetDlgItem (hTab, IDC_VID_WIDTH), std::to_string(w).c_str());
 		}
 	}
 }

--- a/Src/Orbiter/Mfd.cpp
+++ b/Src/Orbiter/Mfd.cpp
@@ -1147,7 +1147,7 @@ bool Instrument::FindScnHeader (ifstream &ifs) const
 	switch (id) {
 	case 0: strcpy (header+10, "Left"); break;
 	case 1: strcpy (header+10, "Right"); break;
-	default: sprintf (header+10, "%lld", id + 1); break;
+	default: sprintf (header+10, "%lld", (int64_t)id + 1); break;
 	}
 	return FindLine (ifs, header);
 }


### PR DESCRIPTION
Second round to replace _itoa calls in OVP.
I took this opportunity to work around a warning introduced earlier in the 32bit build.