### PR TITLE
[Lua]Add support for oapiOpenInputBoxEx

### DIFF
--- a/Script/strict.lua
+++ b/Script/strict.lua
@@ -42,3 +42,5 @@ end
 function strictmode_add_global(name)
 	mt.__declared[name] = true
 end
+-- Global used for aborting coroutines
+wait_exit = nil

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -389,6 +389,7 @@ protected:
 	static int oapiOpenHelp (lua_State *L);
 	static int oapiOpenInputBox (lua_State *L);
 	static int oapiReceiveInput (lua_State *L);
+	static int oapi_open_inputboxex (lua_State *L);
 	static int oapi_global_to_equ(lua_State* L);
 	static int oapi_global_to_local(lua_State* L);
 	static int oapi_local_to_equ(lua_State* L);


### PR DESCRIPTION
This PR adds support for the oapiOpenInputBoxEx function in ScriptVessels/ScriptMFDs
Differences with the C++ version :
-callbacks only take 2 arguments (str and usrdata) since the first "void *id" is useless
-cancel callback does not need to return a bool since it's ignored by the core anyway