### PR TITLE
Update reusable-build action to target VS 2022

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Setup MSVC Console
       uses: ilammy/msvc-dev-cmd@v1
       with:
+        vsversion: "17.0"
         arch: ${{ inputs.architecture }}
 
     - name: Install documentation prerequisites


### PR DESCRIPTION
Github actions by default targets VS 2019 build tools, which can cause some incompatibilities on addons using the latest release, such as NASSP. This PR updates the reusable build to target VS 2022, fixing any incompatibility issues.

Although this works on my system, a build system change would benefit from other systems/setups testing to make sure nothing is broken.