### PR TITLE
Minor code fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,12 @@ cmake_minimum_required(VERSION 3.19)
 # Set the project name
 project (Orbiter VERSION 21.7.24)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+#Add /permissive if using C++20 or higher
+#add_compile_options(/permissive)
 
 # Some functions to simplify debugging CMake scripts
 include(CMakePrintHelpers)

--- a/OVP/D3D9Client/D3D9Util.cpp
+++ b/OVP/D3D9Client/D3D9Util.cpp
@@ -1156,9 +1156,9 @@ LPDIRECT3DVERTEXSHADER9 CompileVertexShader(LPDIRECT3DDEVICE9 pDev, const char *
 const char *RemovePath(const char *in)
 {
 	int len = lstrlen(in);
-	const char *ptr = in;
-	for (int i=0;i<len;i++) if (in[i]=='\\' || in[i]=='/') ptr = &in[i+1];
-	return ptr;
+	const char *cptr = in;
+	for (int i=0;i<len;i++) if (in[i]=='\\' || in[i]=='/') cptr = &in[i+1];
+	return cptr;
 }
 
 // ============================================================================

--- a/OVP/D3D9Client/D3D9Util.h
+++ b/OVP/D3D9Client/D3D9Util.h
@@ -71,8 +71,13 @@ const char *_PTR(const void *p);
 
 // helper function to get address of a temporary
 // NB: use with caution
-template<typename T>
-T* ptr(T&& x) { return &x; }
+
+
+// Required only with c++20 without /permissive flag
+// template<typename T>
+// T* ptr(T&& x) { return &x; }
+
+#define ptr &	// use for faster code
 
 // ------------------------------------------------------------------------------------
 // Vertex Declaration equal to NTVERTEX

--- a/OVP/D3D9Client/Mesh.cpp
+++ b/OVP/D3D9Client/Mesh.cpp
@@ -33,8 +33,8 @@ MeshShader::PSBools MeshShader::ps_bools = {};
 
 int compare_lights(const void * a, const void * b)
 {
-	register float fa = static_cast<const _LightList*>(a)->illuminace;
-	register float fb = static_cast<const _LightList*>(b)->illuminace;
+	float fa = static_cast<const _LightList*>(a)->illuminace;
+	float fb = static_cast<const _LightList*>(b)->illuminace;
 	if (fa < fb * 0.9995f) return  1;
 	if (fa > fb * 1.0005f) return -1;
 	return 0;

--- a/OVP/D3D9Client/TileMgr.cpp
+++ b/OVP/D3D9Client/TileMgr.cpp
@@ -251,8 +251,8 @@ bool TileManager::LoadTileData ()
 
 int compare_idx (const void *el1, const void *el2)
 {
-	register const IDXLIST *idx1 = static_cast<const IDXLIST*>(el1);
-	register const IDXLIST *idx2 = static_cast<const IDXLIST*>(el2);
+	const IDXLIST *idx1 = static_cast<const IDXLIST*>(el1);
+	const IDXLIST *idx2 = static_cast<const IDXLIST*>(el2);
 	return (idx1->ofs < idx2->ofs ? -1 : idx1->ofs > idx2->ofs ? 1 : 0);
 }
 

--- a/OVP/D3D9Client/samples/DrawOrbits/Tools.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Tools.cpp
@@ -34,7 +34,7 @@ const char *ValueToText(double real, int digits)
 	const char *k2 = { "M" };
 	const char *k3 = { "G" };
 	const char *k5 = { "m" };
-	const char *k6 = { "µ" };
+	const char *k6 = { "Âµ" };
 	const char *k7 = { "T" };
 
 	n = (int)floor(log10(v)) + 1;
@@ -89,7 +89,7 @@ const char *AngleToText(double deg, int digits)
 	if (f >= 360.0) f = 0.0;
 	if (deg<0) f = -f;
 
-	sprintf_s(ValueToText_Str, 30, "%1.*f°", digits, f);
+	sprintf_s(ValueToText_Str, 30, "%1.*fÂ°", digits, f);
 
 	return ValueToText_Str;
 }
@@ -364,7 +364,7 @@ double mna2eca(double mna, double ecc)
 {
 
 	// iterative calculation of eccentric anomaly from mean anomaly
-	register double eca, m, x;
+	double eca, m, x;
 	int i;
 
 	if (ecc<1.0) {

--- a/Src/Orbiter/CelSphere.cpp
+++ b/Src/Orbiter/CelSphere.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Martin Schweiger
 // Licensed under the MIT License
 
+#define OAPI_IMPLEMENTATION
+
 #include "CelSphere.h"
 #include "Scene.h"
 #include "Camera.h"


### PR DESCRIPTION
- Removed 'register' keyword.
- fixed link warnings.
- Replaced prt() function with '&' macro.
- Set default standard to C++17