### PR TITLE
Move to windows-2022 runner for reusable-build

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        default: windows-2019
+        default: windows-2022
         type: string
       configuration:
         description: 'Build configuration; release or debug'


### PR DESCRIPTION
2019 is no longer functional