### PR TITLE
Add the possibiliy of querying the keyboard state outside of callbacks

### DIFF
--- a/Orbitersdk/include/OrbiterAPI.h
+++ b/Orbitersdk/include/OrbiterAPI.h
@@ -6560,6 +6560,15 @@ OAPIFUNC bool oapiSimulateBufferedKey (DWORD key, DWORD *mod = 0, DWORD nmod = 0
  *   frames for the duration of the simulated input.
  */
 OAPIFUNC bool oapiSimulateImmediateKey (char kstate[256], bool onRunningOnly = false);
+
+/**
+ * \brief Retrieve the keyboard state.
+ * \note The keyboard state can be queried with the KEYDOWN macro
+ * \note Usually you would use the clbkProcessKeyboardImmediate/clbkProcessKeyboardBuffered or similar
+ *   callbacks of your module to handle key presses, this is for the odd cases where you can't.
+ * \return The keyboard state
+ */
+OAPIFUNC const char *oapiGetKeyState ();
 //@} 
 
 

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -982,6 +982,7 @@ void Interpreter::LoadAPI ()
 		{"simulatebufferedkey", oapi_simulatebufferedkey},
 		{"simulateimmediatekey", oapi_simulateimmediatekey},
 		{"acceptdelayedkey", oapi_acceptdelayedkey},
+		{"get_keystate", oapi_get_keystate},
 			
 		// file i/o functions
 		{"openfile", oapi_openfile},
@@ -6999,6 +7000,27 @@ int Interpreter::oapi_acceptdelayedkey (lua_State *L)
 	lua_pushboolean(L, ret);
 	return 1;
 }
+/***
+Get the keyboard state
+
+Note: you should use the clbk\_consumedirectkey/clbk\_consumebufferedkey callbacks whenever possible, this function is mainly made
+for scenario scripts that don't use these callbacks.
+
+@function get_keystate
+@treturn handle keyboard state
+@usage
+	local kstate = oapi.get_keystate()
+	if oapi.keydown(kstate, OAPI_KEY.E) then
+		...
+	end
+end
+*/
+int Interpreter::oapi_get_keystate (lua_State *L)
+{
+	lua_pushlightuserdata(L, (void *)oapiGetKeyState());
+	return 1;
+}
+
 
 /***
 File I/O.

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -582,6 +582,7 @@ protected:
 	static int oapi_simulatebufferedkey (lua_State *L);
 	static int oapi_simulateimmediatekey (lua_State *L);
 	static int oapi_acceptdelayedkey (lua_State *L);
+	static int oapi_get_keystate (lua_State *L);
 
 	// file i/o functions
 	static int oapi_openfile (lua_State* L);

--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -2452,6 +2452,11 @@ DLLEXPORT bool oapiSimulateImmediateKey (char kstate[256], bool onRunningOnly)
 	return g_pOrbiter->SendKbdImmediate (kstate, onRunningOnly);
 }
 
+DLLEXPORT const char *oapiGetKeyState ()
+{
+	return g_pOrbiter->KeyState();
+}
+
 DLLEXPORT NOTEHANDLE oapiCreateAnnotation (bool exclusive, double size, const VECTOR3 &col)
 {
 	COLORREF c = ((int)(col.z*255.99) << 16) + ((int)(col.y*255.99) << 8) + (int)(col.x*255.99);


### PR DESCRIPTION
The main user of this is the Lua interpreter to be able to handle key presses in "scenario scripts", where callbacks are not available.
The current workaround is to dynamically load a specific DLL (see [this post](https://www.orbiter-forum.com/threads/trying-to-implement-keypress-detection-in-lua-solved.41000/)), this is of course not portable.

This adds an oapiGetKeyState() function, whose return value can be used with the standard KEYDOWN macros in C++, and an oapi.get_keystate() function in Lua, to be used with the corresponding oapi.keydown() functions.