### PR TITLE
[Lua]Fix HUD not showing if clbk_drawHUD is not defined

### DIFF
--- a/Src/Vessel/ScriptVessel/ScriptVessel.cpp
+++ b/Src/Vessel/ScriptVessel/ScriptVessel.cpp
@@ -948,9 +948,9 @@ static void lua_pushsketchpad(lua_State* L, oapi::Sketchpad* skp)
 
 bool ScriptVessel::clbkDrawHUD(int mode, const HUDPAINTSPEC* hps, oapi::Sketchpad* skp)
 {
+	// draw the default HUD
+	VESSEL3::clbkDrawHUD(mode, hps, skp);
 	if (bclbk[DRAWHUD]) {
-		// draw the default HUD
-		VESSEL3::clbkDrawHUD(mode, hps, skp);
 
 		strcpy(func + 5, "drawHUD");
 		lua_getfield(L, LUA_GLOBALSINDEX, func);


### PR DESCRIPTION
This fixes the bug reported [here](https://www.orbiter-forum.com/threads/invisible-hud.41956/).
The default VESSEL3::clbkDrawHUD method was only called if a callback was defined in the vessel script.
I checked for similar issues with other callbacks but it was the only instance.