### PR TITLE
[Lua]Harden vessel dereferencing

### DIFF
--- a/Src/Module/LuaScript/LuaInline/LuaInline.cpp
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.cpp
@@ -135,6 +135,10 @@ void InterpreterList::clbkPostStep (double simt, double simdt, double mjd)
 	}
 }
 
+void InterpreterList::clbkDeleteVessel (OBJHANDLE hVessel)
+{
+	Interpreter::DeleteVessel(hVessel);
+}
 
 InterpreterList::Environment *InterpreterList::AddInterpreter ()
 {

--- a/Src/Module/LuaScript/LuaInline/LuaInline.h
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.h
@@ -45,10 +45,11 @@ public:
 	InterpreterList (HINSTANCE hDLL);
 	~InterpreterList ();
 
-	void clbkSimulationEnd ();
-	void clbkPostStep (double simt, double simdt, double mjd);
-	void clbkSimulationStart (RenderMode mode);
-
+	void clbkSimulationEnd () override;
+	void clbkPostStep (double simt, double simdt, double mjd) override;
+	void clbkSimulationStart (RenderMode mode) override;
+	void clbkDeleteVessel (OBJHANDLE hVessel) override;
+	
 	Environment *AddInterpreter ();
 	int DelInterpreter (Environment *env);
 

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -235,6 +235,7 @@ public:
 
 	static int LuaCall(lua_State *L, int nargs, int nres);
 	void SetErrorBox(NOTEHANDLE eb) { errorbox = eb; }
+	static void DeleteVessel (OBJHANDLE hVessel);
 protected:
 	static inline NOTEHANDLE errorbox;
 	lua_State *L;         // Lua main context
@@ -304,12 +305,11 @@ protected:
 
 	// Pops a VESSEL interface from the stack and returns it.
 	// A NULL return indicates an invalid data type at the specified stack position,
-	// but a nonzero return does not guarantee a valid vessel pointer
+	// a nonzero return guarantees a valid vessel pointer
 	static VESSEL *lua_tovessel (lua_State *L, int idx=-1);
 
 	// type extraction with checks
 	static VESSEL *lua_tovessel_safe (lua_State *L, int idx, const char *funcname);
-	static int lua_isvessel(lua_State *L, int idx);
 
 	static int lua_tointeger_safe (lua_State *L, int idx, const char *funcname);
 	static double lua_tonumber_safe (lua_State *L, int idx, const char *funcname);
@@ -1155,7 +1155,7 @@ private:
 	int (*postfunc)(void*);
 	void *postcontext;
 
-	static inline std::unordered_set<void *>knownVessels; // for lua_isvessel
+	static inline std::unordered_set<VESSEL *>knownVessels; // for lua_isvessel
 
 
 	static int lua_tointeger_safe (lua_State *L, int idx, int prmno, const char *funcname);

--- a/Src/Module/LuaScript/LuaInterpreter/lua_xrsound.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/lua_xrsound.cpp
@@ -141,8 +141,7 @@ int Interpreter::xrsound_create_instance (lua_State *L)
 	if(lua_isstring(L, 1)) {
 		const char *moduleName = lua_tostring(L, 1);
 		snd = XRSound::CreateInstance(moduleName);
-	} else if (lua_isvessel(L, 1)) {
-		VESSEL *v = lua_tovessel(L, 1);
+	} else if (VESSEL *v = lua_tovessel(L, 1)) {
 		snd = XRSound::CreateInstance(v);
 	} else {
 		return luaL_error(L, "Invalid parameter to xrsound.create_instance, string or vessel handle needed");

--- a/Src/Vessel/DeltaGlider/DGLua.cpp
+++ b/Src/Vessel/DeltaGlider/DGLua.cpp
@@ -105,7 +105,7 @@ these methods for other vessel types will generally result in an error. To check
 
 DeltaGlider *lua_toDG (lua_State *L, int idx)
 {
-	VESSEL **pv = (VESSEL**)lua_touserdata (L, idx);
+	VESSEL **pv = (VESSEL **)luaL_checkudata(L, idx, "DG.vtable");
 	DeltaGlider *dg = (DeltaGlider*)*pv;
 	return dg;
 }

--- a/Src/Vessel/HST/HST_Lua.cpp
+++ b/Src/Vessel/HST/HST_Lua.cpp
@@ -43,7 +43,7 @@ int HST::Lua_InitInstance(void *context)
 {
 	lua_State *L = (lua_State*)context;
 
-	// check if interpreter has DG table loaded already
+	// check if interpreter has HST table loaded already
 	luaL_getmetatable (L, "VESSEL.HST");
 
 	if (lua_isnil (L, -1)) { // register new functions
@@ -98,7 +98,7 @@ To check the class of a vessel object, use the vessel:get_classname() method.
 
 HST *lua_toHST (lua_State *L, int idx)
 {
-	VESSEL **pv = (VESSEL**)lua_touserdata (L, idx);
+	VESSEL **pv = (VESSEL **)luaL_checkudata(L, idx, "HST.vtable");
 	HST *hst = (HST*)*pv;
 	return hst;
 }

--- a/Src/Vessel/Quadcopter/QuadcopterLua.cpp
+++ b/Src/Vessel/Quadcopter/QuadcopterLua.cpp
@@ -26,7 +26,7 @@ int LuaInterface::InitInstance(void *context)
 {
 	lua_State *L = (lua_State*)context;
 
-	// check if interpreter has DG table loaded already
+	// check if interpreter has QC table loaded already
 	luaL_getmetatable(L, "VESSEL.QC");
 
 	if (lua_isnil(L, -1)) { // register new functions
@@ -85,7 +85,7 @@ To check the class of a vessel object, use the vessel:get_classname() method.
 
 Quadcopter *LuaInterface::lua_toQC(lua_State *L, int idx)
 {
-	VESSEL **pv = (VESSEL**)lua_touserdata(L, idx);
+	VESSEL **pv = (VESSEL **)luaL_checkudata(L, idx, "QC.vtable");
 	Quadcopter *qc = (Quadcopter*)*pv;
 	return qc;
 }

--- a/Src/Vessel/ShuttleA/ShuttleALua.cpp
+++ b/Src/Vessel/ShuttleA/ShuttleALua.cpp
@@ -102,7 +102,7 @@ VECTOR3 lua_tovector (lua_State *L, int idx)
 
 ShuttleA *lua_toShuttleA (lua_State *L, int idx)
 {
-	VESSEL **pv = (VESSEL**)lua_touserdata (L, idx);
+	VESSEL **pv = (VESSEL **)luaL_checkudata(L, idx, "SHUTTLEA.vtable");
 	ShuttleA *sh = (ShuttleA*)*pv;
 	return sh;
 }

--- a/Src/Vessel/Solarsail/SailLua.cpp
+++ b/Src/Vessel/Solarsail/SailLua.cpp
@@ -35,8 +35,8 @@ int SolarSail::Lua_InitInstance (void *context)
 {
 	lua_State *L = (lua_State*)context;
 
-	// check if interpreter has DG table loaded already
-	luaL_getmetatable (L, "VESSEL.DG");
+	// check if interpreter has SSail table loaded already
+	luaL_getmetatable (L, "VESSEL.SSail");
 
 	if (lua_isnil (L, -1)) { // register new functions
 		lua_pop (L, 1);
@@ -88,7 +88,7 @@ To check the class of a vessel object, use the vessel:get_classname() method.
 
 SolarSail *lua_toSSail (lua_State *L, int idx)
 {
-	VESSEL **pv = (VESSEL**)lua_touserdata (L, idx);
+	VESSEL **pv = (VESSEL **)luaL_checkudata(L, idx, "SSail.vtable");
 	SolarSail *sail = (SolarSail*)*pv;
 	return sail;
 }


### PR DESCRIPTION
This PR adds checks on the "self" parameter when a Lua command executes a virtual function on vessel objects.
Prior to this, there were opportunities for CTD when the user forgot to use the ":" notation when calling a vessel method.
A proper Lua error is now propagated when we try to convert a non vessel object to a VESSEL *.
Orbiter vessels providing Lua bindings have also been updated to check for proper type before casting userdata to VESSEL objects.
Note : luaL_checkudata is not used in the interpreter because we cannot know what type of vessel is to be expected. Instead a set of VESSEL objects is maintained and checked against to test if a userdata is associated with a known vessel.
This method is robust to vessel deletion. If for example you do
v=vessel.get_interface("ISS")
then delete the ISS from the scenario editor
then
print(v:get_name())
it generates an error instead of a crash.