### PR TITLE
Always create surface tile labels on initial load, regardless of launchpad config

### DIFF
--- a/OVP/D3D9Client/Surfmgr2.cpp
+++ b/OVP/D3D9Client/Surfmgr2.cpp
@@ -186,11 +186,7 @@ void SurfTile::Load ()
 		mesh = CreateMesh_quadpatch (res, res, elev, 1.0, 0.0, &texrange, shift_origin, &vtxshift, mgr->GetPlanet()->prm.tilebb_excess);
 	}
 
-	static const DWORD label_enable = MKR_ENABLE | MKR_LMARK;
-	DWORD mkrmode = *(DWORD*)smgr->Client()->GetConfigParam(CFGPRM_SURFMARKERFLAG);
-	if ((mkrmode & label_enable) == label_enable) {
-		CreateLabels();
-	}
+	CreateLabels();
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Whenever a surface tile is loaded, it first checks if the surface markers setting is enabled before creating the labels for the tile, meaning that if the setting is enabled during a session, previously loaded tiles don't show their labels, as they haven't been created. This PR removes the check in order to always create the labels for a tile, regardless of the setting. This doesn't affect the actual display of the labels, which still honors the setting.