### PR TITLE
Fixed cmake configure with default options turned off

### DIFF
--- a/Extern/Lua/CMakeLists.txt
+++ b/Extern/Lua/CMakeLists.txt
@@ -32,7 +32,13 @@ install(TARGETS lua-exe DESTINATION ${ORBITER_INSTALL_SDK_DIR}/Utils/)
 
 # Library - lua.dll
 add_library(lua SHARED ${LUA_SRC_FILES})
-target_compile_definitions(lua PUBLIC LUA_BUILD_AS_DLL)
+
+if(MSVC)
+  target_compile_definitions(lua PUBLIC LUA_BUILD_AS_DLL)
+else()
+  target_link_libraries(lua-exe PUBLIC m)
+  target_link_libraries(lua PUBLIC m)
+endif()
 
 set_target_properties(lua PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${ORBITER_BINARY_ROOT_DIR}

--- a/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BUILD_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/out)
 add_library(LuaInterpreter SHARED
 	Interpreter.cpp
 	lua_vessel_mtd.cpp
-	lua_xrsound.cpp
+  lua_xrsound.cpp
 )
 
 target_include_directories(LuaInterpreter
@@ -21,17 +21,21 @@ target_link_libraries(LuaInterpreter
 	${ORBITER_LIB}
 	${ORBITER_SDK_LIB}
 	lua::lib
-	XRSound_lib
 )
 
 add_dependencies(LuaInterpreter
 	${OrbiterTgt}
 	Orbitersdk
-	D3D9Client
-	D3D9Client_Interface
-	XRSound_lib
-	XRSound_assets
 )
+
+if(ORBITER_BUILD_D3D9CLIENT)
+  add_dependencies(LuaInterpreter	D3D9Client D3D9Client_Interface)
+endif()
+
+if(ORBITER_BUILD_XRSOUND)
+  add_dependencies(LuaInterpreter	XRSound_lib	XRSound_assets)
+  target_link_libraries(LuaInterpreter XRSound_lib)
+endif()
 
 set_target_properties(LuaInterpreter
 	PROPERTIES


### PR DESCRIPTION
Allows CMake configure to complete with
```
ORBITER_BUILD_D3D9CLIENT=OFF
ORBITER_BUILD_XRSOUND=OFF
```
Note that LuaInterpreter does not build correctly without XRSound for now