### PR TITLE
Remove obsolete timer mode config

### DIFF
--- a/Doc/Orbiter User Manual/ADVANCED_CFG.tex
+++ b/Doc/Orbiter User Manual/ADVANCED_CFG.tex
@@ -156,8 +156,6 @@ Normally, only entries whose values differ from their default setting are writte
 	\hline\rule{0pt}{2ex}
 	FixedStep & Float & Fixed time interval per frame [s]. Default: 0 (disable fixed frame intervals)\\
 	\hline\rule{0pt}{2ex}
-	TimerMode & Int & Simulation timer mode (0 = auto, 1 = hires hardware timer, 2 = lores software timer). Default: 0\\
-	\hline\rule{0pt}{2ex}
 	DisableFontSmoothing & Bool & Turn off font smoothing while running Orbiter to improve performance. Default: FALSE\\
 	\hline\rule{0pt}{2ex}
 	ForceReenableFontSmoothing & Bool & Re-enable font smoothing on closing Orbiter even if it was not active at program start. Default: FALSE\\

--- a/Src/Orbiter/Config.cpp
+++ b/Src/Orbiter/Config.cpp
@@ -138,7 +138,6 @@ CFG_VISHELPPRM CfgVisHelpPrm_default = {
 CFG_DEBUGPRM CfgDebugPrm_default = {
 	0,			// ShutdownMode (0=deallocate memory)
 	0.0,		// fixed time step (0=variable)
-	0,			// timer mode (0=auto)
 	false,      // bDisableSmoothFont (don't disable font smoothing)
 	false,      // bForceReenableSmoothFont (don't force reenabling font smoothing on exit)
 	2,          // bHtmlScnDesc (use html browser window for scenario desciption in launchpad)
@@ -702,8 +701,6 @@ bool Config::Load(const char *fname)
 		CfgDebugPrm.ShutdownMode = i;
 	if (GetReal (ifs, "FixedStep", d) && d >= 0)
 		CfgDebugPrm.FixedStep = d;
-	if (GetInt (ifs, "TimerMode", i) && i >= 0 && i <= 2)
-		CfgDebugPrm.TimerMode = i;
 	GetBool (ifs, "DisableFontSmoothing", CfgDebugPrm.bDisableSmoothFont);
 	GetBool (ifs, "ForceReenableFontSmoothing", CfgDebugPrm.bForceReenableSmoothFont);
 	GetInt (ifs, "HtmlScnDesc", CfgDebugPrm.bHtmlScnDesc);
@@ -1130,8 +1127,6 @@ BOOL Config::Write (const char *fname) const
 			ofs << "ShutdownMode = " << CfgDebugPrm.ShutdownMode << '\n';
 		if (CfgDebugPrm.FixedStep != CfgDebugPrm_default.FixedStep || bEchoAll)
 			ofs << "FixedStep = " << CfgDebugPrm.FixedStep << '\n';
-		if (CfgDebugPrm.TimerMode != CfgDebugPrm_default.TimerMode || bEchoAll)
-			ofs << "TimerMode = " << CfgDebugPrm.TimerMode << '\n';
 		if (CfgDebugPrm.bDisableSmoothFont != CfgDebugPrm_default.bDisableSmoothFont || bEchoAll)
 			ofs << "DisableFontSmoothing = " << BoolStr (CfgDebugPrm.bDisableSmoothFont) << '\n';
 		if (CfgDebugPrm.bForceReenableSmoothFont != CfgDebugPrm_default.bForceReenableSmoothFont || bEchoAll)

--- a/Src/Orbiter/Config.h
+++ b/Src/Orbiter/Config.h
@@ -163,7 +163,6 @@ struct CFG_VISHELPPRM {
 struct CFG_DEBUGPRM {
 	int    ShutdownMode;		// 0=standard (redisplay launchpad), 1=respawn, 2=terminate
 	double FixedStep;			// fixed time step length [s] (0=variable)
-	int    TimerMode;			// timer mode (0=auto, 1=hires hardware, 2=lores software
 	bool   bDisableSmoothFont;  // disable font smoothing for better performance
 	bool   bForceReenableSmoothFont; // enable font smoothing on exit, even if it wasn't on originally (recover from losing settings after a previous crash)
 	int    bHtmlScnDesc;        // 0=use simple text box, 1=use inline html viewer, 2=auto-detect (disable inline html under linux/wine)

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -104,10 +104,6 @@ bool g_bStateUpdate = false;
 DWORD  launch_tick;      // counts the first 3 frames
 DWORD  g_vtxcount = 0;   // vertices/frame rendered (for diagnosis)
 DWORD  g_tilecount = 0;  // surface tiles/frame rendered (for diagnosis)
-BOOL   use_fine_counter;         // high-precision timer available?
-double fine_counter_step;        // step interval of high-precision counter (or 0 if not available)
-LARGE_INTEGER fine_counter_freq; // high-precision tick frequency
-LARGE_INTEGER fine_counter;      // current high-precision time value
 TimeData td;             // timing information
 
 // Configuration parameters set from Driver.cfg
@@ -206,7 +202,6 @@ INT WINAPI WinMain (HINSTANCE hInstance, HINSTANCE, LPSTR strCmdLine, INT nCmdSh
 	// Initialise random number generator
 	//srand ((unsigned)time (NULL));
 	srand(12345);
-	LOGOUT("Timer precision: %g sec", fine_counter_step);
 
 	oapiRegisterCustomControls(hInstance);
 
@@ -296,11 +291,6 @@ Orbiter::Orbiter ()
 
 	// Initialise timer
 	timeBeginPeriod(1);
-	if (use_fine_counter = QueryPerformanceFrequency(&fine_counter_freq)) {
-		double freq = fine_counter_freq.LowPart;
-		if (fine_counter_freq.HighPart) freq += fine_counter_freq.HighPart * 4294967296.0;
-		fine_counter_step = 1.0 / freq;
-	}
 
 	pDI             = new DInput(this); TRACENEW
 	pConfig         = new Config; TRACENEW
@@ -754,7 +744,6 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 	strcpy (ScenarioName, scenario);
 	g_qsaveid = 0;
 	launch_tick = 3;
-	if (pCfg->CfgDebugPrm.TimerMode == 2) use_fine_counter = FALSE;
 
 	// Generate logical world objects
 	if (gclient) {

--- a/Src/Orbiter/TabExtra.cpp
+++ b/Src/Orbiter/TabExtra.cpp
@@ -73,7 +73,6 @@ void orbiter::ExtraTab::GetConfig (const Config *cfg)
 	RegisterExtraParam(new ExtraShutdown(this), ht); TRACENEW
 	RegisterExtraParam(new ExtraFixedStep(this), ht); TRACENEW
 	RegisterExtraParam(new ExtraRenderingOptions(this), ht); TRACENEW
-	RegisterExtraParam(new ExtraTimerSettings(this), ht); TRACENEW
 	RegisterExtraParam(new ExtraLaunchpadOptions(this), ht); TRACENEW
 	RegisterExtraParam(new ExtraLogfileOptions(this), ht); TRACENEW
 	RegisterExtraParam(new ExtraPerformanceSettings(this), ht); TRACENEW
@@ -1311,85 +1310,6 @@ INT_PTR CALLBACK ExtraRenderingOptions::DlgProc (HWND hWnd, UINT uMsg, WPARAM wP
 	//		return 0;
 		case IDOK:
 			if (((ExtraRenderingOptions*)GetWindowLongPtr (hWnd, DWLP_USER))->StoreParams (hWnd))
-				EndDialog (hWnd, 0);
-			break;
-		}
-		break;
-	}
-	return BuiltinLaunchpadItem::DlgProc (hWnd, uMsg, wParam, lParam);
-}
-
-//-----------------------------------------------------------------------------
-// Debugging parameters: timer settings
-//-----------------------------------------------------------------------------
-
-char *ExtraTimerSettings::Name ()
-{
-	return (char*)"Timer settings";
-}
-
-char *ExtraTimerSettings::Description ()
-{
-	return (char*)"This option allows the selection of the timer used by Orbiter to calculate time step intervals. Useful for testing and working around buggy hardware timers.";
-}
-
-bool ExtraTimerSettings::clbkOpen (HWND hParent)
-{
-	OpenDialog (hParent, IDD_EXTRA_TIMER, DlgProc);
-	return true;
-}
-
-void ExtraTimerSettings::InitDialog (HWND hWnd)
-{
-	SetDialog (hWnd, pTab->Cfg()->CfgDebugPrm);
-}
-
-void ExtraTimerSettings::ResetDialog (HWND hWnd)
-{
-	extern CFG_DEBUGPRM CfgDebugPrm_default;
-	SetDialog (hWnd, CfgDebugPrm_default);
-}
-
-void ExtraTimerSettings::SetDialog (HWND hWnd, const CFG_DEBUGPRM &prm)
-{
-	SendDlgItemMessage (hWnd, IDC_COMBO1, CB_RESETCONTENT, 0, 0);
-	SendDlgItemMessage (hWnd, IDC_COMBO1, CB_ADDSTRING, 0, (LPARAM)"Automatic selection");
-	SendDlgItemMessage (hWnd, IDC_COMBO1, CB_ADDSTRING, 0, (LPARAM)"High-performance hardware timer");
-	SendDlgItemMessage (hWnd, IDC_COMBO1, CB_ADDSTRING, 0, (LPARAM)"Software timer");
-	SendDlgItemMessage (hWnd, IDC_COMBO1, CB_SETCURSEL, prm.TimerMode, 0);
-}
-
-bool ExtraTimerSettings::StoreParams (HWND hWnd)
-{
-	Config *cfg = pTab->Cfg();
-	int idx = SendDlgItemMessage (hWnd, IDC_COMBO1, CB_GETCURSEL, 0, 0);
-	if (idx == CB_ERR) idx = 0;
-	cfg->CfgDebugPrm.TimerMode = idx;
-	return true;
-}
-
-bool ExtraTimerSettings::OpenHelp (HWND hWnd)
-{
-	OpenDefaultHelp (hWnd, "extra_timer");
-	return true;
-}
-
-INT_PTR CALLBACK ExtraTimerSettings::DlgProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-	switch (uMsg) {
-	case WM_INITDIALOG:
-		((ExtraTimerSettings*)lParam)->InitDialog (hWnd);
-		break;
-	case WM_COMMAND:
-		switch (LOWORD (wParam)) {
-		case IDC_BUTTON1:
-			((ExtraTimerSettings*)GetWindowLongPtr (hWnd, DWLP_USER))->ResetDialog (hWnd);
-			return 0;
-		case IDC_BUTTON2:
-			((ExtraTimerSettings*)GetWindowLongPtr (hWnd, DWLP_USER))->OpenHelp (hWnd);
-			return 0;
-		case IDOK:
-			if (((ExtraTimerSettings*)GetWindowLongPtr (hWnd, DWLP_USER))->StoreParams (hWnd))
 				EndDialog (hWnd, 0);
 			break;
 		}

--- a/Src/Orbiter/TabExtra.h
+++ b/Src/Orbiter/TabExtra.h
@@ -295,26 +295,6 @@ private:
 };
 
 //-----------------------------------------------------------------------------
-// Debugging parameters: timer settings
-//-----------------------------------------------------------------------------
-
-class ExtraTimerSettings: public BuiltinLaunchpadItem {
-public:
-	ExtraTimerSettings (const orbiter::ExtraTab *tab): BuiltinLaunchpadItem (tab) {}
-	char *Name ();
-	char *Description ();
-	bool clbkOpen (HWND hParent);
-
-private:
-	void InitDialog (HWND hWnd);
-	void ResetDialog (HWND hWnd);
-	void SetDialog (HWND hWnd, const CFG_DEBUGPRM &prm);
-	bool StoreParams (HWND hWnd);
-	bool OpenHelp (HWND hWnd);
-	static INT_PTR CALLBACK DlgProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-};
-
-//-----------------------------------------------------------------------------
 // Debugging parameters: performance options
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Time handling was changed to use C++'s chrono API instead of Windows performance counters.
This PR cleans up the unused config param 'TimerMode', its configuration tab, and some left over 'fine_counter_xxx' members that are no longer relevant.