### PR TITLE
Add support for VS2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [x64, x86]
+        os: [windows-2019, windows-2022]
       
-    runs-on: windows-2019
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
@@ -96,6 +97,7 @@ jobs:
       run: git diff -U0 --ignore-cr-at-eol --ignore-space-at-eol --no-index exports.2016.txt out/install/Orbiter/exports.txt
 
     - name: Upload exports
+      if: ${{ matrix.os == 'windows-2019' }}
       uses: actions/upload-artifact@v4
       with:
         name: exports-${{ matrix.architecture }}
@@ -109,7 +111,7 @@ jobs:
       run: '7z a "${{ github.workspace }}/out/Orbiter.zip" .'
 
     - name: Upload Build Artifact
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' && matrix.os == 'windows-2019' }}
       uses: actions/upload-artifact@v4
       with:
         name: Orbiter-${{ matrix.architecture }}

--- a/Src/Orbiter/Planet.cpp
+++ b/Src/Orbiter/Planet.cpp
@@ -501,7 +501,7 @@ void Planet::ScanBases (char *path)
 	std::error_code ec;
 	for (const auto& entry : fs::directory_iterator(configdir, ec)) {
 		if (entry.path().extension().string() == ".cfg") {
-			ifstream ifs(entry);
+			ifstream ifs(entry.path());
 			if (!ifs) continue;
 			do {
 				if (!ifs.getline(cbuf, 256)) break;
@@ -545,7 +545,7 @@ void Planet::ScanLabelLists (ifstream &cfg)
 	ForEach(FILETYPE_MARKER, [&](const fs::directory_entry& entry) {
 		char cbuf[256];
 		// open marker file
-		ifstream ulf(entry);
+		ifstream ulf(entry.path());
 
 		// read label header
 		if (scanheader) {

--- a/Src/Orbiter/Psys.cpp
+++ b/Src/Orbiter/Psys.cpp
@@ -227,7 +227,7 @@ void PlanetarySystem::ScanLabelLists (ifstream &cfg, bool bScanHeaders)
 	int idx = 0;
 	ForEach(FILETYPE_MARKER, [&](const fs::directory_entry& entry) {
 		// open marker file
-		ifstream ulf(entry);
+		ifstream ulf(entry.path());
 		// read label header
 		if (bScanHeaders) {
 			oapi::GraphicsClient::LABELLIST list;


### PR DESCRIPTION
This PR fixes the build issues when compiling with VS2022, it also adds CI jobs to detect potential future failures.
The artifacts for the VS2022 builds are not saved for now.