### PR TITLE
Splashscreen customization

### DIFF
--- a/Doc/Orbiter Developer Manual/SCENARIO.tex
+++ b/Doc/Orbiter Developer Manual/SCENARIO.tex
@@ -102,6 +102,8 @@ The following environment parameters are supported:
 	Help & String [,String] & Scenario help file (in HTML or compressed CHM format). For a HTML page, specify the location of the page relative to the Html\textbackslash Scenarios folder and without extension (.htm is assumed). For a page in a CHM file, specify the location of the file relative to the Html\textbackslash Scenarios folder without extension (.chm is assumed), followed by a comma and the name of the page inside the file without extension (.htm is assumed). Scenario help files can be opened during the simulation with Alt+F1. Default: no help file\\
 	\hline\rule{0pt}{2ex}
 	Playback & String & Folder containing playback data, relative to "Flights" subdirectory. Default: no playback\\
+	\hline\rule{0pt}{2ex}
+	SplashScreen & String String & First argument is a CSS color string (e.g. \#ff0000 or red) indicating the color to use for the text displayed while the scenario is loading. The second argument is the path to an image that will replace the default Orbiter screen. The color name is case insensitive. Default: standard load screen\\
 	\hline
 	\end{tabularx}
 \end{table}

--- a/OVP/D3D9Client/D3D9Client.h
+++ b/OVP/D3D9Client/D3D9Client.h
@@ -1233,6 +1233,7 @@ protected:
 	 */
 	bool clbkSplashLoadMsg (const char *msg, int line);
 
+	void clbkSetSplashScreen(const char *filename, DWORD textCol) override;
 
 	/**
 	 * \brief Store a persistent mesh template
@@ -1307,6 +1308,8 @@ private:
 	std::string				scenarioName;
 	HANDLE					hMainThread;
 	WindowManager *			pWM;
+	const char *            pCustomSplashScreen;
+	DWORD                   pSplashTextColor;
 
 	HWND hRenderWnd;        // render window handle
 

--- a/Orbitersdk/include/GraphicsAPI.h
+++ b/Orbitersdk/include/GraphicsAPI.h
@@ -1620,6 +1620,17 @@ protected:
 	virtual bool clbkSplashLoadMsg (const char *msg, int line) { return false; }
 
 	/**
+	 * \brief Change the default splash screen
+	 * 
+	 * Called before clbkCreateRenderWindow to override the default splash screen
+	 * image and text color.
+	 *
+	 * \param fname File containing the splashscreen (jpg/bmp)
+	 * \param textCol text color
+	 */
+	virtual void clbkSetSplashScreen(const char *fname, DWORD textCol) {}
+
+	/**
 	 * \brief Notifies Orbiter to to initiate rendering of the 2D scene overlay
 	 *
 	 * The 2D overlay is used to render 2D instrument panels, HUD, the info

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -683,6 +683,8 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 	m_pLaunchpad->Hide(); // hide launchpad dialog while the render window is visible
 	
 	if (gclient) {
+		if(pState->SplashScreen())
+			gclient->clbkSetSplashScreen(pState->SplashScreen(), pState->SplashColor());
 		hRenderWnd = gclient->InitRenderWnd (gclient->clbkCreateRenderWindow());
 		GetRenderParameters ();
 	} else {

--- a/Src/Orbiter/State.h
+++ b/Src/Orbiter/State.h
@@ -11,18 +11,21 @@
 
 #include <iostream>
 #include <fstream>
+#include <string>
 
 class State {
 public:
 	State();
 
 	double Mjd() const { return mjd; }
-	char *Solsys() { return solsys; }
-	const char *Context() const { return context[0] ? context : 0; }
-	const char *Script() const { return script[0] ? script : 0; }
-	const char *Focus() const { return focus; }
-	const char *ScnHelp() const { return (scnhelp[0] ? scnhelp : 0); }
-	const char *PlaybackDir() const { return (playback[0] ? playback : scenario); }
+	char *Solsys() { return const_cast<char *>(solsys.c_str()); }
+	const char *Context() const { return context.length() ? context.c_str() : 0; }
+	const char *SplashScreen() const { return splashscreen.length() ? splashscreen.c_str() : 0; }
+	DWORD SplashColor() const { return splashcolor; }
+	const char *Script() const { return script.length() ? script.c_str() : 0; }
+	const char *Focus() const { return focus.c_str(); }
+	const char *ScnHelp() const { return (scnhelp.length() ? scnhelp.c_str() : 0); }
+	const char *PlaybackDir() const { return (playback.length() ? playback.c_str() : scenario.c_str()); }
 	void Update ();
 
 	/// \brief Read state from scenario file
@@ -37,15 +40,17 @@ public:
 	// load/save scenario state
 
 private:
-	double mjd0;        // start time (MJD format)
-	double mjd;         // current simulation time
-	char scenario[256]; // scenario name
-	char solsys[64];    // name of planetary system
-	char context[64];   // scenario context
-	char script[128];   // scenario script
-	char focus[64];     // current focus vessel
-	char scnhelp[128];  // scenario help file
-	char playback[128]; // playback folder name, if applicable
+	double mjd0;           // start time (MJD format)
+	double mjd;            // current simulation time
+	std::string scenario;    // scenario name
+	std::string solsys;       // name of planetary system
+	std::string context;      // scenario context
+	std::string splashscreen;// scenario splash screen
+	DWORD splashcolor;     // text color on splashscreen
+	std::string script;      // scenario script
+	std::string focus;        // current focus vessel
+	std::string scnhelp;     // scenario help file
+	std::string playback;    // playback folder name, if applicable
 
 };
 

--- a/Src/Orbiter/Util.cpp
+++ b/Src/Orbiter/Util.cpp
@@ -5,6 +5,8 @@
 #include <shlobj.h>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
+#include <algorithm>
 
 LONGLONG NameToId (const char *name)
 {
@@ -130,4 +132,176 @@ FltFormat::FltFormat (int precision /* = 6 */)
 
 FltFormatter FltFormat::operator() (double value) const {
 	return FltFormatter(precision, value);
+}
+
+// Extended CSS colors
+static const std::unordered_map<std::string, DWORD> colornames {
+	{"aliceblue",           0xfff8f0},
+	{"antiquewhite",        0xd7ebfa},
+	{"aqua",                0xffff00},
+	{"aquamarine",          0xd4ff7f},
+	{"azure",               0xfffff0},
+	{"beige",               0xdcf5f5},
+	{"bisque",              0xc4e4ff},
+	{"black",               0x000000},
+	{"blanchedalmond",      0xcdebff},
+	{"blue",                0xff0000},
+	{"blueviolet",          0xe22b8a},
+	{"brown",               0x2a2aa5},
+	{"burlywood",           0x87b8de},
+	{"cadetblue",           0xa09e5f},
+	{"chartreuse",          0x00ff7f},
+	{"chocolate",           0x1e69d2},
+	{"coral",               0x507fff},
+	{"cornflowerblue",      0xed9564},
+	{"cornsilk",            0xdcf8ff},
+	{"crimson",             0x3c14dc},
+	{"cyan",                0xffff00},
+	{"darkblue",            0x8b0000},
+	{"darkcyan",            0x8b8b00},
+	{"darkgoldenrod",       0x0b86b8},
+	{"darkgray",            0xa9a9a9},
+	{"darkgreen",           0x006400},
+	{"darkgrey",            0xa9a9a9},
+	{"darkkhaki",           0x6bb7bd},
+	{"darkmagenta",         0x8b008b},
+	{"darkolivegreen",      0x2f6b55},
+	{"darkorange",          0x008cff},
+	{"darkorchid",          0xcc3299},
+	{"darkred",             0x00008b},
+	{"darksalmon",          0x7a96e9},
+	{"darkseagreen",        0x8fbc8f},
+	{"darkslateblue",       0x8b3d48},
+	{"darkslategray",       0x4f4f2f},
+	{"darkslategrey",       0x4f4f2f},
+	{"darkturquoise",       0xd1ce00},
+	{"darkviolet",          0xd30094},
+	{"deeppink",            0x9314ff},
+	{"deepskyblue",         0xffbf00},
+	{"dimgray",             0x696969},
+	{"dimgrey",             0x696969},
+	{"dodgerblue",          0xff901e},
+	{"firebrick",           0x2222b2},
+	{"floralwhite",         0xf0faff},
+	{"forestgreen",         0x228b22},
+	{"fuchsia",             0xff00ff},
+	{"gainsboro",           0xdcdcdc},
+	{"ghostwhite",          0xfff8f8},
+	{"gold",                0x00d7ff},
+	{"goldenrod",           0x20a5da},
+	{"gray",                0x808080},
+	{"green",               0x008000},
+	{"greenyellow",         0x2fffad},
+	{"grey",                0x808080},
+	{"honeydew",            0xf0fff0},
+	{"hotpink",             0xb469ff},
+	{"indianred",           0x5c5ccd},
+	{"indigo",              0x82004b},
+	{"ivory",               0xf0ffff},
+	{"khaki",               0x8ce6f0},
+	{"lavender",            0xfae6e6},
+	{"lavenderblush",       0xf5f0ff},
+	{"lawngreen",           0x00fc7c},
+	{"lemonchiffon",        0xcdfaff},
+	{"lightblue",           0xe6d8ad},
+	{"lightcoral",          0x8080f0},
+	{"lightcyan",           0xffffe0},
+	{"lightgoldenrodyellow",0xd2fafa},
+	{"lightgray",           0xd3d3d3},
+	{"lightgreen",          0x90ee90},
+	{"lightgrey",           0xd3d3d3},
+	{"lightpink",           0xc1b6ff},
+	{"lightsalmon",         0x7aa0ff},
+	{"lightseagreen",       0xaab220},
+	{"lightskyblue",        0xface87},
+	{"lightslategray",      0x998877},
+	{"lightslategrey",      0x998877},
+	{"lightsteelblue",      0xdec4b0},
+	{"lightyellow",         0xe0ffff},
+	{"lime",                0x00ff00},
+	{"limegreen",           0x32cd32},
+	{"linen",               0xe6f0fa},
+	{"magenta",             0xff00ff},
+	{"maroon",              0x000080},
+	{"mediumaquamarine",    0xaacd66},
+	{"mediumblue",          0xcd0000},
+	{"mediumorchid",        0xd355ba},
+	{"mediumpurple",        0xdb7093},
+	{"mediumseagreen",      0x71b33c},
+	{"mediumslateblue",     0xee687b},
+	{"mediumspringgreen",   0x9afa00},
+	{"mediumturquoise",     0xccd148},
+	{"mediumvioletred",     0x8515c7},
+	{"midnightblue",        0x701919},
+	{"mintcream",           0xfafff5},
+	{"mistyrose",           0xe1e4ff},
+	{"moccasin",            0xb5e4ff},
+	{"navajowhite",         0xaddeff},
+	{"navy",                0x800000},
+	{"oldlace",             0xe6f5fd},
+	{"olive",               0x008080},
+	{"olivedrab",           0x238e6b},
+	{"orange",              0x00a5ff},
+	{"orangered",           0x0045ff},
+	{"orchid",              0xd670da},
+	{"palegoldenrod",       0xaae8ee},
+	{"palegreen",           0x98fb98},
+	{"paleturquoise",       0xeeeeaf},
+	{"palevioletred",       0x9370db},
+	{"papayawhip",          0xd5efff},
+	{"peachpuff",           0xb9daff},
+	{"peru",                0x3f85cd},
+	{"pink",                0xcbc0ff},
+	{"plum",                0xdda0dd},
+	{"powderblue",          0xe6e0b0},
+	{"purple",              0x800080},
+	{"red",                 0x0000ff},
+	{"rosybrown",           0x8f8fbc},
+	{"royalblue",           0xe16941},
+	{"saddlebrown",         0x13458b},
+	{"salmon",              0x7280fa},
+	{"sandybrown",          0x60a4f4},
+	{"seagreen",            0x578b2e},
+	{"seashell",            0xeef5ff},
+	{"sienna",              0x2d52a0},
+	{"silver",              0xc0c0c0},
+	{"skyblue",             0xebce87},
+	{"slateblue",           0xcd5a6a},
+	{"slategray",           0x908070},
+	{"slategrey",           0x908070},
+	{"snow",                0xfafaff},
+	{"springgreen",         0x7fff00},
+	{"steelblue",           0xb48246},
+	{"tan",                 0x8cb4d2},
+	{"teal",                0x808000},
+	{"thistle",             0xd8bfd8},
+	{"tomato",              0x4763ff},
+	{"turquoise",           0xd0e040},
+	{"violet",              0xee82ee},
+	{"wheat",               0xb3def5},
+	{"white",               0xffffff},
+	{"whitesmoke",          0xf5f5f5},
+	{"yellow",              0x00ffff},
+	{"yellowgreen",         0x32cd9a},
+};
+
+
+// Convert a CSS color string to a DWORD (in 0xbbggrr format)
+DWORD GetCSSColor(const char *col)
+{
+	if(col[0]=='#') {
+		DWORD rgb = strtoul(&col[1], NULL, 16);
+		DWORD bgr = ((rgb & 0xff0000) >> 16) | (rgb & 0x00ff00) |((rgb & 0x0000ff) << 16);
+		return bgr;
+	}
+
+	// Force lowercase
+	std::string lccol = col;
+	std::transform(lccol.begin(), lccol.end(), lccol.begin(), [](unsigned char c){ return std::tolower(c); });
+
+	if (auto search = colornames.find(lccol); search != colornames.end())
+        return search->second;
+
+	// Color not found, default to fuchsia
+	return 0xFF00FF;
 }

--- a/Src/Orbiter/Util.h
+++ b/Src/Orbiter/Util.h
@@ -88,4 +88,7 @@ struct FltFormat
 	FltFormatter operator() (double value) const;
 };
 
+// Convert a CSS color string to a DWORD (in 0xbbggrr format)
+DWORD GetCSSColor(const char *col);
+
 #endif //!__UTIL_H


### PR DESCRIPTION
~~This PR should probably wait for after the 2024 release.~~
This adds support for custom load screens via a new scenario parameter "SplashScreen" in the ENVIRONMENT section :
```
BEGIN_ENVIRONMENT
   System Sol
   Date MJD 51982.0975169074
   SplashScreen lime Images/myawesomelogo.jpg
END_ENVIRONMENT
```

The first parameter is a color ~~in 0xbbggrr format~~ described as a [CSS color](https://drafts.csswg.org/css-color/#named-colors) (either in #hex or as a color name), followed by the image filename to be shown on the splashscreen.
The color name is case insensitive, I tested with filenames containing spaces and it works OK.
The image is scaled with the same logic as the embedded Orbiter logo.

Since I was messing with State.h, I took the opportunity to replace the error prone char arrays with std::string

End result :
![splashscreen](https://github.com/user-attachments/assets/c6bff47c-fd31-4307-a09b-ab80f2b775dd)
