### PR TITLE
fix: update quadcopter mesh path

### DIFF
--- a/Orbitersdk/sample_build/Quadcopter/CMakeLists.txt
+++ b/Orbitersdk/sample_build/Quadcopter/CMakeLists.txt
@@ -24,7 +24,7 @@ set(Headers
 	${SAMPLES_SRC_DIR}/Common/Vessel/Instrument.h
 )
 set(Other
-	${MESH_DIR}/quadcopter.msh
+	${MESH_DIR}/${PRJ}/quadcopter.msh
 )
 	
 source_group(APIHeaders FILES ${APIHeaders})


### PR DESCRIPTION
This PR updates the mesh location of the Quadcopter in the CMake file to the correct location.