### PR TITLE
fix: tab out/scroll mouse permanently disappearing bug

### DIFF
--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -99,7 +99,7 @@ const double    MinWarpLimit     = 0.1;  // make variable
 const double    MaxWarpLimit     = 1e5;  // make variable
 DWORD           g_qsaveid        = 0;
 DWORD           g_customcmdid    = 0;
-int g_iCursorShowCount;
+int				g_iCursorShowCount = 0;
 
 // 2D info output flags
 BOOL g_bOutputTime  = TRUE;

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -99,6 +99,7 @@ const double    MinWarpLimit     = 0.1;  // make variable
 const double    MaxWarpLimit     = 1e5;  // make variable
 DWORD           g_qsaveid        = 0;
 DWORD           g_customcmdid    = 0;
+int g_iCursorShowCount;
 
 // 2D info output flags
 BOOL g_bOutputTime  = TRUE;
@@ -1171,10 +1172,10 @@ void Orbiter::UpdateServerWnd (HWND hWnd)
 void Orbiter::InitRotationMode ()
 {
 	bKeepFocus = true;
-	bool cursorShown = ShowCursor (FALSE);
 
-	if (cursorShown < 0) {
-		ShowCursor (FALSE);
+	// Checks if the cursor is already hidden
+	if (g_iCursorShowCount == 0) {
+		g_iCursorShowCount = ShowCursor(FALSE);
 	}
 
 	SetCapture (hRenderWnd);
@@ -1196,10 +1197,10 @@ void Orbiter::ExitRotationMode ()
 {
 	bKeepFocus = false;
 	ReleaseCapture ();
-	bool cursorShown = ShowCursor(TRUE);
 
-	if (cursorShown > 0) {
-		ShowCursor(TRUE);
+	// Checks if the cursor is already hidden
+	if (g_iCursorShowCount < 0) {
+		g_iCursorShowCount = ShowCursor (TRUE);
 	}
 
 	// Release cursor from render window confines

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -1171,7 +1171,12 @@ void Orbiter::UpdateServerWnd (HWND hWnd)
 void Orbiter::InitRotationMode ()
 {
 	bKeepFocus = true;
-	ShowCursor (FALSE);
+	bool cursorShown = ShowCursor (FALSE);
+
+	if (cursorShown < 0) {
+		ShowCursor (FALSE);
+	}
+
 	SetCapture (hRenderWnd);
 
 	// Limit cursor to render window confines, so we don't miss the button up event
@@ -1191,7 +1196,11 @@ void Orbiter::ExitRotationMode ()
 {
 	bKeepFocus = false;
 	ReleaseCapture ();
-	ShowCursor (TRUE);
+	bool cursorShown = ShowCursor(TRUE);
+
+	if (cursorShown > 0) {
+		ShowCursor(TRUE);
+	}
 
 	// Release cursor from render window confines
 	if (!bFullscreen && hRenderWnd) {

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -99,7 +99,7 @@ const double    MinWarpLimit     = 0.1;  // make variable
 const double    MaxWarpLimit     = 1e5;  // make variable
 DWORD           g_qsaveid        = 0;
 DWORD           g_customcmdid    = 0;
-int				g_iCursorShowCount = 0;
+int             g_iCursorShowCount = 0;
 
 // 2D info output flags
 BOOL g_bOutputTime  = TRUE;


### PR DESCRIPTION
I was talking to some of the community members in the NASSP discord, and they informed me that the disappearing mouse bug that would happen when tabbing out and zooming while scrolling over a switch while being in the right click (RotationMode), was not an isolated bug. So I decided to take it upon myself to fix it.

The problem is that the reference counter on the ShowCursor function would increment too high due to loosing focus, so it checks that it is below a certain threshold and tries to rectify it by calling the function again.