### PR TITLE
Add heuristic for legacy addons using Windows encoding instead of UTF-8

### DIFF
--- a/OVP/D3D9Client/D3D9Pad.cpp
+++ b/OVP/D3D9Client/D3D9Pad.cpp
@@ -51,10 +51,12 @@ static std::string UTF8ToCP1252(const char *utf8, int ulen)
 {
 	// Convert UTF-8 to Windows-1252
 	// Get the required length to convert from UTF-8 to UTF-16
-	int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8, ulen, nullptr, 0);
+	// Use MB_ERR_INVALID_CHARS to have the call fail if the string
+	// contains invalid characters. In that case we assume it's
+	// a legacy plugin providing a Windows-1252 string instead of UTF-8
+	int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, ulen, nullptr, 0);
 
-	// In case of a problem, return the original string
-	// to help with backward compatibility
+	// Return the original string and hope it was already using Windows-1252
 	if (wlen == 0) {
 		return std::string(utf8);
 	}

--- a/Orbitersdk/include/DrawAPI.h
+++ b/Orbitersdk/include/DrawAPI.h
@@ -1141,6 +1141,8 @@ public:
 	 * \return width of the string, drawn in the currently selected font [pixel]
 	 * \default None, returns 0.
 	 * \sa SetFont
+	 * \note If the user provides a Windows-1252 encoded string, an heuristic is used
+	 *   that *may* provide the expected result
 	 */
 	virtual DWORD GetTextWidth (const char *str, int len = 0) { assert(false); return 0; }
 
@@ -1181,6 +1183,8 @@ public:
 	 * \param len string length for output
 	 * \return \e true on success, \e false on failure.
 	 * \default None, returns false.
+	 * \note If the user provides a Windows-1252 encoded string, an heuristic is used
+	 *   that *may* provide the expected result
 	 */
 	virtual bool Text (int x, int y, const char *str, int len) { assert(false); return false; }
 
@@ -1199,6 +1203,8 @@ public:
 	 *   be applied as required to fit the text in the box.
 	 * \note The bottom edge (y2) should probably be ignored, so text isn't
 	 *   truncated if it doesn't fit the box.
+	 * \note If the user provides a Windows-1252 encoded string, an heuristic is used
+	 *   that *may* provide the expected result
 	 */
 	virtual bool TextBox (int x1, int y1, int x2, int y2, const char *str, int len);
 


### PR DESCRIPTION
Given feedback from the NASSP team, it looks like the fallback was not working in case non UTF-8 strings were provided to the GC.
MultiByteToWideChar requires an explicit MB_ERR_INVALID_CHARS flags to return an error. Without it, it was silently replacing invalid characters with U+FFFD.
