### PR TITLE
Use std::chrono instead of Windows PerformanceCounter

### DIFF
--- a/Src/Orbiter/Log.cpp
+++ b/Src/Orbiter/Log.cpp
@@ -415,33 +415,25 @@ void tracenew (char *fname, int line)
 // =======================================================================
 
 static double prof_sum = 0.0;
-static double prof_scale = 0.0;
-static DWORD prof_count = 0;
-static LARGE_INTEGER prof_t0;
+static uint32_t prof_count = 0;
+static std::chrono::time_point<std::chrono::steady_clock> prof_t0;
 
 void StartProf ()
 {
-	if (!prof_scale) {
-		LARGE_INTEGER freq;
-		QueryPerformanceFrequency (&freq);
-		double f = (double)freq.LowPart + (double)freq.HighPart * 4294967296.0;
-		prof_scale = 1e6/(double)f;
-	}
-	QueryPerformanceCounter (&prof_t0);
+	prof_t0 = std::chrono::steady_clock::now();
 }
 
 double EndProf (DWORD *count)
 {
-	LARGE_INTEGER t1;
-	QueryPerformanceCounter (&t1);
-	double f0 = (double)prof_t0.LowPart + (double)prof_t0.HighPart * 4294967296.0;
-	double f1 = (double)t1.LowPart      + (double)t1.HighPart * 4294967296.0;
-	double dt = f1-f0;
+	auto t1 = std::chrono::steady_clock::now();
+	std::chrono::duration<double> time_delta = t1 - prof_t0;
+
+	double dt = time_delta.count();
 	if (dt > 0.0) {
 		prof_sum += dt;
 		prof_count++;
 	}
 	if (count) *count = prof_count;
-	return prof_sum*prof_scale/(double)prof_count;
+	return prof_sum/(double)prof_count;
 }
 

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -735,7 +735,7 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 		return 0;
 	}
 	LOGOUT("Finished initialising world");
-	ms_prev = timeGetTime () - 1; // make sure SimDT > 0 for first frame
+	time_prev = std::chrono::steady_clock::now() - std::chrono::milliseconds(1); // make sure SimDT > 0 for first frame
 
 	g_psys->InitState (ScnPath (scenario));
 
@@ -1798,52 +1798,23 @@ bool Orbiter::BeginTimeStep (bool running)
 	// an offset and increment, to avoid floating point underflow roundoff
 	// when adding the current time step
 	double deltat;
-	DWORD ms_curr = timeGetTime ();
-	LARGE_INTEGER hi_curr;
-	if (use_fine_counter) QueryPerformanceCounter (&hi_curr);
+	auto time_curr = std::chrono::steady_clock::now();
 
 	if (launch_tick) {
 		// control time interval in first few frames, when loading events occur
 		// enforce interval 10ms for first 3 time steps
 		deltat = 1e-2;
-		ms_prev = ms_curr-10;
-		if (use_fine_counter) fine_counter.QuadPart = hi_curr.QuadPart - fine_counter_freq.QuadPart/100;
+		time_prev = time_curr - std::chrono::milliseconds(10);
 		launch_tick--;
 	} else {
 		// standard time update
-		DWORD ms_delta = ms_curr - ms_prev;
-		if (ms_delta < 10000 && use_fine_counter) {
-			if (hi_curr.QuadPart <= fine_counter.QuadPart) {
-				if (hi_curr.QuadPart < fine_counter.QuadPart) {
-					static bool warn = true;
-					if (warn) {
-						LOGOUT(">>> WARNING: Inconsistent timer value");
-						LOGOUT("    The high-performance timer on this system generates negative time steps.");
-						LOGOUT("    Switching to low-resolution timer.");
-						warn = false;
-					}
-					if (pConfig->CfgDebugPrm.TimerMode == 0)
-						use_fine_counter = false;
-				}
-				return false;
-			}
-			// skip this step if the interval is smaller than the timer resolution
-			LONGLONG dt = hi_curr.QuadPart - fine_counter.QuadPart;
-			deltat = (double)dt * fine_counter_step;
-		} else {
-			if (!ms_delta) return false;
-			// skip this step if the interval is smaller than the timer resolution
-			deltat = ms_delta * 0.001;
-		}
+		std::chrono::duration<double> time_delta = time_curr - time_prev;
+		deltat = time_delta.count();
 	}
 
-	if (deltat < fine_counter_step) {
-		// this should never be triggered, given the previous timer checks
-		return false; // don't allow zero time step (will cause division by zero everywhere!)
-	}
+	if(deltat>0.1) deltat=0.1; // Prevent huge deltat when using breakpoints
 
-	ms_prev = ms_curr;
-	if (use_fine_counter) fine_counter = hi_curr;
+	time_prev = time_curr;
 	td.BeginStep (deltat, running);
 
 	if (!running) return true;
@@ -1910,15 +1881,13 @@ bool Orbiter::Timejump (double _mjd, int pmode)
 
 void Orbiter::Suspend (void)
 {
-	ms_suspend = timeGetTime ();
+	time_suspend = std::chrono::steady_clock::now();
 }
 
 void Orbiter::Resume (void)
 {
-	DWORD dt = timeGetTime() - ms_suspend;
-	ms_prev += dt;
-	if (use_fine_counter)
-		fine_counter.QuadPart += (LONGLONG)dt * (LONGLONG)(1e-3/fine_counter_step);
+	auto dt = std::chrono::steady_clock::now() - time_suspend;
+	time_prev += dt;
 }
 
 //-----------------------------------------------------------------------------

--- a/Src/Orbiter/Orbiter.h
+++ b/Src/Orbiter/Orbiter.h
@@ -12,6 +12,7 @@
 #include <commctrl.h>
 #include "Mesh.h"
 #include "TimeData.h"
+#include <chrono>
 
 class DInput;
 class Config;
@@ -378,8 +379,8 @@ private:
 	int             cfglen;
 	char            simkstate[256];// accumulated simulated key state
 
-	DWORD           ms_prev;       // used for time step calculation
-	DWORD           ms_suspend;    // used for time-skipping within a step
+	std::chrono::time_point<std::chrono::steady_clock> time_prev;       // used for time step calculation
+	std::chrono::time_point<std::chrono::steady_clock> time_suspend;    // used for time-skipping within a step
 	bool            bActive;       // render window has focus
 	bool            bAllowInput;   // allow input processing for the next frame even if render window doesn't have focus
 	bool            bVisible;      // render window exists and is visible

--- a/Src/Orbiter/Util.cpp
+++ b/Src/Orbiter/Util.cpp
@@ -61,28 +61,6 @@ bool iequal(const std::string& s1, const std::string& s2)
 	return true;
 }
 
-static bool need_timer_setup = true;
-static LARGE_INTEGER fine_counter_freq; // high-precision tick frequency
-static LARGE_INTEGER hi_start;
-
-void tic()
-{
-	if (need_timer_setup) {
-		QueryPerformanceFrequency (&fine_counter_freq);
-		need_timer_setup = false;
-	}
-	QueryPerformanceCounter (&hi_start);
-}
-
-double toc()
-{
-	LARGE_INTEGER hi_end;
-	QueryPerformanceCounter (&hi_end);
-	_int64 diff = hi_end.QuadPart-hi_start.QuadPart;
-	_int64 freq = fine_counter_freq.QuadPart;
-	return (double)diff/(double)freq;
-	return 0;
-}
 
 RECT GetClientPos (HWND hWnd, HWND hChild)
 {

--- a/Src/Orbiter/Util.h
+++ b/Src/Orbiter/Util.h
@@ -65,10 +65,6 @@ inline void EulerAngles (const Matrix &R, VECTOR3 &e)
 double rand1();
 // uniformly distributed random number, range [0,1]
 
-// Timing functions
-void tic();   // start clock
-double toc(); // stop clock and return value
-
 RECT GetClientPos (HWND hWnd, HWND hChild);
 void SetClientPos (HWND hWnd, HWND hChild, RECT &r);
 

--- a/Src/Orbiter/VectorMap.cpp
+++ b/Src/Orbiter/VectorMap.cpp
@@ -692,8 +692,6 @@ void VectorMap::DrawMap_engine ()
 {
 	// called either directly (by DrawMap) or from the drawing thread
 
-	tic();
-
 	// clear the bitmap
 	HBITMAP pBmp = (HBITMAP)SelectObject (hDCmem, hBmpDraw);
 	BitBlt (hDCmem, 0, 0, cw, ch, NULL, 0, 0, BLACKNESS);


### PR DESCRIPTION
This PR replaces the Windows only QueryPerformanceCounter/QueryPerformanceFrequency API with C++ chrono equivalents.