### PR TITLE
WIP: Add support for ImGui

### DIFF
--- a/Extern/CMakeLists.txt
+++ b/Extern/CMakeLists.txt
@@ -6,6 +6,7 @@ endif(NOT DEFINED ORBITER_BINARY_ROOT_DIR)
 
 add_subdirectory(lua)
 add_subdirectory(zlib)
+add_subdirectory(imgui)
 
 ## LFS
 add_library(lfs SHARED luafilesystem/src/lfs.c)

--- a/Extern/imgui/CMakeLists.txt
+++ b/Extern/imgui/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(imgui)
+
+Include(FetchContent)
+
+FetchContent_Declare(
+  imgui
+  GIT_REPOSITORY https://github.com/ocornut/imgui.git
+  GIT_TAG v1.91.6-docking
+  PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/imconfig.h .
+  UPDATE_DISCONNECTED 1
+)
+FetchContent_MakeAvailable(imgui)
+
+install(FILES ${imgui_SOURCE_DIR}/misc/fonts/Roboto-Medium.ttf
+	DESTINATION ${ORBITER_INSTALL_ROOT_DIR}
+)

--- a/Extern/imgui/imconfig.h
+++ b/Extern/imgui/imconfig.h
@@ -1,0 +1,155 @@
+//-----------------------------------------------------------------------------
+// DEAR IMGUI COMPILE-TIME OPTIONS
+// Runtime options (clipboard callbacks, enabling various features, etc.) can generally be set via the ImGuiIO structure.
+// You can use ImGui::SetAllocatorFunctions() before calling ImGui::CreateContext() to rewire memory allocation functions.
+//-----------------------------------------------------------------------------
+// A) You may edit imconfig.h (and not overwrite it when updating Dear ImGui, or maintain a patch/rebased branch with your modifications to it)
+// B) or '#define IMGUI_USER_CONFIG "my_imgui_config.h"' in your project and then add directives in your own file without touching this template.
+//-----------------------------------------------------------------------------
+// You need to make sure that configuration settings are defined consistently _everywhere_ Dear ImGui is used, which include the imgui*.cpp
+// files but also _any_ of your code that uses Dear ImGui. This is because some compile-time options have an affect on data structures.
+// Defining those options in imconfig.h will ensure every compilation unit gets to see the same data structure layouts.
+// Call IMGUI_CHECKVERSION() from your .cpp file to verify that the data structures your files are using are matching the ones imgui.cpp is using.
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+//---- Define assertion handler. Defaults to calling assert().
+// If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
+//#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
+//#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
+
+//---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
+// Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
+// - Windows DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
+//   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
+//#define IMGUI_API __declspec(dllexport)                   // MSVC Windows: DLL export
+//#define IMGUI_API __declspec(dllimport)                   // MSVC Windows: DLL import
+//#define IMGUI_API __attribute__((visibility("default")))  // GCC/Clang: override visibility when set is hidden
+
+//---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to clean your code of obsolete function/names.
+//#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+
+//---- Disable all of Dear ImGui or don't implement standard windows/tools.
+// It is very strongly recommended to NOT disable the demo windows and debug tool during development. They are extremely useful in day to day work. Please read comments in imgui_demo.cpp.
+//#define IMGUI_DISABLE                                     // Disable everything: all headers and source files will be empty.
+//#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty.
+//#define IMGUI_DISABLE_DEBUG_TOOLS                         // Disable metrics/debugger and other debug tools: ShowMetricsWindow(), ShowDebugLogWindow() and ShowIDStackToolWindow() will be empty.
+
+//---- Don't implement some functions to reduce linkage requirements.
+//#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)
+//#define IMGUI_ENABLE_WIN32_DEFAULT_IME_FUNCTIONS          // [Win32] [Default with Visual Studio] Implement default IME handler (require imm32.lib/.a, auto-link for Visual Studio, -limm32 on command-line for MinGW)
+//#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] [Default with non-Visual Studio compilers] Don't implement default IME handler (won't require imm32.lib/.a)
+//#define IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32 function (clipboard, IME).
+//#define IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS      // [OSX] Implement default OSX clipboard handler (need to link with '-framework ApplicationServices', this is why this is not the default).
+//#define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS             // Don't implement default platform_io.Platform_OpenInShellFn() handler (Win32: ShellExecute(), require shell32.lib/.a, Mac/Linux: use system("")).
+//#define IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS            // Don't implement ImFormatString/ImFormatStringV so you can implement them yourself (e.g. if you don't want to link with vsnprintf)
+//#define IMGUI_DISABLE_DEFAULT_MATH_FUNCTIONS              // Don't implement ImFabs/ImSqrt/ImPow/ImFmod/ImCos/ImSin/ImAcos/ImAtan2 so you can implement them yourself.
+//#define IMGUI_DISABLE_FILE_FUNCTIONS                      // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle at all (replace them with dummies)
+//#define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS              // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle so you can implement them yourself if you don't want to link with fopen/fclose/fread/fwrite. This will also disable the LogToTTY() function.
+//#define IMGUI_DISABLE_DEFAULT_ALLOCATORS                  // Don't implement default allocators calling malloc()/free() to avoid linking with them. You will need to call ImGui::SetAllocatorFunctions().
+//#define IMGUI_DISABLE_DEFAULT_FONT                        // Disable default embedded font (ProggyClean.ttf), remove ~9.5 KB from output binary. AddFontDefault() will assert.
+//#define IMGUI_DISABLE_SSE                                 // Disable use of SSE intrinsics even if available
+
+//---- Enable Test Engine / Automation features.
+//#define IMGUI_ENABLE_TEST_ENGINE                          // Enable imgui_test_engine hooks. Generally set automatically by include "imgui_te_config.h", see Test Engine for details.
+
+//---- Include imgui_user.h at the end of imgui.h as a convenience
+// May be convenient for some users to only explicitly include vanilla imgui.h and have extra stuff included.
+//#define IMGUI_INCLUDE_IMGUI_USER_H
+//#define IMGUI_USER_H_FILENAME         "my_folder/my_imgui_user.h"
+
+//---- Pack vertex colors as BGRA8 instead of RGBA8 (to avoid converting from one to another). Need dedicated backend support.
+//#define IMGUI_USE_BGRA_PACKED_COLOR
+
+//---- Use legacy CRC32-adler tables (used before 1.91.6), in order to preserve old .ini data that you cannot afford to invalidate.
+//#define IMGUI_USE_LEGACY_CRC32_ADLER
+
+//---- Use 32-bit for ImWchar (default is 16-bit) to support Unicode planes 1-16. (e.g. point beyond 0xFFFF like emoticons, dingbats, symbols, shapes, ancient languages, etc...)
+//#define IMGUI_USE_WCHAR32
+
+//---- Avoid multiple STB libraries implementations, or redefine path/filenames to prioritize another version
+// By default the embedded implementations are declared static and not available outside of Dear ImGui sources files.
+//#define IMGUI_STB_TRUETYPE_FILENAME   "my_folder/stb_truetype.h"
+//#define IMGUI_STB_RECT_PACK_FILENAME  "my_folder/stb_rect_pack.h"
+//#define IMGUI_STB_SPRINTF_FILENAME    "my_folder/stb_sprintf.h"    // only used if IMGUI_USE_STB_SPRINTF is defined.
+//#define IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_SPRINTF_IMPLEMENTATION                   // only disabled if IMGUI_USE_STB_SPRINTF is defined.
+
+//---- Use stb_sprintf.h for a faster implementation of vsnprintf instead of the one from libc (unless IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS is defined)
+// Compatibility checks of arguments and formats done by clang and GCC will be disabled in order to support the extra formats provided by stb_sprintf.h.
+//#define IMGUI_USE_STB_SPRINTF
+
+//---- Use FreeType to build and rasterize the font atlas (instead of stb_truetype which is embedded by default in Dear ImGui)
+// Requires FreeType headers to be available in the include path. Requires program to be compiled with 'misc/freetype/imgui_freetype.cpp' (in this repository) + the FreeType library (not provided).
+// On Windows you may use vcpkg with 'vcpkg install freetype --triplet=x64-windows' + 'vcpkg integrate install'.
+//#define IMGUI_ENABLE_FREETYPE
+
+//---- Use FreeType + plutosvg or lunasvg to render OpenType SVG fonts (SVGinOT)
+// Only works in combination with IMGUI_ENABLE_FREETYPE.
+// - lunasvg is currently easier to acquire/install, as e.g. it is part of vcpkg.
+// - plutosvg will support more fonts and may load them faster. It currently requires to be built manually but it is fairly easy. See misc/freetype/README for instructions.
+// - Both require headers to be available in the include path + program to be linked with the library code (not provided).
+// - (note: lunasvg implementation is based on Freetype's rsvg-port.c which is licensed under CeCILL-C Free Software License Agreement)
+//#define IMGUI_ENABLE_FREETYPE_PLUTOSVG
+//#define IMGUI_ENABLE_FREETYPE_LUNASVG
+
+//---- Use stb_truetype to build and rasterize the font atlas (default)
+// The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.
+//#define IMGUI_ENABLE_STB_TRUETYPE
+
+//---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
+// This will be inlined as part of ImVec2 and ImVec4 class declarations.
+/*
+#define IM_VEC2_CLASS_EXTRA                                                     \
+        constexpr ImVec2(const MyVec2& f) : x(f.x), y(f.y) {}                   \
+        operator MyVec2() const { return MyVec2(x,y); }
+
+#define IM_VEC4_CLASS_EXTRA                                                     \
+        constexpr ImVec4(const MyVec4& f) : x(f.x), y(f.y), z(f.z), w(f.w) {}   \
+        operator MyVec4() const { return MyVec4(x,y,z,w); }
+*/
+//---- ...Or use Dear ImGui's own very basic math operators.
+//#define IMGUI_DEFINE_MATH_OPERATORS
+
+//---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
+// Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
+// Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
+// Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
+//#define ImDrawIdx unsigned int
+
+//---- Override ImDrawCallback signature (will need to modify renderer backends accordingly)
+//struct ImDrawList;
+//struct ImDrawCmd;
+//typedef void (*MyImDrawCallback)(const ImDrawList* draw_list, const ImDrawCmd* cmd, void* my_renderer_user_data);
+//#define ImDrawCallback MyImDrawCallback
+
+//---- Debug Tools: Macro to break in Debugger (we provide a default implementation of this in the codebase)
+// (use 'Metrics->Tools->Item Picker' to pick widgets with the mouse and break into them for easy debugging.)
+//#define IM_DEBUG_BREAK  IM_ASSERT(0)
+//#define IM_DEBUG_BREAK  __debugbreak()
+
+//---- Debug Tools: Enable slower asserts
+//#define IMGUI_DEBUG_PARANOID
+
+//---- Tip: You can add extra functions within the ImGui:: namespace from anywhere (e.g. your own sources/header files)
+/*
+namespace ImGui
+{
+    void MyFunction(const char* name, MyMatrix44* mtx);
+}
+*/
+
+// Orbiter specific :
+// The ImGuiContext is owned by the main exe, libraries are importing it.
+// The ImGui code is stored in the Orbiter SDK so that modules can use it.
+struct ImGuiContext;
+
+#ifdef EXPORT_IMGUI_CONTEXT
+extern __declspec(dllexport) struct ImGuiContext* GImGui;  // Current implicit context pointer
+#else
+extern __declspec(dllimport) struct ImGuiContext* GImGui;  // Current implicit context pointer
+#endif
+
+#define GImGui GImGui

--- a/OVP/D3D9Client/CMakeLists.txt
+++ b/OVP/D3D9Client/CMakeLists.txt
@@ -2,6 +2,7 @@
 project(D3D9Client VERSION 31.0)
 
 configure_file(D3D9ClientConfig.h.in D3D9ClientConfig.h)
+FetchContent_MakeAvailable(imgui)
 
 # specify the C++ standard
 # set(CMAKE_CXX_STANDARD 11)
@@ -67,6 +68,7 @@ set(SourceFiles
 	WindowMgr.cpp
 	ZTreeMgr.cpp
 	Tilemgr2_imp.hpp
+	${imgui_SOURCE_DIR}/backends/imgui_impl_dx9.cpp
 )
 
 set(IncludeFiles
@@ -171,6 +173,8 @@ add_library(D3D9Client MODULE
 target_include_directories(D3D9Client PUBLIC
 	${ORBITER_SOURCE_SDK_INCLUDE_DIR}
 	${DXSDK_DIR}/Include
+	${imgui_SOURCE_DIR}/
+	${imgui_SOURCE_DIR}/backends/
 )
 
 target_link_directories(D3D9Client PUBLIC

--- a/OVP/D3D9Client/D3D9Client.cpp
+++ b/OVP/D3D9Client/D3D9Client.cpp
@@ -40,7 +40,9 @@
 #include "gcConst.h"
 #include <unordered_map>
 #include <d3d9on12.h>
-
+#include "imgui.h"
+#include "imgui_impl_dx9.h"
+#include "imgui_impl_win32.h"
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1700 ) // Microsoft Visual Studio Version 2012 and lower
 #define round(v) floor(v+0.5)
@@ -2723,6 +2725,40 @@ bool D3D9Client::clbkFilterElevation(OBJHANDLE hPlanet, int ilat, int ilng, int 
 {
 	_TRACE;
 	return FilterElevationPhysics(hPlanet, lvl, ilat, ilng, elev_res, elev);
+}
+void D3D9Client::clbkImGuiNewFrame()
+{
+	_TRACE;
+	ImGui_ImplDX9_NewFrame();
+}
+void D3D9Client::clbkImGuiRenderDrawData()
+{
+	_TRACE;
+
+	if (pDevice->BeginScene() >= 0)
+	{
+		ImGui::Render();
+		ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+		pDevice->EndScene();
+	}
+
+	// Update and Render additional Platform Windows
+	ImGuiIO& io = ImGui::GetIO();
+	if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+	{
+		ImGui::UpdatePlatformWindows();
+		ImGui::RenderPlatformWindowsDefault();
+	}
+}
+void D3D9Client::clbkImGuiInit()
+{
+	_TRACE;
+	ImGui_ImplDX9_Init(pDevice);
+}
+void D3D9Client::clbkImGuiShutdown()
+{
+	_TRACE;
+	ImGui_ImplDX9_Shutdown();
 }
 
 // =======================================================================

--- a/OVP/D3D9Client/D3D9Client.h
+++ b/OVP/D3D9Client/D3D9Client.h
@@ -1037,6 +1037,10 @@ public:
 	bool clbkFilterElevation(OBJHANDLE hPlanet, int ilat, int ilng, int lvl, double elev_res, INT16* elev);
 	// @}
 
+	void clbkImGuiNewFrame() override;
+	void clbkImGuiRenderDrawData() override;
+	void clbkImGuiInit() override;
+	void clbkImGuiShutdown() override;
 
 	HWND				GetRenderWindow () const { return hRenderWnd; }
 	CD3DFramework9 *    GetFramework() const { return pFramework; }

--- a/Orbitersdk/include/GraphicsAPI.h
+++ b/Orbitersdk/include/GraphicsAPI.h
@@ -1481,6 +1481,11 @@ public:
 	virtual bool clbkFilterElevation(OBJHANDLE hPlanet, int ilat, int ilng, int lvl, double elev_res, INT16* elev) { return false; }
 	// @}
 
+	virtual void clbkImGuiNewFrame () = 0;
+	virtual void clbkImGuiRenderDrawData () = 0;
+	virtual void clbkImGuiInit () = 0;
+	virtual void clbkImGuiShutdown() = 0;
+
 protected:
 	/** \brief Launchpad video tab indicator
 	 *
@@ -2055,5 +2060,21 @@ private:
 OAPIFUNC bool oapiRegisterGraphicsClient (oapi::GraphicsClient *gc);
 
 OAPIFUNC bool oapiUnregisterGraphicsClient (oapi::GraphicsClient *gc);
+
+class OAPIFUNC DialogImGui {
+public:
+	virtual ~DialogImGui() = default;
+	bool IsActive() { return active; }
+	void Activate() { active = true; }
+	void Display() {
+		Draw();
+		if (!active) OnClose();
+	}
+	virtual void OnClose() {};
+private:
+	virtual void Draw() = 0;
+protected:
+	bool active = false;
+};
 
 #endif // !__GRAPHICSAPI_H

--- a/Src/Orbiter/CMakeLists.txt
+++ b/Src/Orbiter/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # SAFESEH linker flag must be turned off because the DX7 libraries don't support it'
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -SAFESEH:NO")
+FetchContent_MakeAvailable(imgui)
 
 # Sources for all Orbiter executable targets
 set(common_src
@@ -119,6 +120,7 @@ set(common_src
 # Resources
 	Orbiter.rc
 	Orbiter.ico
+	${imgui_SOURCE_DIR}/backends/imgui_impl_win32.cpp
 )
 
 set(Orbiter_includes
@@ -162,7 +164,7 @@ set_target_properties(Orbiter
 	FOLDER Core
 )
 
-target_include_directories(Orbiter PUBLIC ${Orbiter_includes})
+target_include_directories(Orbiter PUBLIC ${Orbiter_includes} ${imgui_SOURCE_DIR}/ ${imgui_SOURCE_DIR}/backends)
 
 target_link_libraries(Orbiter ${Orbiter_common_libs} ${Orbiter_libs})
 

--- a/Src/Orbiter/Mfd.h
+++ b/Src/Orbiter/Mfd.h
@@ -21,6 +21,7 @@
 #include "Vessel.h"
 #include "Element.h"
 #include "Select.h"
+#include <d3d.h>
 
 #define ELN 256           // polygon resolution for orbit trajectory
 #define ELNH (ELN/2)
@@ -42,8 +43,6 @@ public:
 };
 
 class Pane;
-class InputBox;
-class Select;
 class oapi::GraphicsClient;
 
 static char work_kstate[256];

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -761,10 +761,11 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 		pDlgMgr = new DialogManager (this, hRenderWnd);
 
 		// global dialog resources
-		InlineDialog::GlobalInit (gclient);
-		g_select = new Select (gclient, hRenderWnd); TRACENEW
-		g_input = new InputBox (gclient, hRenderWnd, 256); TRACENEW
-		
+		g_select = new Select(); TRACENEW
+		pDlgMgr->AddEntry(g_select);
+		g_input = new InputBox(); TRACENEW
+		pDlgMgr->AddEntry(g_input);
+
 		// playback screen annotation manager
 		snote_playback = gclient->clbkCreateAnnotation ();
 	}
@@ -899,7 +900,6 @@ void Orbiter::CloseSession ()
 			snote = NULL;
 			nsnote = 0;
 		}
-		InlineDialog::GlobalExit (gclient);
 
 		if (g_input)  { delete g_input; g_input = 0; }
 		if (g_select) { delete g_select; g_select = 0; }
@@ -1775,8 +1775,6 @@ VOID Orbiter::Output2DData ()
 		for (DWORD i = 0; i < nsnote; i++)
 			snote[i]->Render();
 		if (snote_playback && pConfig->CfgRecPlayPrm.bShowNotes) snote_playback->Render();
-		if (g_select->IsActive()) g_select->Display(0/*oclient->m_pddsRenderTarget*/);
-		if (g_input->IsActive()) g_input->Display(0/*oclient->m_pddsRenderTarget*/);
 	}
 }
 
@@ -2506,10 +2504,6 @@ bool Orbiter::MouseEvent (UINT event, DWORD state, DWORD x, DWORD y)
 	if (event == WM_MOUSEMOVE) return false; // may be lifted later
 
 	if (bRunning) {
-		if (event == WM_LBUTTONDOWN || event == WM_RBUTTONDOWN) {
-			if (g_input && g_input->IsActive()) g_input->Close();
-			if (g_select && g_select->IsActive()) g_select->Clear (true);
-		}
 		if (g_pane->ProcessMouse_OnRunning (event, state, x, y, simkstate)) return true;
 	}
 	if (g_pane->ProcessMouse_System(event, state, x, y, simkstate)) return true;
@@ -2564,50 +2558,19 @@ LRESULT Orbiter::MsgProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	if (ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam))
 		return true;
 
-	WORD kmod;
-
 	switch (uMsg) {
 
 	case WM_ACTIVATE:
 		bActive = (wParam != WA_INACTIVE);
 		return 0;
 
-	case WM_CHAR:
-		if (ImGuiIO& io = ImGui::GetIO(); io.WantCaptureKeyboard) {
-			return 0;
-		}
-
-		// make dialogs modal to avoid complications
-		if (g_input && g_input->IsActive()) {
-			if (g_input->ConsumeKey (uMsg, wParam) != Select::key_ignore) bRenderOnce = TRUE;
-			return 0;
-		}
-		if (g_select && g_select->IsActive()) {
-			if (g_select->ConsumeKey (uMsg, wParam) != Select::key_ignore) bRenderOnce = TRUE;
-			return 0;
-		}
-		break;
-
 	// *** User Keyboard Input ***
+	case WM_CHAR:
 	case WM_KEYDOWN:
 		if (ImGuiIO& io = ImGui::GetIO(); io.WantCaptureKeyboard) {
 			return 0;
 		}
 
-		// modifiers
-		kmod = 0;
-		if (GetKeyState (VK_SHIFT)   & 0x8000) kmod |= 0x01;
-		if (GetKeyState (VK_CONTROL) & 0x8000) kmod |= 0x02;
-
-		// make dialogs modal to avoid complications
-		if (g_input && g_input->IsActive()) {
-			if (g_input->ConsumeKey (uMsg, wParam, kmod) != Select::key_ignore) bRenderOnce = TRUE;
-			return 0;
-		}
-		if (g_select && g_select->IsActive()) {
-			if (g_select->ConsumeKey (uMsg, wParam, kmod) != Select::key_ignore) bRenderOnce = TRUE;
-			return 0;
-		}
 		break;
 
 	// Mouse event handler

--- a/Src/Orbiter/Select.cpp
+++ b/Src/Orbiter/Select.cpp
@@ -1,855 +1,172 @@
 // Copyright (c) Martin Schweiger
 // Licensed under the MIT License
 
-#define STRICT 1
-
-#include <stdio.h>
-#include <string.h>
-#include "Orbiter.h"
-#include "Config.h"
 #include "Select.h"
-#include "Util.h"
-#include "Log.h"
+#include "imgui.h"
 
-using std::max;
-
-extern Orbiter *g_pOrbiter;
-extern char DBG_MSG[256];
-COLORREF titlecol   = RGB(255,255,255);
-COLORREF enablecol  = RGB(210,210,210);
-COLORREF disablecol = RGB(130,130,130);
-COLORREF enablehi   = RGB(255,255,255);
-COLORREF disablehi  = RGB(150,150,150);
-COLORREF markcol    = RGB(96,96,96);
-
-// =======================================================================
-// local prototypes
-
-//SURFHANDLE AllocSurface (oapi::GraphicsClient *gc, int w, int h);
-void ReleaseSurface (LPDIRECTDRAWSURFACE7 &surf);
-void ClearSurface (oapi::GraphicsClient *gc, SURFHANDLE surf, int h = 0);
-
-// =======================================================================
-// Base class for inline dialog box resources
-
-struct InlineDialog::DRAWRESRC InlineDialog::draw = {0,0,0,0,0};
-
-InlineDialog::InlineDialog (oapi::GraphicsClient *gclient, HWND hwnd)
-{
-	gc = gclient;
-	hWnd = hwnd;
-};
-
-InlineDialog::~InlineDialog()
-{
+Select::Select() {
+    active = false;
+    opened = false;
+    title = "Selection";
+    currententry = nullptr;
 }
 
-void InlineDialog::GlobalInit (oapi::GraphicsClient *gclient)
-{
-	if (!gclient) return; // sanity check
+void Select::Open(const char *_title, Callbk submenu_cbk, Callbk enter_cbk, void *_userdata, int cntx, int cnty) {
+    title = _title;
 
-	draw.pen1 = gclient->clbkCreatePen (1, 0, 0x808080);
-	draw.pen2 = gclient->clbkCreatePen (1, 0, 0xFFFFFF);
-	draw.brushMark = gclient->clbkCreateBrush (markcol);
+    cbSubmenu = submenu_cbk;
+    cbEnter = enter_cbk;
+    userdata = _userdata;
 
-	DWORD viewH = g_pOrbiter->ViewH();
-	double scale = g_pOrbiter->Cfg()->CfgFontPrm.dlgFont_Scale;
-	char *face1 = g_pOrbiter->Cfg()->CfgFontPrm.dlgFont1_Face;
+    rootmenu.clear();
+    currententry = &rootmenu;
 
-	draw.fontH = (int)(viewH*0.02*scale);
-	if (draw.fontH < 8) draw.fontH = 8;
-	draw.fontNorm = gclient->clbkCreateFont (draw.fontH, true, face1);
-	draw.fontInactive = gclient->clbkCreateFont (draw.fontH, true, face1, FONT_ITALIC);
-	draw.fontInput = gclient->clbkCreateFont (draw.fontH, false, "Courier New");
+    submenu_cbk(this, 0, nullptr, _userdata);
+    opened = true;
+    active = true;
 }
 
-void InlineDialog::GlobalExit (oapi::GraphicsClient *gclient)
-{
-	if (draw.pen1)         gclient->clbkReleasePen (draw.pen1);
-	if (draw.pen2)         gclient->clbkReleasePen (draw.pen2);
-	if (draw.brushMark)    gclient->clbkReleaseBrush (draw.brushMark);
-	if (draw.fontNorm)     gclient->clbkReleaseFont (draw.fontNorm);
-	if (draw.fontInactive) gclient->clbkReleaseFont (draw.fontInactive);
-	if (draw.fontInput)    gclient->clbkReleaseFont (draw.fontInput);
+void Select::Append(const char *str, int flags) {
+    SelectEntry e;
+    e.m_Flags = flags;
+    e.m_Text = str;
+
+    currententry->emplace_back(e);
 }
 
-// =======================================================================
-// menu dialog box
+void Select::AppendSeparator() {
+    SelectEntry e;
+    e.m_Flags = ITEM_SEPARATOR;
 
-Select::Select (oapi::GraphicsClient *gclient, HWND hwnd): InlineDialog (gclient, hwnd)
-{
-	alen = llen = level = 0;
-	cbk_submenu = 0;
-	cbk_enter = 0;
-	cntx = cnty = -1;
-	surf = 0;
-	Clear ();
-	lineh = draw.fontH;
-	arrow = lineh/3;
+    currententry->emplace_back(e);
 }
 
-Select::~Select ()
-{
-	if (alen) {
-		for (int i = 0; i < alen; i++) {
-			delete []buf[i];
-			buf[i] = NULL;
-		}
-		delete []buf;
-		buf = NULL;
-		delete []buflen;
-		buflen = 0;
-	}
-	if (llen) {
-		for (int i = 0; i < llen; i++) {
-			delete []lbuf[i];
-			lbuf[i] = NULL;
-		}
-		delete []lbuf;
-		lbuf = NULL;
-		delete []lbuflen;
-		lbuflen = 0;
-		delete []lcur;
-		lcur = 0;
-	}
+void Select::DrawMenu(std::list<SelectEntry>& entries) {
+    int i = 0;
+    for (auto& e : entries) {
+        if (e.m_Flags & ITEM_SEPARATOR) {
+            ImGui::Separator();
+        }
+        else if (e.m_Flags & ITEM_SUBMENU) {
+            if (e.m_SubEntries.size() == 0) {
+                currententry = &e.m_SubEntries;
+                cbSubmenu(this, i, const_cast<char*>(e.m_Text.c_str()), userdata);
+            }
+            if (ImGui::BeginMenu(e.m_Text.c_str(), e.m_SubEntries.size() != 0)) {
+                DrawMenu(e.m_SubEntries);
+                ImGui::EndMenu();
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_RectOnly) && !(e.m_Flags & ITEM_NOHILIGHT)) {
+                    if (ImGui::IsMouseReleased(0)) {
+                        cbEnter(this, i, const_cast<char*>(e.m_Text.c_str()), userdata);
+                        active = false;
+                        ImGui::CloseCurrentPopup();
+                    }
+                }
+            }
+            i++;
+        }
+        else {
+            if (ImGui::MenuItem(e.m_Text.c_str())) {
+                cbEnter(this, i, const_cast<char*>(e.m_Text.c_str()), userdata);
+                active = false;
+            }
+            i++;
+        }
+    }
 }
 
-void Select::Activate ()
-{
-	DWORD viewW = g_pOrbiter->ViewW(), viewH = g_pOrbiter->ViewH();
-	int i, colh, itemh;
-	bool submenu = false;
-	DWORD textW;
+void Select::Draw() {
+    auto& io = ImGui::GetIO();
 
-	// remove trailing separator
-	buf[len-1][0] &= ~ITEM_SEPARATOR;
+    if (io.MouseDown[0] && opened) {
+        return;
+    }
 
-	// find width of longest entry
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (NULL);
-	if (skp) {
-		oapi::Font *nfnt, *ofnt = 0;
+    if (opened) {
+        ImGui::OpenPopup(title.c_str());
+        opened = false;
+    }
 
-		colh = 0;
-		surfw = lineh; // left and right frame borders
-		surfh = 0;
-		ncol = 0;
-		col[ncol].nitem = 0;
-		col[ncol].w = 0;
-		for (i = 0; i < len; i++) {
-			nfnt = (buf[i][0] & ITEM_NOHILIGHT ? draw.fontInactive : draw.fontNorm);
-			if (nfnt != ofnt) skp->SetFont (ofnt = nfnt);
-			textW = skp->GetTextWidth (buf[i]+1);
-			itemh = (buf[i][0] & ITEM_SEPARATOR ? lineh+3 : lineh);
-			if (colh + itemh + 2*lineh > viewH) { // new column
-				if (submenu) col[ncol].w += lineh/2+arrow;
-				surfw += col[ncol].w + lineh; // column and vertical divider
-				ncol++;
-				col[ncol].w = textW;
-				surfh = max (surfh, colh);
-				colh = itemh;
-				submenu = false;
-			} else {
-				col[ncol].w = max (col[ncol].w, (int)textW);
-				colh += itemh;
-			}
-			col[ncol].nitem++;
-			if (buf[i][0] & ITEM_SUBMENU) submenu = true;
-		}
-		if (submenu) col[ncol].w += lineh/2+arrow;
-		surfw += col[ncol].w;
-		surfh = max (surfh, colh) + lineh + 4;
-
-		if (ofnt != draw.fontNorm) skp->SetFont (draw.fontNorm);
-		textW = skp->GetTextWidth (title);
-		if (textW+lineh > surfw) surfw = textW+lineh;
-		gc->clbkReleaseSketchpad (skp);
-	}
-
-	X0 = (cntx >= 0 ? cntx : viewW/2) - surfw/2;
-	if      (X0 < 0)              X0 = 0;
-	else if (X0+surfw >= viewW) X0 = viewW-surfw-1;
-	Y0 = (cnty >= 0 ? cnty : viewH/2) - surfh/2;
-	if      (Y0 < 0)              Y0 = 0;
-	else if (Y0+surfh >= viewH) Y0 = viewH-surfh-1;
-
-	// allocate and init surface
-	surf = gc->clbkCreateSurface (surfw, surfh);
-	RefreshSurface ();
-	SetFocus (g_pOrbiter->GetRenderWnd());
+    if (ImGui::BeginPopup(title.c_str()))
+    {
+        ImGui::TextUnformatted(title.c_str());
+        ImGui::Separator();
+        DrawMenu(rootmenu);
+        ImGui::EndPopup();
+    }
+    else {
+        active = false;
+    }
 }
 
-void Select::Open (const char *_title, Callbk submenu_cbk, Callbk enter_cbk,
-				   void *_userdata, int _cntx, int _cnty)
-{
-	if (surf) Clear (true); // this line was commented. why?
-	SetTitle (_title);
-	SetSubmenuCallback (submenu_cbk);
-	SetEnterCallback (enter_cbk);
-	userdata = _userdata;
-	cntx = _cntx, cnty = _cnty;
-	submenu_cbk (this, 0, 0, userdata);
-	Activate ();
+InputBox::InputBox() {
+    active = false;
+    opened = false;
+    title = "InputBox";
 }
 
-void Select::Clear (bool resetlevel)
+void InputBox::Open(const char *_title, char *_buf, int _vislen,
+    Callbk cbk, void *_userdata, int cntx, int cnty)
 {
-	len = 0; // keep buffered entries around
-	cur = 0;
-	listw = listh = 0;
-	if (resetlevel) level = 0;
-	if (surf) {
-		gc->clbkReleaseSurface (surf);
-		surf = 0;
-	}
+    OpenEx(_title, _buf, _vislen, cbk, 0, _userdata, 0, cntx, cnty);
 }
 
-void Select::MarkItem (int item)
-{
-	gc->clbkFillSurface (surf, 0, item*lineh, surfw, lineh,
-		gc->clbkGetDeviceColour (0x80, 0x80, 0x80));
-	//RECT r = {0, item*lineh, surfw, item*lineh+lineh};
-	//DDBLTFX bltfx;
-	//ZeroMemory (&bltfx, sizeof(bltfx));
-	//bltfx.dwSize = sizeof(bltfx);
-	//bltfx.dwFillColor = GetSurfColour (0x80,0x80,0x80);
-	//surf->Blt (&r, NULL, NULL, DDBLT_COLORFILL, &bltfx);
+bool InputBox::OpenEx(const char *_title, char *_buf, int _vislen,
+    Callbk enter_cbk, Callbk cancel_cbk, void *_userdata,
+    int flags, int cntx, int cnty) {
+
+    title = _title;
+
+    cbEnter = enter_cbk;
+    cbCancel = cancel_cbk;
+    userdata = _userdata;
+
+    opened = true;
+    active = true;
+
+    if (_buf)
+        strcpy(inputbuf, _buf);
+    else
+        inputbuf[0] = '\0';
+
+    return true;
 }
 
-void Select::Display (LPDIRECTDRAWSURFACE7 pdds)
-{
-	if (!surf) return; // sanity check
-	gc->clbkBlt (0, X0, Y0, surf, 0);
-}
+void InputBox::Draw() {
+    char buf[256];
+    sprintf(buf, "%s###InputBox", title.c_str());
 
-void Select::RefreshSurface ()
-{
-	if (!surf) return; // sanity check
-	ClearSurface (gc, surf, lineh);
+    bool firstTime = false;
+    if (opened) {
+        ImGui::OpenPopup(buf);
+        opened = false;
+        firstTime = true;
+    }
 
-	// draw list
-	int i, cl, item0, item1, ay, x = lineh/2, y = 2;
-	int subx = surfw-lineh/2-arrow;
-	oapi::Font *ofnt, *nfnt;
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (surf);
-	if (skp) {
-		skp->SetFont (ofnt = draw.fontNorm);
-		skp->SetBackgroundMode (oapi::Sketchpad::BK_TRANSPARENT);
-		skp->SetTextColor (titlecol);
-		skp->SetPen (draw.pen1);
-		skp->Text (x, y-1, title, strlen(title)), y += lineh;
-		cl = 0;
-		item0 = 0; item1 = col[0].nitem;
-		for (i = 0; i < len; i++) {
-			nfnt = (buf[i][0] & ITEM_NOHILIGHT ? draw.fontInactive : draw.fontNorm);
-			if (nfnt != ofnt) skp->SetFont (ofnt = nfnt);
-			if (i == item1) {
-				skp->Line (x + col[cl].w + lineh/2, lineh+2, x + col[cl].w + lineh/2, surfh);
-				x += col[cl].w + lineh;
-				subx += col[cl].w + lineh;
-				y = 2+lineh;
-				item0 = item1;
-				item1 += col[++cl].nitem;
-			}
-			if (i == cur) {
-				int x0 = x-lineh/2;
-				int x1 = (cl == ncol ? surfw : x0+col[cl].w+lineh);
-				oapi::Brush *pbrush = skp->SetBrush (draw.brushMark);
-				skp->Rectangle (x0+2, y, x1-2, y+lineh);
-				skp->SetBrush (pbrush);
-			}
-			if (i == cur) skp->SetTextColor (buf[i][0] & ITEM_NOHILIGHT ? disablehi : enablehi);
-			else          skp->SetTextColor (buf[i][0] & ITEM_NOHILIGHT ? disablecol : enablecol);
-			skp->Text (x, y, buf[i]+1, strlen (buf[i]+1));
+    if (ImGui::BeginPopup(buf))
+    {
+        ImGui::TextUnformatted(title.c_str());
+        ImGui::Separator();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (firstTime)
+            ImGui::SetKeyboardFocusHere();
+        bool entered = ImGui::InputText("##InputText", inputbuf, IM_ARRAYSIZE(inputbuf), ImGuiInputTextFlags_EnterReturnsTrue);
 
-			if (buf[i][0] & ITEM_SUBMENU) { // submenu indicator
-				ay = y+lineh/2;
-				skp->MoveTo (subx, ay-arrow);
-				if (i == cur) skp->SetPen (draw.pen2);
-				skp->LineTo (subx+arrow, ay);
-				skp->LineTo (subx, ay+arrow);
-				skp->LineTo (subx, ay-arrow);
-				if (i == cur) skp->SetPen (draw.pen1);
-			}
-			y += lineh;
-			if (buf[i][0] & ITEM_SEPARATOR) { // separator indicator
-				skp->Line (0, y+1, surfw, y+1);
-				y += 3;
-			}
-		}
-		skp->Rectangle (0, 0, surfw, surfh);
-		gc->clbkReleaseSketchpad (skp);
-	}
-}
-
-int Select::Append (const char *_str, BYTE flag)
-{
-	if (len == alen) { // need to allocate new entry
-		char **ctmp = new char*[alen+1]; TRACENEW
-		memcpy (ctmp, buf, alen*sizeof(char*));
-		if (alen) delete []buf;
-		buf = ctmp;
-		int *itmp = new int[alen+1]; TRACENEW
-		memcpy (itmp, buflen, alen*sizeof(int));
-		if (alen) delete []buflen;
-		buflen = itmp;
-		buflen[alen++] = 0;
-	}
-	int nlen = strlen (_str)+2; // reserve space for flag and EOL
-	if (buflen[len] < nlen) { // need to (re)allocate space for entry
-		if (buflen[len]) delete []buf[len];
-		buf[len] = new char[buflen[len] = nlen]; TRACENEW
-	}
-	memcpy (buf[len]+1, _str, nlen-1);
-	buf[len][0] = (char)flag;
-	listh += lineh;
-	if (flag & ITEM_SEPARATOR) listh += 3;
-	return len++;
-}
-
-void Select::AppendSeparator ()
-{
-	if (!len) return;
-	if (buf[len-1][0] & ITEM_SEPARATOR) return; // got a separator already
-	buf[len-1][0] |= ITEM_SEPARATOR;
-	listh += 3;
-}
-
-void Select::SetTitle (const char *_title)
-{
-	strncpy(title, _title, select_strlen);
-	title[select_strlen - 1] = '\0';
-}
-
-void Select::Push ()
-{
-	if (level == llen) { // grow stack
-		char **ctmp = new char*[llen+1]; TRACENEW
-		memcpy (ctmp, lbuf, llen*sizeof(char*));
-		if (llen) delete []lbuf;
-		lbuf = ctmp;
-		int *itmp = new int[llen+1]; TRACENEW
-		memcpy (itmp, lbuflen, llen*sizeof(int));
-		if (llen) delete []lbuflen;
-		lbuflen = itmp;
-		lbuflen[llen] = 0;
-		itmp = new int[llen+1]; TRACENEW
-		memcpy (itmp, lcur, llen*sizeof(int));
-		if (llen) delete []lcur;
-		lcur = itmp;
-		llen++;
-	}
-	if (lbuflen[level] < buflen[cur]) { // grow stack entry
-		if (lbuflen[level]) delete lbuf[level];
-		lbuf[level] = new char[lbuflen[level] = buflen[cur]]; TRACENEW
-	}
-	memcpy (lbuf[level], buf[cur], buflen[cur]);
-	lcur[level++] = cur;
-}
-
-void Select::Pop ()
-{
-	if (!level) return; // sanity check
-	cur = lcur[--level];
-}
-
-int Select::ConsumeKey (UINT uMsg, WPARAM wParam, WORD mod)
-{
-	if (!IsActive() || uMsg != WM_KEYDOWN || mod) return key_ignore;
-
-	switch (wParam) {
-	case VK_RETURN:
-		if (!(buf[cur][0] & ITEM_NOHILIGHT) &&
-			(!cbk_enter || cbk_enter (this, cur, buf[cur]+1, userdata))) {
-			Clear (true);
-			return key_ok;
-		} else return key_consume;
-	case VK_ESCAPE:
-		Clear (true);
-		return key_cancel;
-	case VK_DOWN:
-		if (cur < len-1) {
-			cur++;
-			RefreshSurface ();
-		}
-		return key_consume;
-	case VK_UP:
-		if (cur > 0) {
-			cur--;
-			RefreshSurface ();
-		}
-		return key_consume;
-	case VK_RIGHT:
-		if ((buf[cur][0] & ITEM_SUBMENU) && cbk_submenu) {
-			Push (); // push current level to stack
-			Clear ();
-			if (cbk_submenu (this, lcur[level-1], lbuf[level-1]+1, userdata)) {
-				Activate ();
-				return key_consume;
-			}
-		} else return key_ignore;
-		// fall through
-	case VK_LEFT:
-		if (level && cbk_submenu) {
-			Clear ();
-			Pop (); // get previous level from stack
-			if (level) cbk_submenu (this, lcur[level-1], lbuf[level-1]+1, userdata);
-			else       cbk_submenu (this, 0, 0, userdata);  // main menu
-			Activate ();
-		}
-		return key_consume;
-	default:
-		return key_ignore;
-	}
-}
-
-// =======================================================================
-
-SelectionList::SelectionList (oapi::GraphicsClient *gclient, HWND hwnd): InlineDialog (gclient, hwnd)
-{
-	clbk = 0;
-	userdata = 0;
-	listflag = 0;
-	list = 0;
-	nlist = 0;
-	title = 0;
-	lineh = draw.fontH;
-	arrow = lineh/3;
-	surf = 0;
-	cur = 0;
-}
-
-void SelectionList::Open (LISTENTRY *_list, DWORD _nlist, char *_title, Listentry_clbk _clbk,
-	DWORD flag, void *_userdata)
-{
-	Clear ();
-
-	clbk = _clbk;
-	userdata = _userdata;
-	listflag = flag;
-	list = new LISTENTRY[nlist = _nlist];
-	memcpy (list, _list, nlist*sizeof(LISTENTRY));
-
-	if (_title) {
-		title = new char[strlen(_title)+1];
-		strcpy (title, _title);
-	}
-
-	AllocSurface();
-}
-
-void SelectionList::Clear ()
-{
-	clbk = 0;
-	userdata = 0;
-	listflag = 0;
-	if (nlist) {
-		delete []list;
-		list = 0;
-		nlist = 0;
-	}
-	if (title) {
-		delete []title;
-		title = 0;
-	}
-	if (surf) {
-		gc->clbkReleaseSurface (surf);
-		surf = 0;
-	}
-}
-
-void SelectionList::AllocSurface ()
-{
-	DWORD viewW = g_pOrbiter->ViewW(), viewH = g_pOrbiter->ViewH();
-	int colh, itemh;
-	DWORD i, textw;
-	bool submenu = false;
-
-	// remove trailing separator
-	list[nlist-1].flag &= ~LISTENTRY_SEPARATOR;
-
-	// find width of longest entry
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (NULL);
-	if (skp) {
-		oapi::Font *nfnt, *ofnt = 0;
-		colh = 0;
-		surfw = lineh;
-		surfh = 0;
-		ncol = 0;
-		col[ncol].nitem = 0;
-		col[ncol].w = 0;
-		for (i = 0; i < nlist; i++) {
-			nfnt = (list[i].flag & LISTENTRY_INACTIVE ? draw.fontInactive : draw.fontNorm);
-			if (nfnt != ofnt) skp->SetFont (ofnt = nfnt);
-			textw = skp->GetTextWidth (list[i].name);
-			itemh = (list[i].flag & LISTENTRY_SEPARATOR ? lineh+3 : lineh);
-			if (colh + itemh + 2*lineh > viewH) { // new column
-				if (submenu) col[ncol].w += lineh/2+arrow;
-				surfw += col[ncol].w + lineh; // column and vertical divider
-				ncol++;
-				col[ncol].w = textw;
-				surfh = max (surfh, colh);
-				colh = itemh;
-				submenu = false;
-			} else {
-				col[ncol].w = max ((DWORD)col[ncol].w, textw);
-				colh += itemh;
-			}
-			col[ncol].nitem++;
-			if (list[i].flag & LISTENTRY_SUBITEM) submenu = true;
-		}
-		if (submenu) col[ncol].w += lineh/2+arrow;
-		surfw += col[ncol].w;
-		surfh = max (surfh, colh) + lineh + 4;
-
-		if (ofnt != draw.fontNorm) skp->SetFont (draw.fontNorm);
-		textw = skp->GetTextWidth (title);
-		if (textw+lineh > surfw) surfw = textw+lineh;
-		gc->clbkReleaseSketchpad (skp);
-	}
-
-	surfx = viewW/2 - surfw/2;
-	if      (surfx < 0)            surfx = 0;
-	else if (surfx+surfw >= viewW) surfx = viewW-surfw-1;
-	surfy = viewH/2 - surfh/2;
-	if      (surfy < 0)            surfy = 0;
-	else if (surfy+surfh >= viewH) surfy = viewH-surfh-1;
-
-	if (surf) gc->clbkReleaseSurface (surf);
-	surf = gc->clbkCreateSurface (surfw, surfh);
-}
-
-void SelectionList::RefreshSurface ()
-{
-	if (!surf) return; // sanity check
-	ClearSurface (gc, surf, lineh);
-
-	// draw list
-	int i, cl, item0, item1, ay, x = lineh/2, y = 2;
-	int subx = surfw-lineh/2-arrow;
-	oapi::Font *ofnt, *nfnt;
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (surf);
-	if (skp) {
-		skp->SetFont (ofnt = draw.fontNorm);
-		skp->SetBackgroundMode (oapi::Sketchpad::BK_TRANSPARENT);
-		skp->SetTextColor (titlecol);
-		skp->SetPen (draw.pen1);
-		skp->Text (x, y-1, title, strlen(title)), y += lineh;
-		cl = 0;
-		item0 = 0; item1 = col[0].nitem;
-		for (i = 0; i < nlist; i++) {
-			nfnt = (list[i].flag & LISTENTRY_INACTIVE ? draw.fontInactive : draw.fontNorm);
-			if (nfnt != ofnt) skp->SetFont (ofnt = nfnt);
-			if (i == item1) {
-				skp->Line (x + col[cl].w + lineh/2, lineh+2, x + col[cl].w + lineh/2, surfh);
-				x += col[cl].w + lineh;
-				subx += col[cl].w + lineh;
-				y = 2+lineh;
-				item0 = item1;
-				item1 += col[++cl].nitem;
-			}
-			if (i == cur) {
-				int x0 = x-lineh/2;
-				int x1 = (cl == ncol ? surfw : x0+col[cl].w+lineh);
-				oapi::Brush *pbrush = skp->SetBrush (draw.brushMark);
-				skp->Rectangle (x0+2, y, x1-2, y+lineh);
-				skp->SetBrush (pbrush);
-			}
-			if (i == cur) skp->SetTextColor (list[i].flag & LISTENTRY_INACTIVE ? disablehi : enablehi);
-			else          skp->SetTextColor (list[i].flag & LISTENTRY_INACTIVE ? disablecol : enablecol);
-			skp->Text (x, y, list[i].name, strlen (list[i].name));
-
-			if (list[i].flag & LISTENTRY_SUBITEM) { // submenu indicator
-				ay = y+lineh/2;
-				skp->MoveTo (subx, ay-arrow);
-				if (i == cur) skp->SetPen (draw.pen2);
-				skp->LineTo (subx+arrow, ay);
-				skp->LineTo (subx, ay+arrow);
-				skp->LineTo (subx, ay-arrow);
-				if (i == cur) skp->SetPen (draw.pen1);
-			}
-			y += lineh;
-			if (list[i].flag & LISTENTRY_SEPARATOR) { // separator indicator
-				skp->Line (0, y+1, surfw, y+1);
-				y += 3;
-			}
-		}
-		skp->Rectangle (0, 0, surfw, surfh);
-		gc->clbkReleaseSketchpad (skp);
-	}
-}
-
-// =======================================================================
-
-InputBox::InputBox (oapi::GraphicsClient *gclient, HWND hwnd, int _buflen): InlineDialog (gclient, hwnd)
-{
-	buflen = _buflen;
-	titlelen = 20; // can grow as required
-	title = new char[titlelen+1];  title[0] = '\0'; TRACENEW
-	buf   = new char[buflen+1];    buf[0] = '\0';   TRACENEW
-	slen = vis0 = cur = 0;
-	vislen = 20;   // arbitrary default
-	surf = 0;
-	cbk_enter = 0;
-	cbk_cancel = 0;
-	userdata = 0;
-	lineh  = draw.fontH;
-	cw     = g_gdires->dlgF2W;  // replace this!
-}
-
-InputBox::~InputBox ()
-{
-	delete []buf;
-	buf = NULL;
-	delete []title;
-	title = NULL;
-}
-
-void InputBox::SetTitle (const char *_title)
-{
-	int len = (_title ? strlen(_title) : 0);
-	if (len > titlelen) {
-		if (titlelen) delete []title;
-		title = new char[(titlelen=len)+1]; TRACENEW
-	}
-	if (len) strcpy (title, _title);
-	else title[0] = '\0';
-}
-
-void InputBox::InitBuffer (int _vislen, char *_buf)
-{
-	vislen = _vislen;
-	vis0 = 0;
-	if (_buf) {
-		slen = cur = strlen(_buf);
-		strcpy (buf, _buf);
-	} else {
-		slen = cur = 0;
-		buf[0] = '\0';
-	}
-}
-
-void InputBox::Activate (int cntx, int cnty)
-{
-	DWORD viewW = g_pOrbiter->ViewW(), viewH = g_pOrbiter->ViewH();
-	DWORD textW;
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (NULL);
-	if (skp) {
-		skp->SetFont (draw.fontNorm);
-		textW = skp->GetTextWidth (title);
-		surfw = textW + lineh;
-		boxw = cw*vislen;
-		if (boxw+lineh > surfw) surfw = boxw+lineh;
-		surfh = 4*lineh;
-		gc->clbkReleaseSketchpad (skp);
-	}
-	X0 = (cntx >= 0 ? cntx : viewW/2) - surfw/2;
-	if      (X0 < 0)              X0 = 0;
-	else if (X0+surfw >= viewW) X0 = viewW-surfw-1;
-	Y0 = (cnty >= 0 ? cnty : viewH/2) - surfh/2;
-	if      (Y0 < 0)              Y0 = 0;
-	else if (Y0+surfh >= viewH) Y0 = viewH-surfh-1;
-
-	// allocate and init surface
-	if (surf) gc->clbkReleaseSurface (surf);
-	surf = gc->clbkCreateSurface (surfw, surfh);
-	RefreshSurface ();
-}
-
-void InputBox::Open (const char *_title, char *_buf, int _vislen,
-					 Callbk cbk, void *_userdata, int cntx, int cnty)
-{
-	OpenEx (_title, _buf, _vislen, cbk, 0, _userdata, 0, cntx, cnty);
-}
-
-bool InputBox::OpenEx (const char *_title, char *_buf, int _vislen,
-					 Callbk enter_cbk, Callbk cancel_cbk, void *_userdata, DWORD flags, int cntx, int cnty)
-{
-	if (surf) {
-		if (flags & USRINPUT_NEEDANSWER) return false;
-		// can't open new input box if currently open one requires an answer
-		if (cbk_cancel) cbk_cancel (this, buf, userdata);
-		Close();
-	}
-	SetTitle (_title);
-	InitBuffer (_vislen, _buf);
-	SetEnterCallback (enter_cbk);
-	cbk_cancel = cancel_cbk;
-	flag = flags;
-	userdata = _userdata;
-	Activate (cntx, cnty);
-	return true;
-}
-
-bool InputBox::Close (bool onEnter)
-{
-	if (!onEnter && (flag & USRINPUT_NEEDANSWER)) return false;
-	if (surf) {
-		gc->clbkReleaseSurface (surf);
-		surf = 0;
-	}
-	userdata = 0;
-	return true;
-}
-
-void InputBox::RefreshSurface ()
-{
-	if (!surf) return; // sanity check
-	ClearSurface (gc, surf, lineh);
-
-	oapi::Sketchpad *skp = gc->clbkGetSketchpad (surf);
-	if (skp) {
-		int x = lineh/2, y = 2;
-		skp->SetFont (draw.fontNorm);
-		skp->SetPen (draw.pen1);
-		skp->SetBackgroundMode (oapi::Sketchpad::BK_TRANSPARENT);
-		skp->SetTextColor (titlecol);
-		skp->Text (x, y-1, title, strlen(title)); y += 2*lineh;
-		skp->SetTextColor (enablecol);
-		skp->SetFont (draw.fontInput);
-		int n = slen-vis0;
-		if (n > vislen) n = vislen;
-		skp->Text (x, y, buf+vis0, n);
-		skp->SetBackgroundMode (oapi::Sketchpad::BK_OPAQUE);
-		skp->SetTextColor (0);
-		skp->Text (x+(cur-vis0)*cw, y, cur < slen ? buf+cur : " ", 1);
-		skp->Rectangle (0, 0, surfw, surfh);
-		skp->Rectangle (x-2, y-2, x+boxw+2, y+lineh+2);
-		gc->clbkReleaseSketchpad (skp);
-	}
-}
-
-void InputBox::Display (LPDIRECTDRAWSURFACE7 pdds)
-{
-	if (!surf) return; // sanity check
-	gc->clbkBlt (0, X0, Y0, surf, 0);
-	//pdds->BltFast (X0, Y0, surf, NULL, DDBLTFAST_WAIT);
-}
-
-int InputBox::ConsumeKey (UINT uMsg, WPARAM wParam, WORD mod)
-{
-	int i;
-
-	if (!IsActive()) return key_ignore;
-
-	switch (uMsg) {
-	case WM_CHAR:
-		if (isgraph(wParam) || wParam == VK_SPACE) {
-			if (slen < buflen) {
-				for (i = slen; i >= cur; i--) buf[i+1] = buf[i];
-				buf[cur] = wParam;
-				slen++;
-				if (++cur == vislen+vis0) vis0++;
-				RefreshSurface();
-			}
-			return key_consume;
-		}
-		return key_ignore;
-	case WM_KEYDOWN:
-		if (!mod) {
-			switch (wParam) {
-			case VK_RETURN:
-				if (!cbk_enter || cbk_enter (this, buf, userdata)) {
-					Close (true);
-					return key_ok;
-				} else {
-					MessageBeep (-1);
-					return key_consume;
-				}
-			case VK_ESCAPE:
-				if (flag & USRINPUT_NEEDANSWER) {
-					return key_consume;
-				} else {
-					if (cbk_cancel) cbk_cancel (this, buf, userdata);
-					Close ();
-					return key_cancel;
-				}
-			case VK_LEFT:
-				if (cur > 0) {
-					if (--cur < vis0) vis0 = cur;
-					RefreshSurface();
-				}
-				return key_consume;
-			case VK_RIGHT:
-				if (cur < slen) {
-					if (++cur == vislen+vis0) vis0++;
-					RefreshSurface();
-				}
-				return key_consume;
-			case VK_BACK:
-				if (cur > 0) {
-					for (i = cur; i <= slen; i++) buf[i-1] = buf[i];
-					slen--;
-					if (--cur < vis0) vis0 = cur;
-					RefreshSurface();
-				}
-				return key_consume;
-			case VK_DELETE:
-				if (cur < slen) {
-					for (i = cur+1; i <= slen; i++) buf[i-1] = buf[i];
-					slen--;
-					RefreshSurface();
-				}
-				return key_consume;
-			case VK_HOME:
-				if (cur > 0) {
-					cur = 0;
-					if (vis0 > 0) vis0 = 0;
-					RefreshSurface();
-				}
-				return key_consume;
-			case VK_END:
-				if (cur < slen) {
-					if ((cur = slen) >= vislen+vis0) vis0 = cur-vislen+1;
-					RefreshSurface();
-				}
-				return key_consume;
-			default:
-				// trap unmodified and shift keys
-				if (!(mod & 0x02)) return key_consume;
-				break;
-			}
-		}
-	}
-	return key_ignore;
-}
-
-// =======================================================================
-// auxiliary routines
-
-#ifdef UNDEF
-SURFHANDLE AllocSurface (oapi::GraphicsClient *gc, int w, int h)
-{
-	return NULL;
-}
-#endif
-
-void ReleaseSurface (LPDIRECTDRAWSURFACE7 &surf)
-{
-	if (surf) {
-		surf->Release ();
-		surf = 0;
-	}
-}
-
-void ClearSurface (oapi::GraphicsClient *gc, SURFHANDLE surf, int h)
-{
-	gc->clbkFillSurface (surf, gc->clbkGetDeviceColour (0x50, 0x50, 0x50));
-	//DDBLTFX bltfx;
-	//ZeroMemory (&bltfx, sizeof(bltfx));
-	//bltfx.dwSize = sizeof(bltfx);
-	//bltfx.dwFillColor = GetSurfColour (0x50,0x50,0x50);
-	//surf->Blt (NULL, NULL, NULL, DDBLT_COLORFILL, &bltfx);
-
-	if (h) { // paint title bar
-		DWORD width, height;
-		gc->clbkGetSurfaceSize (surf, &width, &height);
-		gc->clbkFillSurface (surf, 0, 0, width, h+1,
-			gc->clbkGetDeviceColour (0x60, 0x20, 0x20));
-		//DDSURFACEDESC2 ddsd;
-		//ddsd.dwSize = sizeof(ddsd);
-		//surf->GetSurfaceDesc (&ddsd);
-		//RECT r = {0, 0, ddsd.dwWidth, h+1};
-		//bltfx.dwFillColor = GetSurfColour (0x60,0x20,0x20);
-		//surf->Blt (&r, NULL, NULL, DDBLT_COLORFILL, &bltfx);
-	}
+        if (ImGui::Button("OK") || entered) {
+            cbEnter(this, inputbuf, userdata);
+            ImGui::CloseCurrentPopup();
+            active = false;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel")) {
+            if (cbCancel)
+                cbCancel(this, inputbuf, userdata);
+            ImGui::CloseCurrentPopup();
+            active = false;
+        }
+        ImGui::EndPopup();
+    }
+    else {
+        active = false;
+    }
 }

--- a/Src/Orbiter/Select.h
+++ b/Src/Orbiter/Select.h
@@ -4,215 +4,57 @@
 #ifndef __SELECT_H
 #define __SELECT_H
 
-#define STRICT 1
-#include <windows.h>
-#include <d3d.h>
 #include "OrbiterAPI.h"
 #include "GraphicsAPI.h"
+#include <list>
 
 #define ITEM_SUBMENU 0x01
 #define ITEM_NOHILIGHT 0x02
 #define ITEM_SEPARATOR 0x04
 
-const int select_strlen = 100;
-const int select_chunk = 32;
-const int select_maxlevel = 10;
-const int maxcol = 20;
-
-// =======================================================================
-// Base class for inline dialog box resources
-
-class InlineDialog {
-public:
-	InlineDialog (oapi::GraphicsClient *gclient, HWND hwnd);
-	virtual ~InlineDialog();
-
-	// initialise global drawing resources
-	static void GlobalInit (oapi::GraphicsClient *gclient);
-
-	// release global drawing resources
-	static void GlobalExit (oapi::GraphicsClient *gclient);
-
-protected:
-	static struct DRAWRESRC {  // global drawing resources
-		oapi::Pen *pen1, *pen2;
-		oapi::Brush *brushMark;
-		oapi::Font *fontNorm, *fontInactive, *fontInput;
-		int fontH;
-	} draw;
-
-	oapi::GraphicsClient *gc;  // graphics client instance
-	HWND hWnd;                 // render window handle
+struct SelectEntry {
+    int m_Flags;
+    std::string m_Text;
+    std::list<SelectEntry> m_SubEntries;
 };
 
-// =======================================================================
-// menu dialog box
-
-class Select: public InlineDialog {
+class Select : public DialogImGui {
 public:
-	Select (oapi::GraphicsClient *gclient, HWND hwnd);
-	~Select ();
-	void Activate ();
-	void Clear (bool resetlevel = false);
-	void Display (LPDIRECTDRAWSURFACE7 pdds);
-	bool IsActive() { return (len > 0); }
-	int Len() const { return len; }
-	int Cur() const { return cur; }
-	char *Str (int i) const { return buf[i]+1; }
-	int ParentCur () const { return (level > 0 ? lcur[level-1] : 0); }
-	const char *ParentStr () const { return (level > 0 ? lbuf[level-1]+1 : 0); }
-	const char *StackStr (int lev) { return (lev >= 0 && lev < level ? lbuf[lev]+1 : 0); }
-	bool HasSubmenu (int i) const { return buf[i][0] & 0x01; }
-	int Level() const { return level; }
-	int Append (const char *_str, BYTE flag = 0);
-	void AppendSeparator ();
-	void SetTitle (const char *_title);
-	const char *Title () const { return title; }
-	int ConsumeKey (UINT uMsg, WPARAM wParam, WORD mod = 0);
-	enum { key_ignore, key_consume, key_ok, key_cancel };
-	typedef bool (*Callbk)(Select*, int, char*, void*);
-	void SetSubmenuCallback (Callbk cbk) { cbk_submenu = cbk; }
-	void SetEnterCallback (Callbk cbk) { cbk_enter = cbk; }
-	
-	void Open (const char *_title = 0, Callbk submenu_cbk = 0, Callbk enter_cbk = 0,
-		void *_userdata = 0, int cntx = -1, int cnty = -1);
-	// activates the menu with the specified parameters (menu items must have
-	// been added with Append before)
+    typedef bool (*Callbk)(Select*, int, char*, void*);
+    Select();
+    void Draw() override;
+    bool opened;
+    std::string title;
+    std::list<SelectEntry> rootmenu;
+    std::list<SelectEntry> *currententry;
+    Callbk cbSubmenu;
+    Callbk cbEnter;
+    void *userdata;
 
-private:
-	void RefreshSurface ();
-	void MarkItem (int item);
-	void Push ();
-	void Pop ();
-
-	SURFHANDLE surf;  // drawing surface
-	int surfw, surfh; // surface dimensions
-	int cntx, cnty;   // centre coords
-	int X0, Y0;       // upper left corner of input box
-	int lineh;    // font height
-	int arrow;    // arrow size
-	int listw;    // pixel width of longest list entry
-	int listh;    // pixel height of full list (w/o title)
-	int len;      // number of active entries
-	int alen;     // number of allocated entries
-	struct COL {  // column specs
-		int nitem; //  # items in column
-		int w;     //   column width
-	} col[maxcol];
-	int ncol;     // # columns
-	int llen;     // level stack size
-	int level;    // current submenu level (0=top level)
-	int cur;      // selected entry index
-	int *lcur;    // entry index stack (length llen)
-	char **buf;   // array of string buffers (length alen)
-	int *buflen;  // array buffer sizes (length alen);
-	char **lbuf;  // entry stack (length llen);
-	int *lbuflen; // array of stack entry sizes (length llen)
-	char title[select_strlen];
-	void *userdata;
-	Callbk cbk_submenu;
-	Callbk cbk_enter;
+    void Open(const char *_title = 0, Callbk submenu_cbk = 0, Callbk enter_cbk = 0, void *_userdata = 0, int cntx = -1, int cnty = -1);
+    void Append(const char *str, int flags = 0);
+    void AppendSeparator();
+    void DrawMenu(std::list<SelectEntry>& entries);
 };
 
-// =======================================================================
-// selection list
-
-class SelectionList: public InlineDialog {
+class InputBox : public DialogImGui {
 public:
-	SelectionList (oapi::GraphicsClient *gclient, HWND hwnd);
+    typedef bool (*Callbk)(InputBox*, char*, void*);
+    InputBox();
+    void Draw() override;
+    bool opened;
+    std::string title;
+    Callbk cbEnter;
+    Callbk cbCancel;
+    void *userdata;
+    char inputbuf[128];
 
-	void Open (LISTENTRY *list, DWORD nlist, char *_title, Listentry_clbk _clbk,
-		DWORD flag = 0, void *_userdata = 0);
+    void Open(const char *_title = 0, char *_buf = 0, int _vislen = 20,
+        Callbk cbk = 0, void *_userdata = 0, int cntx = -1, int cnty = -1);
 
-	void Clear();
-
-private:
-	void AllocSurface();
-	void RefreshSurface();
-
-	Listentry_clbk clbk;
-	void *userdata;
-	DWORD listflag;
-	LISTENTRY *list;  // entries in selection list
-	DWORD nlist;      // number of entries
-	char *title;
-	SURFHANDLE surf;  // drawing surface
-	int surfw, surfh; // surface dimensions
-	int surfx, surfy; // display location
-	int lineh;        // font height
-	int arrow;        // arrow size
-	int cur;      // selected entry index
-	int ncol;         // number of columns
-	struct COL {      // column specs
-		int nitem;      //  # items in column
-		int w;          //   column width
-	} col[maxcol];
+    bool OpenEx(const char *_title = 0, char *_buf = 0, int _vislen = 20,
+        Callbk enter_cbk = 0, Callbk cancel_cbk = 0, void *_userdata = 0,
+        int flags = 0, int cntx = -1, int cnty = -1);
 };
 
-// =======================================================================
-// text input dialog box
-
-class InputBox: public InlineDialog {
-public:
-	InputBox (oapi::GraphicsClient *gclient, HWND hwnd, int _buflen);
-	// construct an input box resource for hwnd, allocating
-	// an input buffer of size _buflen
-
-	~InputBox ();
-
-	typedef bool (*Callbk)(InputBox*, char*, void*);
-	// template for callback function. Returns pointer to calling input box,
-	// input box string and user-defined data
-
-	void SetTitle (const char *_title);
-	void InitBuffer (int _vislen, char *str);
-
-	void Activate (int cntx = -1, int cnty = -1);
-	// activate intput box centered at position cntx, cnty (default is viewport centre)
-
-	bool IsActive() { return (surf != 0); }
-
-	void Display (LPDIRECTDRAWSURFACE7 pdds);
-	// copy input box onto viewport surface
-
-	enum { key_ignore, key_consume, key_ok, key_cancel };
-
-	int ConsumeKey (UINT uMsg, WPARAM wParam, WORD mod = 0);
-	// Processes WM_CHAR and WM_KEYDOWN messages
-
-	void SetEnterCallback (Callbk cbk) { cbk_enter = cbk; }
-	// set callback function for accepting input
-
-	void Open (const char *_title = 0, char *_buf = 0, int _vislen = 20,
-		Callbk cbk = 0, void *_userdata = 0, int cntx = -1, int cnty = -1);
-	// activates the input box with the specified parameters
-	// combines SetTitle, InitBuffer, SetEnterCallback and Activate
-
-	bool OpenEx (const char *_title = 0, char *_buf = 0, int _vislen = 20,
-		Callbk enter_cbk = 0, Callbk cancel_cbk = 0, void *_userdata = 0,
-		DWORD flags = 0, int cntx = -1, int cnty = -1);
-	// This version also provides a callback function for cancelling the
-	// input box
-
-	bool Close (bool onEnter = false);
-	// de-activates the input box
-
-private:
-	void RefreshSurface ();
-
-	SURFHANDLE surf;  // drawing surface
-	int surfw, surfh; // surface dimensions
-	int X0, Y0;       // upper left corner of input box
-	int lineh;        // font height
-	int boxw;         // input box width
-	int cw;           // fixed character width
-	char *title, *buf;
-	int titlelen, buflen, vislen, vis0, slen;
-	int cur;          // cursor position
-	void *userdata;
-	DWORD flag;
-	Callbk cbk_enter;
-	Callbk cbk_cancel;
-};
-
-#endif // !__SELECT_H
+#endif

--- a/Src/Orbitersdk/CMakeLists.txt
+++ b/Src/Orbitersdk/CMakeLists.txt
@@ -3,9 +3,15 @@
 
 # Static library containing the DLL entry point for Orbiter plugins.
 # To be included by all Orbiter plugin DLLs.
+FetchContent_MakeAvailable(imgui)
 
 add_library(Orbitersdk STATIC
 	Orbitersdk.cpp
+	${imgui_SOURCE_DIR}/imgui.cpp
+	${imgui_SOURCE_DIR}/imgui_demo.cpp
+	${imgui_SOURCE_DIR}/imgui_draw.cpp
+	${imgui_SOURCE_DIR}/imgui_tables.cpp
+	${imgui_SOURCE_DIR}/imgui_widgets.cpp
 )
 
 set_target_properties(Orbitersdk


### PR DESCRIPTION
This PR adds support for [Dear ImGui](https://github.com/ocornut/imgui), which provides an OS agnostic GUI toolkit.

- The first commit hooks the library to the orbiter core and the D3D9Client library. I've used cmake fetch+patch mecanism to add the external dependency. I'm not an expert in cmake so don't hesitate to comment if you're not satisfied with the way the library has been added.
The ImGui code is instanciated inside the Orbitersdk.lib file so that modules can eventually use it in the future.

- The second commit changes the handling of input boxes/context menus to use the new library.
Some feedback would be nice from users with high DPI monitors so that we can know if the font size is acceptable.

The library has backends for DX9/DX12, OpenGL, vulkan, WinAPI, SDL, glfw... so it should be future proof.

I've got ImGui equivalents for almost all dialogs in my linux branch so if we decide to expand on this, it should not be too difficult to replace the core Orbiter dialogs currently using the Windows API.