### PR TITLE
[Lua][Fix]Return 2 values on call to oapi_get_windvector

### DIFF
--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -4719,7 +4719,7 @@ int Interpreter::oapi_get_windvector(lua_State *L)
 	VECTOR3 gv = oapiGetWindVector(hRef, lng, lat, alt, frame, &windspeed);
 	lua_pushvector(L, gv);
 	lua_pushnumber(L, windspeed);
-	return 1;
+	return 2;
 }
 
 /***


### PR DESCRIPTION
This fixes #565 