### PR TITLE
fix: rotationmode now takes mouse priority over panel buttons + alt-tab mouse disappearing fix

### DIFF
--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2639,6 +2639,12 @@ void Orbiter::UserJoyInput_OnRunning (DIJOYSTATE2 *js)
 
 bool Orbiter::MouseEvent (UINT event, DWORD state, DWORD x, DWORD y)
 {
+	// Prioritizes mouse handling while in rotation mode
+	if (g_pOrbiter->StickyFocus()) {
+		if (event == WM_MOUSEMOVE) return false; // may be lifted later
+		if (g_camera->ProcessMouse(event, state, x, y, simkstate)) return true;
+	}
+
 	if (g_pane->MIBar() && g_pane->MIBar()->ProcessMouse (event, state, x, y)) return true;
 	if (BroadcastMouseEvent (event, state, x, y)) return true;
 	if (event == WM_MOUSEMOVE) return false; // may be lifted later

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -99,6 +99,7 @@ const double    MinWarpLimit     = 0.1;  // make variable
 const double    MaxWarpLimit     = 1e5;  // make variable
 DWORD           g_qsaveid        = 0;
 DWORD           g_customcmdid    = 0;
+int g_iCursorShowCount;
 
 // 2D info output flags
 BOOL g_bOutputTime  = TRUE;
@@ -1171,10 +1172,10 @@ void Orbiter::UpdateServerWnd (HWND hWnd)
 void Orbiter::InitRotationMode ()
 {
 	bKeepFocus = true;
-	bool cursorShown = ShowCursor (FALSE);
 
-	if (cursorShown < 0) {
-		ShowCursor (FALSE);
+	// Checks if the cursor is already hidden
+	if (g_iCursorShowCount == 0) {
+		g_iCursorShowCount = ShowCursor(FALSE);
 	}
 
 	SetCapture (hRenderWnd);
@@ -1196,10 +1197,10 @@ void Orbiter::ExitRotationMode ()
 {
 	bKeepFocus = false;
 	ReleaseCapture ();
-	bool cursorShown = ShowCursor(TRUE);
 
-	if (cursorShown > 0) {
-		ShowCursor(TRUE);
+	// Checks if the cursor is already hidden
+	if (g_iCursorShowCount < 0) {
+		g_iCursorShowCount = ShowCursor (TRUE);
 	}
 
 	// Release cursor from render window confines

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -1171,7 +1171,12 @@ void Orbiter::UpdateServerWnd (HWND hWnd)
 void Orbiter::InitRotationMode ()
 {
 	bKeepFocus = true;
-	ShowCursor (FALSE);
+	bool cursorShown = ShowCursor (FALSE);
+
+	if (cursorShown < 0) {
+		ShowCursor (FALSE);
+	}
+
 	SetCapture (hRenderWnd);
 
 	// Limit cursor to render window confines, so we don't miss the button up event
@@ -1191,7 +1196,11 @@ void Orbiter::ExitRotationMode ()
 {
 	bKeepFocus = false;
 	ReleaseCapture ();
-	ShowCursor (TRUE);
+	bool cursorShown = ShowCursor(TRUE);
+
+	if (cursorShown > 0) {
+		ShowCursor(TRUE);
+	}
 
 	// Release cursor from render window confines
 	if (!bFullscreen && hRenderWnd) {


### PR DESCRIPTION
This PR patches the bug where the mouse could disappear when alt tabbing from the game, this was an almost game-breaking bug where you would have to restart your entire sim in order to fix the bug. The mouse now has a global hide counter to check for if it is already hidden, and prevents it from being hidden twice, this makes it so it can never be permanently hidden, as ShowCursor(true) only increments the counter by 1, whereas before it'd get stuck below 0 and therefore stay permanently hidden. 

After patching the alt-tab bug, I noticed a bug in NASSP where when moving and scrolling the mouse, it would activate unintended buttons when trying to change the FOV. Rather than changing the FOV it would perform the "right click" action on any button while scrolling. I do not believe this is intended behavior, so I created a shim that activates when the camera rotation mode activates which prevents it from doing anything other than mouse movement, and camera interaction. This shouldn't affect anything other than mouse inputs as the shim is put into the orbiter mouse handler. 

I decided that I should just combine the PRs because they're both complements to each other and should be merged together 