### PR TITLE
exclude non-64-bit-modules from 64 bit builds

### DIFF
--- a/Src/Celbody/Ariel/CMakeLists.txt
+++ b/Src/Celbody/Ariel/CMakeLists.txt
@@ -28,6 +28,7 @@ set_target_properties(${CELBODY}
 	FOLDER Celbody
 )
 
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +37,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Deimos/CMakeLists.txt
+++ b/Src/Celbody/Deimos/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Miranda/CMakeLists.txt
+++ b/Src/Celbody/Miranda/CMakeLists.txt
@@ -28,6 +28,7 @@ set_target_properties(${CELBODY}
 	FOLDER Celbody
 )
 
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +37,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Oberon/CMakeLists.txt
+++ b/Src/Celbody/Oberon/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 #Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Phobos/CMakeLists.txt
+++ b/Src/Celbody/Phobos/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Sol/Config/Sol64.cfg
+++ b/Src/Celbody/Sol/Config/Sol64.cfg
@@ -1,0 +1,36 @@
+; === Configuration file for solar system ===
+Name = Sol
+
+Star1 = Sun
+Planet1 = Mercury
+Planet2 = Venus
+Planet3 = Earth
+Earth:Moon1 = Moon
+Planet4 = Mars
+;Mars:Moon1 = Phobos
+;Mars:Moon2 = Deimos
+Planet5 = Vesta
+Planet6 = Jupiter
+Jupiter:Moon1 = Io
+Jupiter:Moon2 = Europa
+Jupiter:Moon3 = Ganymede
+Jupiter:Moon4 = Callisto
+Planet7 = Saturn
+Saturn:Moon1 = Mimas
+Saturn:Moon2 = Enceladus
+Saturn:Moon3 = Tethys
+Saturn:Moon4 = Dione
+Saturn:Moon5 = Rhea
+Saturn:Moon6 = Titan
+Saturn:Moon7 = Hyperion
+Saturn:Moon8 = Iapetus
+Planet8 = Uranus
+;Uranus:Moon1 = Miranda
+;Uranus:Moon2 = Ariel
+;Uranus:Moon3 = Umbriel
+;Uranus:Moon4 = Titania
+;Uranus:Moon5 = Oberon
+Planet9 = Neptune
+;Neptune:Moon1 = Triton
+Neptune:Moon2 = Proteus
+Neptune:Moon3 = Nereid

--- a/Src/Celbody/Titania/CMakeLists.txt
+++ b/Src/Celbody/Titania/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Triton/CMakeLists.txt
+++ b/Src/Celbody/Triton/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()

--- a/Src/Celbody/Umbriel/CMakeLists.txt
+++ b/Src/Celbody/Umbriel/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${CELBODY}
 	PROPERTIES
 	FOLDER Celbody
 )
-
+if(NOT CMAKE_CL_64) #remove me when this celbody has source code that can be built
 # Installation
 install(PROGRAMS
 	${CELBODY}.dll
@@ -36,3 +36,4 @@ install(PROGRAMS
 install(DIRECTORY Config
 	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
 )
+endif()


### PR DESCRIPTION
This is a temporary fix to make 64-bit builds usable "out of the box" without commenting out anything in sol.cfg

closes #243
closes #353 

This is not a replacement for the missing modules. It just prevents CMAKE from packaging non-working 32-bit DLLs with OOx64