### PR TITLE
Fix unchecked thruster level

### DIFF
--- a/OVP/D3D9Client/D3D9Util.cpp
+++ b/OVP/D3D9Client/D3D9Util.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <cctype>
 #include <unordered_map>
+#include <algorithm>
 
 extern D3D9Client* g_client;
 extern unordered_map<MESHHANDLE, class SketchMesh*> MeshMap;

--- a/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
@@ -30,6 +30,7 @@ add_dependencies(LuaInterpreter
 	D3D9Client
 	D3D9Client_Interface
 	XRSound_lib
+	XRSound_assets
 )
 
 set_target_properties(LuaInterpreter

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -8297,6 +8297,7 @@ void VESSEL::IncThrusterLevel (THRUSTER_HANDLE th, double dlevel) const
 	if (vessel->bFRplayback) return;
 	ThrustSpec *ts = (ThrustSpec*)th;
 	ts->level_permanent += dlevel;
+	ts->level_permanent = max (0.0, min (1.0, ts->level_permanent));
 	if (ts->tank && ts->tank->mass)
 		ts->level = max (0.0, min (1.0, ts->level_permanent + ts->level_override));
 }

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -443,6 +443,7 @@ public:
 	{
 		if (!bFRplayback) {
 			ts->level_permanent += dlevel;
+			ts->level_permanent = std::max(0.0, std::min(1.0, ts->level_permanent));
 			if (ts->tank && ts->tank->mass)
 				ts->level = std::max(0.0, std::min(1.0, ts->level+dlevel));
 		}


### PR DESCRIPTION
This PR fixes the issue #512
The "permanent" level of thrust was not clamped when using the IncThrusterLevel API.
