### PR TITLE
Use ImGui to draw annotations

### DIFF
--- a/OVP/D3D9Client/D3D9Client.cpp
+++ b/OVP/D3D9Client/D3D9Client.cpp
@@ -1427,14 +1427,6 @@ ParticleStream *D3D9Client::clbkCreateReentryStream (PARTICLESTREAMSPEC *pss,
 
 #pragma endregion
 
-// ==============================================================
-
-ScreenAnnotation* D3D9Client::clbkCreateAnnotation()
-{
-	_TRACE;
-	return GraphicsClient::clbkCreateAnnotation();
-}
-
 #pragma region Mesh functions
 
 // ==============================================================

--- a/OVP/D3D9Client/D3D9Client.h
+++ b/OVP/D3D9Client/D3D9Client.h
@@ -518,14 +518,6 @@ public:
 	// @}
 
 	/**
-	 * \brief Create an annotation object for displaying on-screen text.
-	 * \return Pointer to new screen annotation object.
-	 * \default Dynamically allocates a 'ScreenAnnotation' instance and returns
-	 *   a pointer to it.
-	 */
-	ScreenAnnotation* clbkCreateAnnotation();
-
-	/**
 	 * \brief Render window message handler
 	 *
 	 * Derived classes should also call the base class method to allow

--- a/Orbitersdk/include/GraphicsAPI.h
+++ b/Orbitersdk/include/GraphicsAPI.h
@@ -778,14 +778,6 @@ public:
 	// @}
 
 	/**
-	 * \brief Create an annotation object for displaying on-screen text.
-	 * \return Pointer to new screen annotation object.
-	 * \default Dynamically allocates a 'ScreenAnnotation' instance and returns
-	 *   a pointer to it.
-	 */
-	virtual ScreenAnnotation *clbkCreateAnnotation ();
-
-	/**
 	 * \brief Returns the handle of the main render window.
 	 */
 	HWND GetRenderWindow () const { return hRenderWnd; }

--- a/Src/Orbiter/DlgMgr.cpp
+++ b/Src/Orbiter/DlgMgr.cpp
@@ -568,6 +568,11 @@ void DialogManager::ImGuiNewFrame()
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
 
+	for(auto &annotation: annotations) {
+		annotation->Render();
+	}
+
+
 	RenderNotifications();
 
 	// We can't use a range-based loop here because Display() may unregister the current dialog
@@ -598,6 +603,17 @@ void DialogManager::SetMainColor(COLORREF col)
     ImVec4 color = ImVec4((col & 0xff) / 255.0f, ((col >> 8) & 0xff) / 255.0f, (col >> 16)/255.0f, 1.0f);
     ApplyGlowTheme(color);
 }
+
+void DialogManager::RegisterAnnotation(oapi::ScreenAnnotation *an)
+{
+	annotations.push_back(an);
+}
+
+void DialogManager::UnregisterAnnotation(oapi::ScreenAnnotation *an)
+{
+	annotations.remove(an);
+}
+
 
 ImGuiDialog::~ImGuiDialog(){
 	// Make sure this dialog is no longer referenced in the DialogManager
@@ -917,7 +933,6 @@ namespace ImGui {
 		}
 		return ret;
 	}
-
 
 	DLLEXPORT void PushFont(ImGuiFont f, float scale)
 	{

--- a/Src/Orbiter/DlgMgr.h
+++ b/Src/Orbiter/DlgMgr.h
@@ -182,6 +182,8 @@ public:
 	ImFont *GetFont(ImGuiFont f);
 
 	void SetMainColor(COLORREF col);
+	void RegisterAnnotation(oapi::ScreenAnnotation *);
+	void UnregisterAnnotation(oapi::ScreenAnnotation *);
 private:
 	void InitImGui();
 	void ShutdownImGui();
@@ -189,6 +191,7 @@ private:
 	ImFont *consoleFont;
 	ImFont *monoFont;
 	ImFont *manuscriptFont;
+	std::list<oapi::ScreenAnnotation *>annotations;
 };
 
 INT_PTR OrbiterDefDialogProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/Src/Orbiter/DlgOptions.cpp
+++ b/Src/Orbiter/DlgOptions.cpp
@@ -499,7 +499,7 @@ void DlgOptions::DrawAxes()
 		ImGui::BeginChild("##right");
 			ImGui::SeparatorText("Display");
 			ImGui::CheckboxFlags("Show negative axis", &prm.flagFrameAxes, FAV_NEGATIVE);
-			ImGui::BeginDisabled(!(prm.flagFrameAxes, FAV_NEGATIVE));
+			ImGui::BeginDisabled(!(prm.flagFrameAxes & FAV_NEGATIVE));
 				ImGui::SliderFloat("Scale", &prm.scaleFrameAxes, 0.25, 4.0, "%0.2f", ImGuiSliderFlags_AlwaysClamp);
 				ImGui::SliderFloat("Opacity", &prm.opacFrameAxes, 0.0, 1.0, "%0.2f", ImGuiSliderFlags_AlwaysClamp);
 			ImGui::EndDisabled();


### PR DESCRIPTION
As the title says, this makes annotations go through ImGui.
Since it's not using Arial anymore, and the font size calculations are not the same, it's not a pixel perfect replica.
It can be a problem if someone expected the automatic text wrapping to lay out its text in a particular way.