### PR TITLE
[Lua]Fix clbk_visualdestroyed not being called

### DIFF
--- a/OVP/D3D9Client/D3D9Util.cpp
+++ b/OVP/D3D9Client/D3D9Util.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <cctype>
 #include <unordered_map>
+#include <algorithm>
 
 extern D3D9Client* g_client;
 extern unordered_map<MESHHANDLE, class SketchMesh*> MeshMap;

--- a/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
@@ -30,6 +30,7 @@ add_dependencies(LuaInterpreter
 	D3D9Client
 	D3D9Client_Interface
 	XRSound_lib
+	XRSound_assets
 )
 
 set_target_properties(LuaInterpreter

--- a/Src/Vessel/ScriptVessel/ScriptVessel.cpp
+++ b/Src/Vessel/ScriptVessel/ScriptVessel.cpp
@@ -86,7 +86,7 @@ const char *CLBKNAME[NCLBK] = {
 	"panelredrawevent",
 	"loadVC",
 	"visualcreated",
-	"visualdestroyes",
+	"visualdestroyed",
 	"VCmouseevent",
 	"VCredrawevent",
 	"drawHUD",


### PR DESCRIPTION
Fix lame typo in ScriptVessel.cpp preventing clbk_visualdestroyed from being called.