### PR TITLE
Add support for the Tracy Profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,13 @@ option(ORBITER_SANITIZER
 	OFF
 )
 
+option(ORBITER_TRACY_PROFILER
+	"Build orbiter with profiler support"
+	OFF
+)
+
+include(cmake/tracy.cmake)
+
 if(ORBITER_BUILD_XRSOUND)
 	set(IRRKLANG_DIR "" CACHE PATH "Path to the irrKlang library")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -111,6 +111,15 @@
       }
     },
     {
+      "name": "windows-x64-tracy",
+      "displayName": "x64 Tracy Profiler",
+      "inherits": "windows-x64-release",
+      "cacheVariables": {
+        "ORBITER_TRACY_PROFILER": true,
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
       "name": "windows-x86-debug",
       "displayName": "x86 Debug",
       "inherits": "windows-base",

--- a/Src/Orbiter/CMakeLists.txt
+++ b/Src/Orbiter/CMakeLists.txt
@@ -163,9 +163,9 @@ set_target_properties(Orbiter
 	FOLDER Core
 )
 
-target_include_directories(Orbiter PUBLIC ${Orbiter_includes})
+target_include_directories(Orbiter PUBLIC ${Orbiter_includes} ${TRACY_CLIENT_INCLUDE})
 
-target_link_libraries(Orbiter ${Orbiter_common_libs} ${Orbiter_libs})
+target_link_libraries(Orbiter ${Orbiter_common_libs} ${Orbiter_libs} ${TRACY_CLIENT})
 
 add_dependencies(Orbiter ${Orbiter_depends})
 

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -44,6 +44,9 @@
 #include "GraphicsAPI.h"
 #include "ConsoleManager.h"
 #include <filesystem>
+
+#include "Tracy.hpp"
+
 namespace fs = std::filesystem;
 
 using namespace std;
@@ -978,6 +981,8 @@ HRESULT Orbiter::Render3DEnvironment ()
 		Output2DData ();
 		gclient->clbkDisplayFrame ();
 	}
+	// Mark frame boundary for when using the profiler
+	FrameMark;
     return S_OK;
 }
 

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -1,0 +1,93 @@
+# Copyright (c) Gondos
+# Licensed under the MIT License
+
+# Tracy profiler integration (https://github.com/wolfpld/tracy)
+#
+# The profiler is split in 2 parts:
+#    - client code that needs to be added to the process to profile
+#    - server process that handles aggregating amd displaying the profiling data.
+#
+# Since Orbiter uses multiple DLLs, we must use a shared library for the client code.
+# This TracyClient library must be added as dependency to DLLs wanting to use the profiler.
+#
+# When profiling is disabled, we don't build the server nor the client library.
+# However we still need the Tracy.hpp file in the include path (tracy macros will be nop-ed).
+#
+# We build the server ourselves to make sure the version is compatible with the client.
+#
+# The default behavior makes the installation step copy files in bin/include/lib/cmake directories.
+# We don't want that so with use EXCLUDE_FROM_ALL and then manually install the files where needed.
+#
+# The profiler is meant for the Orbiter core and possibly for in tree modules, but not external plugins,
+# so we don't add the dependencies in the Orbiter SDK.
+#
+# HOW TO USE:
+# - in the Orbiter core:
+#   just #include "Tracy.hpp" and use the ZoneScoped macro on the functions you want to profile
+# - in Orbiter modules:
+#   add tracy to your include path:
+#       target_include_directories(...
+#       	PUBLIC ${ORBITER_SOURCE_SDK_INCLUDE_DIR}
+#       	...
+#       	PUBLIC ${TRACY_CLIENT_INCLUDE}
+#       )
+#   add the tracy client library: 
+#       target_link_libraries(...
+#       	${ORBITER_LIB}
+#       	${ORBITER_SDK_LIB}
+#       	...
+#       	${TRACY_CLIENT}
+#       )
+#
+# - build the solution
+# - start Orbiter
+# - start the profiler (in Utils) and connect to the Orbiter process
+# - have fun
+
+
+if(ORBITER_TRACY_PROFILER)
+	set(TRACY_ENABLE ON)
+else()
+	set(TRACY_ENABLE OFF)
+endif()
+
+set(BUILD_SHARED_LIBS ON)
+set(TRACY_ONLY_LOCALHOST ON)
+set(TRACY_ON_DEMAND ON)
+set(TRACY_ONLY_IPV4 ON)
+
+Include(FetchContent)
+
+FetchContent_Declare(tracy
+	GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+	GIT_TAG v0.12.2
+	GIT_SHALLOW TRUE
+	EXCLUDE_FROM_ALL # prevents installation of lib and include directories in ${ORBITER_INSTALL_ROOT_DIR}
+)
+FetchContent_MakeAvailable(tracy)
+
+set(TRACY_CLIENT_INCLUDE ${tracy_SOURCE_DIR}/public/tracy CACHE PATH "Tracy public include path")
+
+# Build the server and client library only if profiling is enabled.
+if(ORBITER_TRACY_PROFILER)
+	# To be used in CMakeLists.txt. 
+	set(TRACY_CLIENT TracyClient)
+
+	# Copy the DLL alongside the main Orbiter binary.
+	install(TARGETS TracyClient RUNTIME DESTINATION ${ORBITER_INSTALL_ROOT_DIR})
+
+	# The root CMakeLists.txt file of the repo only handles the client side.
+	# The server is inside the profiler subdirectory.
+	# Use EXCLUDE_FROM_ALL because we don't want to be polluted with bin/include/lib directories.
+	add_subdirectory("${tracy_SOURCE_DIR}/profiler" EXCLUDE_FROM_ALL)
+
+	# Since we excluded the profiler, we now need to make it compile anyway...
+	add_custom_target(BuildProfiler ALL DEPENDS tracy-profiler)
+
+	# Copy the profiler and its dependencies into the Utils directory.
+	install(TARGETS tracy-profiler RUNTIME DESTINATION ${ORBITER_INSTALL_UTILS_DIR})
+	install(TARGETS freetype RUNTIME DESTINATION ${ORBITER_INSTALL_UTILS_DIR})
+	install(TARGETS nfd RUNTIME DESTINATION ${ORBITER_INSTALL_UTILS_DIR})
+	install(TARGETS capstone RUNTIME DESTINATION ${ORBITER_INSTALL_UTILS_DIR})
+	install(TARGETS glfw RUNTIME DESTINATION ${ORBITER_INSTALL_UTILS_DIR})
+endif()


### PR DESCRIPTION
This is a draft to add support for the [Tracy Profiler](https://github.com/wolfpld/tracy).
I'm working on something that may have an impact on performance, so I tried this to see how it performs with Orbiter.
Here is the work in progress if anyone is interested.
Everything is gated behind an ORBITER_TRACY_PROFILER option.
Because it's an instrumented profiler, you need to add _zone_ definitions in the code with macros.
When profiling is disabled, these macros are no-ops, but we still need the Tracy.hpp file to do that.
As a result the tracy repo is always fetched.
The server is compiled when the option is set, and is installed in the Utils directory.
I sprinkled a few zones in this commit and here is the result :
<img width="1652" height="898" alt="tracy" src="https://github.com/user-attachments/assets/0ecd186c-7996-4a3f-97ac-7e6fb70a78fc" />

I tried to limit the impact on the build system so hopefully this can be merged at one point.

Edit: added an "x64 Tracy Profiler" configuration preset