### PR TITLE
Pull irrklang from self-hosted mirror

### DIFF
--- a/Sound/XRSound/CMakeLists.txt
+++ b/Sound/XRSound/CMakeLists.txt
@@ -4,9 +4,9 @@ if(NOT IRRKLANG_DIR)
 
 	if(NOT EXISTS ${IRRKLANG_DIR})
 		if(BUILD64)
-			set(IRRKLANG_URL https://cdn.orbiter-forum.com/irrKlang-64bit-1.6.0.zip)
+			set(IRRKLANG_URL https://cdn.orbithangar.com/irrKlang-64bit-1.6.0.zip)
 		else()
-			set(IRRKLANG_URL https://cdn.orbiter-forum.com/irrKlang-32bit-1.6.0.zip)
+			set(IRRKLANG_URL https://cdn.orbithangar.com/irrKlang-32bit-1.6.0.zip)
 		endif()
 
 		include(FetchContent)


### PR DESCRIPTION
The original source download for these files is no longer available, which causes the build to fail. This is a short-term fix.

Fixes #593 