### PR TITLE
Chore/disable xrsound irrklang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(ldoc $<TARGET_FILE:lua::exe> ${ORBITER_BINARY_ROOT_DIR}/packages/LDoc/ldoc.l
 
 find_package(OpenGL QUIET)
 find_package(HTMLHelp)
-find_package(LATEX)		
+find_package(LATEX)
 find_package(MFC)
 
 # We don't query Qt with find_package because we need the 64-bit version here
@@ -193,7 +193,7 @@ option(
 option(
 	ORBITER_BUILD_XRSOUND
 	"Build XRSound module to enable sound in Orbiter"
-	ON
+	OFF
 )
 
 option(ORBITER_MAKE_DOC
@@ -301,7 +301,7 @@ endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CPackOptions.cmake.in
 	${CMAKE_BINARY_DIR}/OrbiterCPackOptions.cmake)
-			   
+
 set(CPACK_GENERATOR "WIX;ZIP")
 set(CPACK_PACKAGE_NAME OpenOrbiter)
 set(CPACK_PACKAGE_VENDOR Orbitersim)

--- a/Sound/XRSound/CMakeLists.txt
+++ b/Sound/XRSound/CMakeLists.txt
@@ -4,9 +4,9 @@ if(NOT IRRKLANG_DIR)
 
 	if(NOT EXISTS ${IRRKLANG_DIR})
 		if(BUILD64)
-			set(IRRKLANG_URL https://cdn.orbithangar.com/irrKlang-64bit-1.6.0.zip)
+			set(IRRKLANG_URL https://www.ambiera.at/downloads/irrKlang-64bit-1.6.0.zip)
 		else()
-			set(IRRKLANG_URL https://cdn.orbithangar.com/irrKlang-32bit-1.6.0.zip)
+			set(IRRKLANG_URL https://www.ambiera.at/downloads/irrKlang-32bit-1.6.0.zip)
 		endif()
 
 		include(FetchContent)

--- a/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInterpreter/CMakeLists.txt
@@ -6,10 +6,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ORBITER_BINARY_ROOT_DIR})
 set(BUILD_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/out)
 
 add_library(LuaInterpreter SHARED
-	Interpreter.cpp
-	lua_vessel_mtd.cpp
-  lua_xrsound.cpp
+        Interpreter.cpp
+        lua_vessel_mtd.cpp
 )
+
+if(ORBITER_BUILD_XRSOUND)
+  target_sources(LuaInterpreter PRIVATE lua_xrsound.cpp)
+endif()
 
 target_include_directories(LuaInterpreter
 	PUBLIC ${ORBITER_SOURCE_SDK_INCLUDE_DIR}
@@ -63,7 +66,7 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/interpreter.hhp ${BUILD_OUT_DIR}
 	JOB_POOL htmlhelp
 )
-	
+
 add_custom_command(
 	POST_BUILD
 	OUTPUT ${ORBITER_BINARY_SDK_DIR}/doc/orbiter_lua.chm

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -123,7 +123,9 @@ void Interpreter::Initialise ()
 	LoadSketchpadAPI ();  // load Sketchpad methods
 	LoadAnnotationAPI (); // load screen annotation methods
 	LoadVesselStatusAPI ();
+#ifdef XRSOUND
 	LoadXRSoundAPI ();
+#endif
 	LoadStartupScript (); // load default initialisation script
 }
 
@@ -1056,11 +1058,13 @@ void Interpreter::LoadAPI ()
 	luaL_openlib (L, "term", termLib, 0);
 
 	// Load XRSound library
+#ifdef XRSOUND
 	static const struct luaL_reg XRSoundLib[] = {
 		{"create_instance", xrsound_create_instance},
 		{NULL, NULL}
 	};
 	luaL_openlib (L, "xrsound", XRSoundLib, 0);
+#endif
 
 	// Set up global tables of constants
 

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -58,7 +58,10 @@ class gcCore;
 
 class VESSEL;
 class MFD2;
+
+#ifdef XRSOUND
 class XRSound;
+#endif
 
 struct AirfoilContext {
 	lua_State *L;

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -1111,9 +1111,10 @@ protected:
 	static int idx_collect(lua_State *L);
 	static void push_indexarray(lua_State *L, WORD *, int);
 
-	
+
 	friend int OpenHelp (void *context);
 
+#ifdef XRSOUND
 	// -------------------------------------------
 	// XRSound
 	// -------------------------------------------
@@ -1140,6 +1141,7 @@ protected:
 	static int xrsound_set_playposition(lua_State *L);
 	static int xrsound_get_playposition(lua_State *L);
 	static int xrsound_collect(lua_State *L);
+#endif
 
 private:
 	HANDLE hExecMutex; // flow control synchronisation


### PR DESCRIPTION
Disables building the XRSound module via the self-hosted workaround for irrklang after it was pointed out to me that this breaches the irrklang license; will look for alternative libs with more workable licensing to replace it.