### PR TITLE
[Lua]Generate doc by default

### DIFF
--- a/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
@@ -46,38 +46,36 @@ add_custom_command(TARGET LuaInterpreter
 	COMMAND ${CMAKE_COMMAND} -E copy ${LUAINTERPRETER_LIB} ${ORBITER_BINARY_SDK_DIR}/lib/Lua/
 )
 
-if(ORBITER_MAKE_DOC)
-	file(GLOB lua_in *.h *.cpp *.ld *.md *.lua)
-	add_custom_command(
-		POST_BUILD
-		DEPENDS ${lua_in} lfs CopyLDoc
-		OUTPUT ${BUILD_OUT_DIR}/index.html
-		COMMAND ${CMAKE_COMMAND} -E copy ${lua_in} ${CMAKE_CURRENT_BINARY_DIR}
-		COMMAND ${ldoc} .
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/interpreter.hhp ${BUILD_OUT_DIR}
-		JOB_POOL htmlhelp
-	)
-	
-	add_custom_command(
-		POST_BUILD
-		OUTPUT ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
-		DEPENDS ${BUILD_OUT_DIR}/index.html
-		WORKING_DIRECTORY ${BUILD_OUT_DIR}
-		COMMAND ${HHC_CMD} interpreter.hhp
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different ./interpreter.chm ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
-		JOB_POOL htmlhelp
+file(GLOB lua_in *.h *.cpp *.ld *.md *.lua)
+add_custom_command(
+	POST_BUILD
+	DEPENDS ${lua_in} lfs CopyLDoc
+	OUTPUT ${BUILD_OUT_DIR}/index.html
+	COMMAND ${CMAKE_COMMAND} -E copy ${lua_in} ${CMAKE_CURRENT_BINARY_DIR}
+	COMMAND ${ldoc} .
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/interpreter.hhp ${BUILD_OUT_DIR}
+	JOB_POOL htmlhelp
 )
-	add_custom_target(orbiter_lua
-		DEPENDS ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
-	)
-	add_dependencies(${OrbiterTgt}
-		orbiter_lua
-	)
+	
+add_custom_command(
+	POST_BUILD
+	OUTPUT ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
+	DEPENDS ${BUILD_OUT_DIR}/index.html
+	WORKING_DIRECTORY ${BUILD_OUT_DIR}
+	COMMAND ${HHC_CMD} interpreter.hhp
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ./interpreter.chm ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
+	JOB_POOL htmlhelp
+)
+add_custom_target(orbiter_lua
+	DEPENDS ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
+)
+add_dependencies(${OrbiterTgt}
+	orbiter_lua
+)
 
-	install(FILES ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
-		DESTINATION ${ORBITER_INSTALL_SDK_DIR}/doc
-	)
-endif()
+install(FILES ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm
+	DESTINATION ${ORBITER_INSTALL_SDK_DIR}/doc
+)
 
 # Installation
 install(TARGETS LuaInterpreter

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -3818,7 +3818,6 @@ This function is primarily used internally, you should prefer using open_inputbo
 @function open_inputbox
 @tparam string title input box title
 @see open_inputboxex
-@see proc.wait_input
 @usage oapi.open_inputbox(title)
  -- elsewhere
  local ans = oapi.receive_input ()
@@ -7225,8 +7224,8 @@ int Interpreter::oapi_inflate (lua_State *L)
 Return a colour value adapted to the current screen colour depth for given
 red, green and blue components.
 
-Colour values are required for some surface functions like @{clear_surface}
-   or @{set_surfacecolourkey}. The colour key for a given RGB triplet depends
+Colour values are required for some surface functions like @{clear_surface}.
+   The colour key for a given RGB triplet depends
    on the screen colour depth. This function returns the colour value for the
    closest colour match which can be displayed in the current screen mode.
 

--- a/Src/Module/LuaScript/LuaInterpreter/lua_vessel_mtd.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/lua_vessel_mtd.cpp
@@ -2875,7 +2875,7 @@ orbit ellipse.
 @treturn number semi-minor axis [m]
 @treturn handle Handle of reference object, relative to which the orbit is
    calculated. _nil_ indicates failure (no orbit information available)
-@see orbit, ELEMENTS, types.ORBITPARAMS, get_elements
+@see types.ELEMENTS, types.ORBITPARAMS, get_elements
 */
 int Interpreter::v_get_smi (lua_State *L)
 {
@@ -2906,7 +2906,7 @@ ascending node.
 @treturn number argument of periapsis for current orbit [rad]
 @treturn handle Handle of reference body, relative to which the orbit is
    calculated. nil indicates failure (no orbit information available)
-@see orbit, ELEMENTS, ORBITPARAM, get_pedist, get_apdist, get_elements
+@see types.ELEMENTS, types.ORBITPARAMS, get_pedist, get_apdist, get_elements
 */
 int Interpreter::v_get_argper (lua_State *L)
 {
@@ -2937,7 +2937,7 @@ The periapsis distance is the smallest radius of the orbit (see
 @treturn number periapsis distance [m]
 @treturn handle Handle of reference body, relative to which the orbit is
    calculated. NULL indicates failure (no orbit information available)
-@see orbit, ELEMENTS, ORBITPARAM, get_apdist, get_argper, get_elements
+@see types.ELEMENTS, types.ORBITPARAMS, get_apdist, get_argper, get_elements
 */
 int Interpreter::v_get_pedist (lua_State *L)
 {
@@ -2968,7 +2968,7 @@ The apoapsis distance is the largest radius of the orbit (see
 @treturn number apoapsis distance [m]
 @treturn handle Handle of reference body, relative to which the orbit is
    calculated. NULL indicates failure (no orbit information available)
-@see orbit, ELEMENTS, ORBITPARAM, get_pedist, get_argper, get_elements
+@see types.ELEMENTS, types.ORBITPARAMS, get_pedist, get_argper, get_elements
 */
 int Interpreter::v_get_apdist(lua_State* L)
 {
@@ -7483,7 +7483,7 @@ within visual range of the observer camera).
 @tparam ?string|handle mesh mesh file name (meshName) or handle of template mesh (hMesh)
 @param[opt] ofs (<i><b>@{types.vector|vector}</b></i>) vector defining the offset of mesh origin from vessel origin [<b>m</b>]
 @treturn int idx mesh index (&ge; 0)
-@see vessel:del_mesh, vessel:insert_mesh, oapi.loadmesh_global
+@see vessel:del_mesh, vessel:insert_mesh, oapi.load_meshglobal
 */
 int Interpreter::v_add_mesh (lua_State *L)
 {
@@ -7534,7 +7534,7 @@ The return value is always equal to _idx_.
 @tparam int idx mesh index (&ge; 0)
 @param[opt] ofs (<i><b>@{types.vector|vector}</b></i>) vector defining the offset of mesh origin from vessel origin [<b>m</b>]
 @treturn int mesh index (&ge; 0)
-@see vessel:del_mesh, vessel:add_mesh, oapi.loadmesh_global
+@see vessel:del_mesh, vessel:add_mesh, oapi.load_meshglobal
 */
 int Interpreter::v_insert_mesh (lua_State *L)
 {
@@ -7983,7 +7983,7 @@ mechanism is an alternative way to define animations where the
 transformations are managed by the Orbiter core.
 
 @function register_animation
-@see clbk_animate, unregister_animation, create_animation, add_animationcomponent
+@see unregister_animation, create_animation, add_animationcomponent
 */
 int Interpreter::v_register_animation (lua_State *L)
 {
@@ -8005,7 +8005,7 @@ The call to UnregisterAnimation should not be placed in the body of
    doesn't exist.
 
 @function unregister_animation
-@see register_animation, clbk_animate
+@see register_animation
 */
 int Interpreter::v_unregister_animation (lua_State *L)
 {


### PR DESCRIPTION
The Lua documentation does not need LaTeX and all tools necessary to produce it are in the repo ; we might as well generate it automatically.
The orbiter_lua.chm file is installed in Orbitersdk/doc.
