### PR TITLE
[DX9]Fix oapiSetMaterialEx

### DIFF
--- a/OVP/D3D9Client/D3D9Client.cpp
+++ b/OVP/D3D9Client/D3D9Client.cpp
@@ -1507,7 +1507,7 @@ int D3D9Client::clbkMeshMaterial (DEVMESHHANDLE hMesh, DWORD matidx, MATERIAL *m
 
 // ==============================================================
 
-int D3D9Client::clbkSetMaterialEx(DEVMESHHANDLE hMesh, DWORD matidx, MatProp mat, const oapi::FVECTOR4* in)
+int D3D9Client::clbkSetMeshMaterialEx(DEVMESHHANDLE hMesh, DWORD matidx, MatProp mat, const oapi::FVECTOR4* in)
 {
 	if (!hMesh) return 3;
 	D3D9Mesh* mesh = (D3D9Mesh*)hMesh;

--- a/OVP/D3D9Client/D3D9Client.h
+++ b/OVP/D3D9Client/D3D9Client.h
@@ -334,7 +334,7 @@ public:
 	 * \default, None, returns 2 ("client does not support operation").
 	 */
 	int clbkSetMeshMaterial(DEVMESHHANDLE hMesh, DWORD matidx, const MATERIAL* mat);
-	int clbkSetMaterialEx(DEVMESHHANDLE hMesh, DWORD matidx, MatProp mat, const oapi::FVECTOR4* in);
+	int clbkSetMeshMaterialEx(DEVMESHHANDLE hMesh, DWORD matidx, MatProp mat, const oapi::FVECTOR4* in);
 
 	/**
 	* \brief Retrieve the properties of one of the mesh materials.

--- a/OVP/D3D9Client/gcConst.cpp
+++ b/OVP/D3D9Client/gcConst.cpp
@@ -199,7 +199,7 @@ int	gcConst::MeshMaterial(DEVMESHHANDLE hMesh, DWORD idx, int prop, FVECTOR4* va
 	if (prop == MESHM_METALNESS) mat = MatProp::Metal;
 	if (prop == MESHM_SPECIALFX) mat = MatProp::SpecialFX;
 
-	if (bSet) return g_client->clbkSetMaterialEx(hMesh, idx, mat, value);
+	if (bSet) return g_client->clbkSetMeshMaterialEx(hMesh, idx, mat, value);
 	return g_client->clbkMeshMaterialEx(hMesh, idx, mat, value);
 }
 

--- a/OVP/D3D9Client/gcCore.cpp
+++ b/OVP/D3D9Client/gcCore.cpp
@@ -344,7 +344,7 @@ int gcCore::GetMeshMaterial(DEVMESHHANDLE hMesh, DWORD idx, MatProp prop, FVECTO
 //
 int gcCore::SetMeshMaterial(DEVMESHHANDLE hMesh, DWORD idx, MatProp prop, const FVECTOR4* value)
 {
-	return g_client->clbkSetMaterialEx(hMesh, idx, prop, value);
+	return g_client->clbkSetMeshMaterialEx(hMesh, idx, prop, value);
 }
 
 // ===============================================================================================


### PR DESCRIPTION
@jarmonik can confirm but it looks like there's been some kind of naming confusion between clbkSetMaterialEx and clbkSetMeshMaterialEx.
oapiSetMaterialEx in the core calls clbkSetMeshMaterialEx in the GC.
The D3D9Client implements a clbkSetMaterialEx method which is used by the gcCore API but it will not match when calling oapiSetMaterialEx and the default implementation will be used (i.e. "return 2;").
I modified the D3D9Client to implement the correct naming but it could also be done by changing the GC interface in the core.
Don't know what's best between naming consistency in the core (clbkSetMeshMaterial, clbkMeshMaterial and clbkMeshMaterialEx also exist) or the GC ; tell me if you think it should be done the other way around.