### PR TITLE
(Core) Copyright notices and site link

### DIFF
--- a/Doc/Orbiter User Manual/CREDITS.tex
+++ b/Doc/Orbiter User Manual/CREDITS.tex
@@ -355,7 +355,7 @@ NASA/LAMBDA\\
 \url{http://lambda.gsfc.nasa.gov/product/map/current/sos/}\\
 \\
 \textbf{Constellation boundaries}\\
-(c) 2012-2022 Pierre Barbier,\\
+(c) 2012-2026 Pierre Barbier,\\
 Interpolated merged edges (J2000)\\
 Creative Commons Attribution-ShareAlike 4.0 International License\\
 \url{https://pbarbier.com/constellations/boundaries.html}\\
@@ -406,3 +406,4 @@ Balázs Patyi\\
 
 
 \end{document}
+

--- a/Doc/Orbiter User Manual/LICENSE.tex
+++ b/Doc/Orbiter User Manual/LICENSE.tex
@@ -6,7 +6,7 @@ Orbiter Space Flight Simulator\\
 \\
 MIT License\\
 \\
-Copyright (c) 2000-2021 Martin Schweiger\\
+Copyright (c) 2000-2026 Martin Schweiger\\
 \\
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\\
 \\
@@ -15,3 +15,4 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 \end{document}
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2000-2021 Martin Schweiger
+Copyright (c) 2000-2026 Martin Schweiger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/OVP/D3D9Client/AABBUtil.cpp
+++ b/OVP/D3D9Client/AABBUtil.cpp
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2013-2016 Jarmo Nikkanen
+// Copyright (C) 2013-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -419,3 +419,4 @@ void EnvMapDirection(int dir, D3DXVECTOR3 *Dir, D3DXVECTOR3 *Up)
 			break;
     }
 }
+

--- a/OVP/D3D9Client/AABBUtil.h
+++ b/OVP/D3D9Client/AABBUtil.h
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2013-2016 Jarmo Nikkanen
+// Copyright (C) 2013-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -46,3 +46,4 @@ void		EnvMapDirection(int dir, D3DXVECTOR3 *Dir, D3DXVECTOR3 *Up);
 D3DXVECTOR3 WorldPickRay(float x, float y, const LPD3DXMATRIX mProj, const LPD3DXMATRIX mView);
 bool		SolveLUSystem(int n, double *A, double *b, double *x, double *det=NULL);
 #endif
+

--- a/OVP/D3D9Client/AtmoControls.cpp
+++ b/OVP/D3D9Client/AtmoControls.cpp
@@ -2,7 +2,7 @@
 // Atmospheric controls implementation
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2014 - 2016 Jarmo Nikkanen
+// Copyright (C) 2014-2026 Jarmo Nikkanen
 // ==============================================================
 
 #include "D3D9Client.h"
@@ -580,5 +580,6 @@ INT_PTR CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 }
 
 } //namespace
+
 
 

--- a/OVP/D3D9Client/AtmoControls.h
+++ b/OVP/D3D9Client/AtmoControls.h
@@ -2,7 +2,7 @@
 // Atmospheric controls implementation
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2014-2016 Jarmo Nikkanen
+// Copyright (C) 2014-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __ATMOCONTROLS_H
@@ -105,3 +105,4 @@ namespace AtmoControls {
 };
 
 #endif // !__ATMOCONTROLS_H
+

--- a/OVP/D3D9Client/BeaconArray.cpp
+++ b/OVP/D3D9Client/BeaconArray.cpp
@@ -1,7 +1,7 @@
 // ===========================================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 #include "BeaconArray.h"
@@ -145,3 +145,4 @@ void BeaconArray::Render(LPDIRECT3DDEVICE9 dev, const LPD3DXMATRIX pW, float tim
 
 	dev->SetRenderState(D3DRS_POINTSPRITEENABLE, 0);
 }
+

--- a/OVP/D3D9Client/BeaconArray.h
+++ b/OVP/D3D9Client/BeaconArray.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 
@@ -80,3 +80,4 @@ private:
 };
 
 #endif // !__BEACONARRAY_H
+

--- a/OVP/D3D9Client/CSphereMgr.cpp
+++ b/OVP/D3D9Client/CSphereMgr.cpp
@@ -3,8 +3,8 @@
 // resolutions.
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
-// Copyright (C) 2011 - 2016 Jarmo Nikkanen (D3D9Client modification) 
+// Copyright (C) 2007-2026 Martin Schweiger
+// Copyright (C) 2011-2026 Jarmo Nikkanen (D3D9Client modification) 
 // ==============================================================
 
 #include "D3D9util.h"
@@ -551,5 +551,6 @@ bool CSphereManager::TileInView (int lvl, int ilat)
 	D3DXVec3TransformCoord(&vP, &mesh.bsCnt, &mWorld);
 	return gc->GetScene()->IsVisibleInCamera(&vP, mesh.bsRad);
 }
+
 
 

--- a/OVP/D3D9Client/CSphereMgr.h
+++ b/OVP/D3D9Client/CSphereMgr.h
@@ -3,7 +3,7 @@
 // resolutions.
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2011-2016 Jarmo Nikkanen (D3D9Client modification) 
 // =======================================================================
 
@@ -153,3 +153,4 @@ private:
 };
 
 #endif // !__CSPHEREMGR_H
+

--- a/OVP/D3D9Client/CelSphere.cpp
+++ b/OVP/D3D9Client/CelSphere.cpp
@@ -2,7 +2,7 @@
 // CelSphere.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -668,3 +668,4 @@ D3DXHANDLE D3D9CelestialSphere::s_eLine = 0;
 D3DXHANDLE D3D9CelestialSphere::s_eLabel = 0;
 D3DXHANDLE D3D9CelestialSphere::s_eColor = 0;
 D3DXHANDLE D3D9CelestialSphere::s_eWVP = 0;
+

--- a/OVP/D3D9Client/CelSphere.h
+++ b/OVP/D3D9Client/CelSphere.h
@@ -2,7 +2,7 @@
 // CelSphere.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __D3D9CELSPHERE_H
@@ -189,3 +189,4 @@ private:
 };
 
 #endif // !__D3D9CELSPHERE_H
+

--- a/OVP/D3D9Client/CloudMgr.cpp
+++ b/OVP/D3D9Client/CloudMgr.cpp
@@ -2,7 +2,7 @@
 // CloudMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================
@@ -188,3 +188,4 @@ void CloudManager::RenderTile (int lvl, int hemisp, int ilat, int nlat, int ilng
 	pDev->SetIndices(mesh.pIB);
 	pDev->DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 0, mesh.nv, 0, mesh.nf);
 }
+

--- a/OVP/D3D9Client/CloudMgr.h
+++ b/OVP/D3D9Client/CloudMgr.h
@@ -2,7 +2,7 @@
 // CloudMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __CLOUDMGR_H

--- a/OVP/D3D9Client/Cloudmgr2.cpp
+++ b/OVP/D3D9Client/Cloudmgr2.cpp
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -298,3 +298,4 @@ void TileManager2<CloudTile>::Unload(int lvl)
 	tiletree[0].DelAbove(lvl);
 	tiletree[1].DelAbove(lvl);
 }
+

--- a/OVP/D3D9Client/Cloudmgr2.h
+++ b/OVP/D3D9Client/Cloudmgr2.h
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -45,3 +45,4 @@ protected:
 };
 
 #endif // !__CLOUDMGR2_H
+

--- a/OVP/D3D9Client/D3D9Catalog.h
+++ b/OVP/D3D9Client/D3D9Catalog.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __D3D9CATALOG_H
@@ -365,3 +365,4 @@ protected:
 };
 
 #endif // !__D3D9EXTRA_H
+

--- a/OVP/D3D9Client/D3D9Client.cpp
+++ b/OVP/D3D9Client/D3D9Client.cpp
@@ -2,7 +2,7 @@
 // D3D9Client.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -3309,3 +3309,4 @@ VisObject::VisObject(OBJHANDLE hObj) : hObj(hObj)
 VisObject::~VisObject ()
 {
 }
+

--- a/OVP/D3D9Client/D3D9Client.h
+++ b/OVP/D3D9Client/D3D9Client.h
@@ -2,7 +2,7 @@
 // D3DClient.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -1482,3 +1482,4 @@ public:
 };
 
 #endif // !__D3D9CLIENT_H
+

--- a/OVP/D3D9Client/D3D9Config.cpp
+++ b/OVP/D3D9Client/D3D9Config.cpp
@@ -2,7 +2,7 @@
 // Configuration Manager
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007-2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -307,3 +307,4 @@ void D3D9Config::WriteParams ()
 
 	oapiCloseFile (hFile, FILE_OUT);
 }
+

--- a/OVP/D3D9Client/D3D9Config.h
+++ b/OVP/D3D9Client/D3D9Config.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -115,3 +115,4 @@ private:
 };
 
 #endif // !__D3D9CONFIG_H
+

--- a/OVP/D3D9Client/D3D9ControlPanel.cpp
+++ b/OVP/D3D9Client/D3D9ControlPanel.cpp
@@ -1,7 +1,7 @@
 // ===========================================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 
@@ -348,3 +348,4 @@ bool D3D9Client::ControlPanelMsg(WPARAM wParam)
 {
 	return false;
 }
+

--- a/OVP/D3D9Client/D3D9Effect.cpp
+++ b/OVP/D3D9Client/D3D9Effect.cpp
@@ -2,7 +2,7 @@
 // D3D9Effect.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2011 - 2016 Jarmo Nikkanen
+// Copyright (C) 2011-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 #include "D3D9Effect.h"
@@ -1019,3 +1019,4 @@ void D3D9Effect::RenderArrow(OBJHANDLE hObj, const VECTOR3 *ofs, const VECTOR3 *
     HR(FX->EndPass());
     HR(FX->End()); 
 }
+

--- a/OVP/D3D9Client/D3D9Effect.h
+++ b/OVP/D3D9Client/D3D9Effect.h
@@ -1,7 +1,7 @@
 // ===========================================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2011 - 2016 Jarmo Nikkanen
+// Copyright (C) 2011-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 #ifndef __D3D9EFFECT_H
@@ -190,3 +190,4 @@ public:
 };
 
 #endif // !__D3D9EFFECT_H
+

--- a/OVP/D3D9Client/D3D9Frame.cpp
+++ b/OVP/D3D9Client/D3D9Frame.cpp
@@ -3,7 +3,7 @@
 // Desc: Class functions to implement a Direct3D app framework.
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -637,4 +637,5 @@ HRESULT CD3DFramework9::CreateWindowedMode()
 
 	return -1;
 }
+
 

--- a/OVP/D3D9Client/D3D9Frame.h
+++ b/OVP/D3D9Client/D3D9Frame.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -143,3 +143,4 @@ public:
 #define D3DFWERR_NOTINITIALIZED       0x8200000f
 
 #endif // !D3D9FRAME_H
+

--- a/OVP/D3D9Client/D3D9Pad.cpp
+++ b/OVP/D3D9Client/D3D9Pad.cpp
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -2095,3 +2095,4 @@ void D3D9PadBrush::D3D9TechInit(LPDIRECT3DDEVICE9 pDevice)
 {
 	//pDev = pDevice;
 }
+

--- a/OVP/D3D9Client/D3D9Pad.h
+++ b/OVP/D3D9Client/D3D9Pad.h
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -887,4 +887,5 @@ private:
 };
 
 #endif
+
 

--- a/OVP/D3D9Client/D3D9Pad2.cpp
+++ b/OVP/D3D9Client/D3D9Pad2.cpp
@@ -1,6 +1,6 @@
 
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -1028,3 +1028,4 @@ void D3D9Triangle::Update(const gcCore::clrVtx *pt, int npt)
 	}
 	HR(pVB->Unlock());
 }
+

--- a/OVP/D3D9Client/D3D9Pad3.cpp
+++ b/OVP/D3D9Client/D3D9Pad3.cpp
@@ -1,6 +1,6 @@
 
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -302,3 +302,4 @@ void D3D9Pad::SetClipDistance(float nr, float fr)
 	mP._33 = fr / (fr - nr);
 	mP._43 = -nr * mP._33;
 }
+

--- a/OVP/D3D9Client/D3D9Surface.cpp
+++ b/OVP/D3D9Client/D3D9Surface.cpp
@@ -2,7 +2,7 @@
 // D3D9Surface.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2011 - 2016 Jarmo Nikkanen
+// Copyright (C) 2011-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 #define STRICT
@@ -1318,3 +1318,4 @@ void NatDumpResource(LPDIRECT3DRESOURCE9 pResource)
 		oapiWriteLogV("DX9_DUMP: Size = (%u, %u)", desc.Width, desc.Height);
 	}
 }
+

--- a/OVP/D3D9Client/D3D9Surface.h
+++ b/OVP/D3D9Client/D3D9Surface.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __D3DSURFACE_H
@@ -156,3 +156,4 @@ public:
 
 
 #endif
+

--- a/OVP/D3D9Client/D3D9TextMgr.cpp
+++ b/OVP/D3D9Client/D3D9TextMgr.cpp
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -616,3 +616,4 @@ void D3D9Text::GlobalExit()
 }
 
 char *		 D3D9Text::Buffer = 0;
+

--- a/OVP/D3D9Client/D3D9TextMgr.h
+++ b/OVP/D3D9Client/D3D9TextMgr.h
@@ -2,7 +2,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2012-2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
@@ -125,3 +125,4 @@ private:
 	//
 	static char *		Buffer;
 };
+

--- a/OVP/D3D9Client/D3D9Util.cpp
+++ b/OVP/D3D9Client/D3D9Util.cpp
@@ -2,7 +2,7 @@
 // Utilities
 // Part of the ORBITER VISUALISATION PROJECT (OVP) D3D9 Client
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 //				 2012-2016 �mile "Bibi Uncle" Gr�goire
 // ==============================================================
@@ -471,7 +471,7 @@ void strremchr(char *str, int idx)
 
 // --------------------------------------------------------------
 // Improved version of fgets
-// Copyright (C) 2012 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // Return:
 // -1 = eof
 //  0 = invalid string
@@ -2098,4 +2098,5 @@ void ShaderClass::SetVSConstants(HANDLE hVar, void* data, UINT bytes)
 		LogErr("Shader::SetVSConstants() Failed. File[%s], Entrypoint[%s]", fn.c_str(), vsn.c_str());
 	}
 }
+
 

--- a/OVP/D3D9Client/D3D9Util.h
+++ b/OVP/D3D9Client/D3D9Util.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -773,3 +773,4 @@ struct AutoFile
 #define CLEARARRAY(p) { memset(p, 0, sizeof(p)); }
 
 #endif // !__D3DUTIL_H
+

--- a/OVP/D3D9Client/DebugControls.cpp
+++ b/OVP/D3D9Client/DebugControls.cpp
@@ -1,7 +1,7 @@
 // ===========================================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 
@@ -2099,5 +2099,6 @@ void OpenGFXDlgClbk(void *context)
 }
 
 } //namespace
+
 
 

--- a/OVP/D3D9Client/DebugControls.h
+++ b/OVP/D3D9Client/DebugControls.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __DEBUGCONTROLS_H
@@ -132,3 +132,4 @@ namespace DebugControls {
 };
 
 #endif // !__DEBUGCONTROLS_H
+

--- a/OVP/D3D9Client/GDIPad.cpp
+++ b/OVP/D3D9Client/GDIPad.cpp
@@ -2,7 +2,7 @@
 // GDIPad.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006 - 2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #include "GDIPad.h"
@@ -303,3 +303,4 @@ void GDIPad::PolyPolyline (const IVECTOR2 *pt, const int *npt, const int nline)
 {
 	::PolyPolyline (hDC, (const POINT*)pt, (const DWORD*)npt, nline);
 }
+

--- a/OVP/D3D9Client/GDIPad.h
+++ b/OVP/D3D9Client/GDIPad.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __GDIPAD_H
@@ -276,3 +276,4 @@ private:
 };
 
 #endif // !__GDIPAD_H
+

--- a/OVP/D3D9Client/HazeMgr.cpp
+++ b/OVP/D3D9Client/HazeMgr.cpp
@@ -2,7 +2,7 @@
 // HazeMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen
 // ============================================================================
 
@@ -526,4 +526,5 @@ LPDIRECT3DVERTEXBUFFER9 HazeManager2::pSkyVB[6];
 LPDIRECT3DVERTEXBUFFER9 HazeManager2::pRingVB = NULL;
 int HazeManager2::xreslvl[6] = {9,6,5,4,3,2};
 int HazeManager2::yreslvl[6] = {11,8,6,5,5,4};
+
 

--- a/OVP/D3D9Client/HazeMgr.h
+++ b/OVP/D3D9Client/HazeMgr.h
@@ -2,7 +2,7 @@
 // HazeMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -115,3 +115,4 @@ private:
 
 
 #endif // !__HAZEMGR_H
+

--- a/OVP/D3D9Client/IProcess.cpp
+++ b/OVP/D3D9Client/IProcess.cpp
@@ -1,6 +1,6 @@
 
 // ===================================================
-// Copyright (C) 2021 Jarmo Nikkanen
+// Copyright (C) 2021-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -807,3 +807,4 @@ int gcIPInterface::FindDefine(const char *key)
 {
 	return pIPI->FindDefine(key);
 }
+

--- a/OVP/D3D9Client/IProcess.h
+++ b/OVP/D3D9Client/IProcess.h
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2021 Jarmo Nikkanen
+// Copyright (C) 2021-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -159,3 +159,4 @@ private:
 };
 
 #endif
+

--- a/OVP/D3D9Client/Log.cpp
+++ b/OVP/D3D9Client/Log.cpp
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
@@ -487,3 +487,4 @@ void LogOk(const char *format, ...)
 		LeaveCriticalSection(&LogCrit);
 	}*/
 }
+

--- a/OVP/D3D9Client/Log.h
+++ b/OVP/D3D9Client/Log.h
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2012-2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -70,3 +70,4 @@ void   LogAttribs(DWORD attrib, DWORD w, DWORD h, LPCSTR origin);
 #define HALT() { RuntimeError(__FILE__,__FUNCTION__,__LINE__); }
 
 #endif
+

--- a/OVP/D3D9Client/MaterialMgr.cpp
+++ b/OVP/D3D9Client/MaterialMgr.cpp
@@ -1,7 +1,7 @@
 // ===========================================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2013 - 2016 Jarmo Nikkanen
+// Copyright (C) 2013-2026 Jarmo Nikkanen
 // ===========================================================================================
 
 
@@ -507,6 +507,7 @@ bool MatMgr::LoadCameraConfig()
 
 	return true;
 }
+
 
 
 

--- a/OVP/D3D9Client/MaterialMgr.h
+++ b/OVP/D3D9Client/MaterialMgr.h
@@ -2,7 +2,7 @@
 // MaterialMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2012 - 2016 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __MATERIALMGR_H
@@ -87,3 +87,4 @@ private:
 };
 
 #endif
+

--- a/OVP/D3D9Client/Mesh.cpp
+++ b/OVP/D3D9Client/Mesh.cpp
@@ -2,7 +2,7 @@
 // Mesh.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006 - 2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010 - 2022 Jarmo Nikkanen (D3D9Client implementation)
 // ==============================================================
 
@@ -3428,3 +3428,4 @@ void D3D9Mesh::GlobalExit()
 {
 	for (auto x : s_pShader) if (x) delete x;
 }
+

--- a/OVP/D3D9Client/Mesh.h
+++ b/OVP/D3D9Client/Mesh.h
@@ -2,7 +2,7 @@
 // Mesh.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2019 Jarmo Nikkanen
 // ==============================================================
 
@@ -373,3 +373,4 @@ private:
 };
 
 #endif // !__MESH_H
+

--- a/OVP/D3D9Client/MeshMgr.cpp
+++ b/OVP/D3D9Client/MeshMgr.cpp
@@ -2,7 +2,7 @@
 // MeshMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================
@@ -77,3 +77,4 @@ const D3D9Mesh *MeshManager::GetMesh (MESHHANDLE hMesh)
 	// Should we store the mesh here ??
 	return NULL;
 }
+

--- a/OVP/D3D9Client/MeshMgr.h
+++ b/OVP/D3D9Client/MeshMgr.h
@@ -2,7 +2,7 @@
 // MeshMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __MESHMGR_H

--- a/OVP/D3D9Client/Particle.cpp
+++ b/OVP/D3D9Client/Particle.cpp
@@ -2,7 +2,7 @@
 // Particle.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006 - 2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen (D3D9Client modification)
 // ==============================================================
 
@@ -848,3 +848,4 @@ void ReentryStream::Update ()
 		}
 	} else t0 = simt;
 }
+

--- a/OVP/D3D9Client/Particle.h
+++ b/OVP/D3D9Client/Particle.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -157,3 +157,4 @@ private:
 };
 
 #endif // !__PARTICLE_H
+

--- a/OVP/D3D9Client/Qtree.h
+++ b/OVP/D3D9Client/Qtree.h
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -154,3 +154,4 @@ void QuadTreeNode<T>::DelAbove(int lvl)
 }
 
 #endif // !__QTREE_H
+

--- a/OVP/D3D9Client/RingMgr.cpp
+++ b/OVP/D3D9Client/RingMgr.cpp
@@ -2,7 +2,7 @@
 // RingMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011 - 2106 Jarmo Nikkanen (D3D9Client modification)  
 // ==============================================================
 
@@ -196,3 +196,4 @@ D3D9Mesh *RingManager::CreateRing(double irad, double orad, int nsect)
 }
 
 oapi::D3D9Client *RingManager::gc = 0;
+

--- a/OVP/D3D9Client/RingMgr.h
+++ b/OVP/D3D9Client/RingMgr.h
@@ -2,7 +2,7 @@
 // RingMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007-2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __RINGMGR_H

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -2,7 +2,7 @@
 // Scene.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2012 - 2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -3838,3 +3838,4 @@ int distcomp (const void *arg1, const void *arg2)
 	double d2 = ((PList*)arg2)->dist;
 	return (d1 > d2 ? -1 : d1 < d2 ? 1 : 0);
 }
+

--- a/OVP/D3D9Client/Scene.h
+++ b/OVP/D3D9Client/Scene.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -537,3 +537,4 @@ private:
 };
 
 #endif // !__SCENE_H
+

--- a/OVP/D3D9Client/Spherepatch.cpp
+++ b/OVP/D3D9Client/Spherepatch.cpp
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -369,4 +369,5 @@ void ClearVBMesh (VBMESH &mesh)
 	mesh.vtx = nullptr;
 	mesh.idx = nullptr;
 }
+
 

--- a/OVP/D3D9Client/Spherepatch.h
+++ b/OVP/D3D9Client/Spherepatch.h
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -44,3 +44,4 @@ void CreateSpherePatch(LPDIRECT3DDEVICE9 pDev, VBMESH &mesh, int nlng, int nlat,
 void ClearVBMesh (VBMESH &mesh);
 
 #endif // !__SPHEREPATCH_H
+

--- a/OVP/D3D9Client/SurfMgr.cpp
+++ b/OVP/D3D9Client/SurfMgr.cpp
@@ -2,7 +2,7 @@
 // SurfMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen (D3D9Client modification)  
 // ==============================================================
 
@@ -223,3 +223,4 @@ void SurfaceManager::RenderTile (int lvl, int hemisp, int ilat, int nlat, int il
 	pDev->SetIndices(mesh.pIB);
 	pDev->DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 0, mesh.nv, 0, mesh.nf);
 }
+

--- a/OVP/D3D9Client/SurfMgr.h
+++ b/OVP/D3D9Client/SurfMgr.h
@@ -2,7 +2,7 @@
 // SurfMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007-2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __SURFMGR_H

--- a/OVP/D3D9Client/Surfmgr2.cpp
+++ b/OVP/D3D9Client/Surfmgr2.cpp
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -1880,3 +1880,4 @@ float* TileManager2<SurfTile>::BrowseElevationData(int lvl, int ilat, int ilng, 
 
 	return elev;
 }
+

--- a/OVP/D3D9Client/Surfmgr2.h
+++ b/OVP/D3D9Client/Surfmgr2.h
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -96,3 +96,4 @@ private:
 };
 
 #endif // !__SURFMGR2_H
+

--- a/OVP/D3D9Client/Texture.cpp
+++ b/OVP/D3D9Client/Texture.cpp
@@ -2,7 +2,7 @@
 // Texture.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006 -2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================
@@ -192,3 +192,4 @@ DWORD TextureManager::MakeTexId (const char *fname)
 	for (const char *c = fname; *c; c++) id += *c;
 	return id;
 }
+

--- a/OVP/D3D9Client/Texture.h
+++ b/OVP/D3D9Client/Texture.h
@@ -2,7 +2,7 @@
 // Texture.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================

--- a/OVP/D3D9Client/TileLabel.cpp
+++ b/OVP/D3D9Client/TileLabel.cpp
@@ -2,7 +2,7 @@
 // TileLabel.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2017 Martin Schweiger (martins/apogee)
+// Copyright (C) 2017-2026 Martin Schweiger (martins/apogee)
 //                    Peter Schneider (Kuddel)
 // ==============================================================
 
@@ -459,3 +459,4 @@ int TileLabel::LimitAndRotateLongLabelList(TLABEL *l, DWORD H, int *y)
 
 	return partLen;
 }
+

--- a/OVP/D3D9Client/TileLabel.h
+++ b/OVP/D3D9Client/TileLabel.h
@@ -2,7 +2,7 @@
 // TileLabel.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2017 Martin Schweiger (martins/apogee)
+// Copyright (C) 2017-2026 Martin Schweiger (martins/apogee)
 //                    Peter Schneider (Kuddel)
 // ==============================================================
 
@@ -55,3 +55,4 @@ private:
 };
 
 #endif // !__TILELABEL_H
+

--- a/OVP/D3D9Client/TileMgr.cpp
+++ b/OVP/D3D9Client/TileMgr.cpp
@@ -2,7 +2,7 @@
 // TileMgr.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006 - 2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen (D3D9Client modification)
 // ==============================================================
 
@@ -1290,4 +1290,5 @@ HANDLE TileBuffer::hQueueMutex = NULL;
 HANDLE TileBuffer::hLoadThread = NULL;
 HANDLE TileBuffer::hStopThread(CreateEvent(NULL, FALSE, FALSE, NULL));
 struct TileBuffer::QUEUEDESC TileBuffer::loadqueue[MAXQUEUE] = {0};
+
 

--- a/OVP/D3D9Client/TileMgr.h
+++ b/OVP/D3D9Client/TileMgr.h
@@ -2,7 +2,7 @@
 // TileMgr.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================
@@ -278,3 +278,4 @@ private:
 };
 
 #endif // !__TILEMGR_H
+

--- a/OVP/D3D9Client/Tilemgr2.cpp
+++ b/OVP/D3D9Client/Tilemgr2.cpp
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -1223,3 +1223,4 @@ MATRIX4 TileManager2Base::WorldMatrix (int ilng, int nlng, int ilat, int nlat)
 		return mul(lrot,prm.dwmat_tmp);
 	}
 }
+

--- a/OVP/D3D9Client/Tilemgr2.h
+++ b/OVP/D3D9Client/Tilemgr2.h
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -496,3 +496,4 @@ protected:
 };
 
 #endif // !__TILEMGR2_H
+

--- a/OVP/D3D9Client/Tilemgr2_imp.hpp
+++ b/OVP/D3D9Client/Tilemgr2_imp.hpp
@@ -1,6 +1,6 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -426,3 +426,4 @@ Tile *TileManager2<TileType>::SearchTileSub (const QuadTreeNode<TileType> *node,
 }
 
 #endif // !__TILEMGR2_IMP_HPP
+

--- a/OVP/D3D9Client/VBase.cpp
+++ b/OVP/D3D9Client/VBase.cpp
@@ -2,7 +2,7 @@
 // VBase.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007 - 2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 //				 2011 - 2016 Jarmo Nikkanen (D3D9Client modification)  
 // ==============================================================
 
@@ -554,3 +554,4 @@ void vBase::RenderGroundShadow(LPDIRECT3DDEVICE9 dev, float alpha)
 		}
 	}
 }
+

--- a/OVP/D3D9Client/VBase.h
+++ b/OVP/D3D9Client/VBase.h
@@ -2,7 +2,7 @@
 // VBase.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2007-2016 Martin Schweiger
+// Copyright (C) 2007-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __VBASE_H
@@ -99,3 +99,4 @@ private:
 };
 
 #endif // !__VBASE_H
+

--- a/OVP/D3D9Client/VObject.cpp
+++ b/OVP/D3D9Client/VObject.cpp
@@ -2,7 +2,7 @@
 // VObject.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010-2016 Jarmo Nikkanen (D3D9Client related parts)
 // ==============================================================
 
@@ -468,4 +468,5 @@ void vObject::RenderAxisLabel(D3D9Pad *pSkp, const D3DXCOLOR *clr, VECTOR3 vecto
 		pSkp->Text(xc + 10, yc, label, lstrlen(label));
 	}
 }
+
 

--- a/OVP/D3D9Client/VObject.h
+++ b/OVP/D3D9Client/VObject.h
@@ -2,7 +2,7 @@
 // VObject.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -274,3 +274,4 @@ protected:
 };
 
 #endif // !__VOBJECT_H
+

--- a/OVP/D3D9Client/VPlanet.cpp
+++ b/OVP/D3D9Client/VPlanet.cpp
@@ -2,7 +2,7 @@
 // VPlanet.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -1586,3 +1586,4 @@ void vPlanet::LoadMicroTextures(LPDIRECT3DDEVICE9 pDev)
 		}
 	}
 }
+

--- a/OVP/D3D9Client/VPlanet.h
+++ b/OVP/D3D9Client/VPlanet.h
@@ -2,8 +2,8 @@
 // VPlanet.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 //   Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
-// Copyright (C) 2012-2016 Jarmo Nikkanen
+// Copyright (C) 2006-2026 Martin Schweiger
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // ==============================================================
 
 #ifndef __VPLANET_H
@@ -484,3 +484,4 @@ public:
 };
 
 #endif // !__VPLANET_H
+

--- a/OVP/D3D9Client/VPlanetAtmo.cpp
+++ b/OVP/D3D9Client/VPlanetAtmo.cpp
@@ -2,7 +2,7 @@
 // VPlanet.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under LGPL v3
-// Copyright (C) 2006-2022 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010-2022 Jarmo Nikkanen
 // ==============================================================
 
@@ -1456,5 +1456,6 @@ void vPlanet::TestComputations(Sketchpad* pSkp)
 	}
 	pSkp->SetViewMode(Sketchpad::USER);
 }
+
 
 

--- a/OVP/D3D9Client/VStar.cpp
+++ b/OVP/D3D9Client/VStar.cpp
@@ -2,7 +2,7 @@
 // VStar.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 // ==============================================================
@@ -96,3 +96,4 @@ bool vStar::Render(LPDIRECT3DDEVICE9 dev)
 	D3D9Effect::RenderBillboard(&mWorld, SURFACE(deftex)->GetTexture(), 1.0f);
 	return true;
 }
+

--- a/OVP/D3D9Client/VStar.h
+++ b/OVP/D3D9Client/VStar.h
@@ -2,7 +2,7 @@
 // VStar.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // ==============================================================
 
 #ifndef __VSTAR_H

--- a/OVP/D3D9Client/VVessel.cpp
+++ b/OVP/D3D9Client/VVessel.cpp
@@ -2,7 +2,7 @@
 // VVessel.cpp
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010-2019 Jarmo Nikkanen (D3D9Client modification)
 // ==============================================================
 
@@ -2031,3 +2031,4 @@ const char *value_string (double val)
 	static char buf[16];
 	return value_string(buf, sizeof(buf), val);
 }
+

--- a/OVP/D3D9Client/VVessel.h
+++ b/OVP/D3D9Client/VVessel.h
@@ -2,7 +2,7 @@
 // VVessel.h
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -226,3 +226,4 @@ private:
 };
 
 #endif // !__VVESSEL_H
+

--- a/OVP/D3D9Client/VectorHelpers.h
+++ b/OVP/D3D9Client/VectorHelpers.h
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2013-2016 Jarmo Nikkanen
+// Copyright (C) 2013-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -340,4 +340,5 @@ inline D3DXVECTOR4 &operator*= (D3DXVECTOR4 &v, const D3DXVECTOR4 &d)
 }
 
 #endif
+
 

--- a/OVP/D3D9Client/VideoTab.cpp
+++ b/OVP/D3D9Client/VideoTab.cpp
@@ -4,7 +4,7 @@
 // Launchpad dialog.
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2010-2016 Jarmo Nikkanen (D3D9Client implementation)
 // ==============================================================
 
@@ -1130,5 +1130,6 @@ void VideoTab::ScanAtmoCfgs()
 		FindClose(hFile);
 	}
 }
+
 
 

--- a/OVP/D3D9Client/VideoTab.h
+++ b/OVP/D3D9Client/VideoTab.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2006-2016 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 //				 2012-2016 Jarmo Nikkanen
 // ==============================================================
 
@@ -65,3 +65,4 @@ private:
 //};
 
 #endif // !__VIDEOTAB_H
+

--- a/OVP/D3D9Client/WindowMgr.cpp
+++ b/OVP/D3D9Client/WindowMgr.cpp
@@ -1,7 +1,7 @@
 
 // =================================================================================================================================
 //
-// Copyright (C) 2019 Jarmo Nikkanen
+// Copyright (C) 2019-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
 // files (the "Software"), to use, copy, modify, merge, publish, distribute, interact with the Software and sublicense copies
@@ -1823,3 +1823,4 @@ void SideBar::PaintWindow()
 		else if (ap->hDlg) ShowWindow(ap->hDlg, SW_HIDE);
 	}
 }
+

--- a/OVP/D3D9Client/WindowMgr.h
+++ b/OVP/D3D9Client/WindowMgr.h
@@ -1,7 +1,7 @@
 
 // =================================================================================================================================
 //
-// Copyright (C) 2019 Jarmo Nikkanen
+// Copyright (C) 2019-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
 // files (the "Software"), to use, copy, modify, merge, publish, distribute, interact with the Software and sublicense copies
@@ -257,3 +257,4 @@ private:
 
 
 #endif
+

--- a/OVP/D3D9Client/ZTreeMgr.cpp
+++ b/OVP/D3D9Client/ZTreeMgr.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
 //   D3D9 Client module
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -216,3 +216,4 @@ void ZTreeMgr::ReleaseData (BYTE *data)
 	delete []data;
 	data = NULL;
 }
+

--- a/OVP/D3D9Client/ZTreeMgr.h
+++ b/OVP/D3D9Client/ZTreeMgr.h
@@ -1,7 +1,7 @@
 // ==============================================================
 //   ORBITER VISUALISATION PROJECT (OVP)
 //   D3D9 Client module
-//   Copyright (C) 2006-2016 Martin Schweiger
+//   Copyright (C) 2006-2026 Martin Schweiger
 //   Dual licensed under GPL v3 and LGPL v3
 // ==============================================================
 
@@ -142,3 +142,4 @@ private:
 /// @}
 
 #endif // !__ZTREEMGR_H
+

--- a/OVP/D3D9Client/gcConst.cpp
+++ b/OVP/D3D9Client/gcConst.cpp
@@ -1,7 +1,7 @@
 // =================================================================================================================================
 // The MIT Lisence:
 //
-// Copyright (C) 2013-2016 Jarmo Nikkanen
+// Copyright (C) 2013-2026 Jarmo Nikkanen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
 // files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
@@ -359,3 +359,4 @@ COLOUR4	gcConst::Colour4(DWORD dwABGR)
 {
 	return FVECTOR4(dwABGR).Colour4();
 }
+

--- a/OVP/D3D9Client/gcConst.h
+++ b/OVP/D3D9Client/gcConst.h
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -675,3 +675,4 @@ public:
 		mat->m41 = (pos.x);		  mat->m42 = (pos.y);		mat->m43 = (pos.z);		  mat->m44 = 1.0f;
 	}
 };
+

--- a/OVP/D3D9Client/gcCore.cpp
+++ b/OVP/D3D9Client/gcCore.cpp
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2021 Jarmo Nikkanen
+// Copyright (C) 2021-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -784,4 +784,5 @@ void gcCore2::ReleaseIPInterface(gcIPInterface* pIPI)
 	if (pIPI->pIPI) delete pIPI->pIPI;
 	delete pIPI;
 }
+
 

--- a/OVP/D3D9Client/gcCore.h
+++ b/OVP/D3D9Client/gcCore.h
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2012-2021 Jarmo Nikkanen
+// Copyright (C) 2012-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 
@@ -906,3 +906,4 @@ inline gcCore2* gcGetCoreInterface()
 }
 
 #endif // !__GC_CORE
+

--- a/OVP/D3D9Client/gcGUI.h
+++ b/OVP/D3D9Client/gcGUI.h
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2021 Jarmo Nikkanen
+// Copyright (C) 2021-2026 Jarmo Nikkanen
 // licensed under LGPL v2
 // ===================================================
 

--- a/OVP/D3D9Client/samples/DX9ExtMFD/ExtMFD.cpp
+++ b/OVP/D3D9Client/samples/DX9ExtMFD/ExtMFD.cpp
@@ -1,5 +1,5 @@
 // ==============================================================          
-// Copyright (C) 2006 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // Licensed under the MIT License
 // ==============================================================
 //
@@ -132,4 +132,5 @@ void OpenDlgClbk (void *context)
 //{
 //	oapiCloseDialog (hDlg);
 //}
+
 

--- a/OVP/D3D9Client/samples/DX9ExtMFD/MFDWindow.cpp
+++ b/OVP/D3D9Client/samples/DX9ExtMFD/MFDWindow.cpp
@@ -1,5 +1,5 @@
 // ==============================================================          
-// Copyright (C) 2006 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // Licensed under the MIT License
 // ==============================================================
 
@@ -335,3 +335,4 @@ LRESULT FAR PASCAL MFD_BtnProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 	return DefWindowProc (hWnd, uMsg, wParam, lParam);
 }
+

--- a/OVP/D3D9Client/samples/DX9ExtMFD/MFDWindow.h
+++ b/OVP/D3D9Client/samples/DX9ExtMFD/MFDWindow.h
@@ -1,5 +1,5 @@
 // ==============================================================          
-// Copyright (C) 2006 Martin Schweiger
+// Copyright (C) 2006-2026 Martin Schweiger
 // Licensed under the MIT License
 // ==============================================================
 
@@ -43,3 +43,4 @@ private:
 };
 
 #endif // !__MFDWINDOW_H
+

--- a/OVP/D3D9Client/samples/DrawOrbits/Draw.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Draw.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -667,3 +667,4 @@ void Orbits::CreateOrbitTemplates()
 		pHyperbolic[i] = pCore->CreatePoly(NULL, points, 512, 0);
 	}
 }
+

--- a/OVP/D3D9Client/samples/DrawOrbits/Orbit.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Orbit.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -586,3 +586,4 @@ void COrbit::CreateCircular(const VECTOR3 &_Pos, const VECTOR3 &_N, double Mu, d
 	VECTOR3 _Vel = unit(crossp_LH(_N, _Pos)) * sqrt(Mu / length(_Pos));
 	CreateFromStateVectors(_Pos, _Vel, Mu, MJD);
 }
+

--- a/OVP/D3D9Client/samples/DrawOrbits/Orbit.h
+++ b/OVP/D3D9Client/samples/DrawOrbits/Orbit.h
@@ -1,6 +1,6 @@
 
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -229,4 +229,5 @@ private:
 	VECTOR3 _Aux;	//!< Perpendicular to _Equ and _Pol
 	VECTOR3 _Pol;	//!< Reference Pole (i.e. _K_ECL)
 };
+
 

--- a/OVP/D3D9Client/samples/DrawOrbits/Reference.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Reference.cpp
@@ -1,6 +1,6 @@
 
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -327,3 +327,4 @@ double ReferenceClass::GetSOI(OBJHANDLE obj)
 	return(oapiGetSize(obj));
 
 }
+

--- a/OVP/D3D9Client/samples/DrawOrbits/Reference.h
+++ b/OVP/D3D9Client/samples/DrawOrbits/Reference.h
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -48,4 +48,5 @@ private:
 extern class ReferenceClass *Refer;
 
 #endif
+
 

--- a/OVP/D3D9Client/samples/DrawOrbits/Tools.cpp
+++ b/OVP/D3D9Client/samples/DrawOrbits/Tools.cpp
@@ -1,6 +1,6 @@
 
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -678,4 +678,5 @@ double CalculateSOI(OBJHANDLE obj, OBJHANDLE ref)
 }
 
 	
+
 

--- a/OVP/D3D9Client/samples/DrawOrbits/Tools.h
+++ b/OVP/D3D9Client/samples/DrawOrbits/Tools.h
@@ -1,6 +1,6 @@
 
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -508,3 +508,4 @@ double  GetHeading(OBJHANDLE Ref, VECTOR3 &_Pos, VECTOR3 &_Vel);
 //@}
 
 #endif
+

--- a/OVP/D3D9Client/samples/GenericCamera/MFD.cpp
+++ b/OVP/D3D9Client/samples/GenericCamera/MFD.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -625,4 +625,5 @@ void CameraMFD::ReadStatus(FILEHANDLE scn)
 		}
 	}
 }
+
 

--- a/OVP/D3D9Client/samples/GenericCamera/MFD.h
+++ b/OVP/D3D9Client/samples/GenericCamera/MFD.h
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -63,3 +63,4 @@ private:
 };
 
 #endif
+

--- a/OVP/D3D9Client/samples/GenericCamera/Shell.cpp
+++ b/OVP/D3D9Client/samples/GenericCamera/Shell.cpp
@@ -1,6 +1,6 @@
 
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -189,3 +189,4 @@ void ShellMFD::StoreStatus (void) const
 void ShellMFD::RecallStatus (void)
 {
 }
+

--- a/OVP/D3D9Client/samples/GenericCamera/Shell.h
+++ b/OVP/D3D9Client/samples/GenericCamera/Shell.h
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -77,3 +77,4 @@ private:
 };
 
 #endif 
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/Basics.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/Basics.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -430,3 +430,4 @@ VECTOR3 ToolKit::GetSurfacePosUnit(double lng, double lat)
 	oapiGetRotationMatrix(hPlanet, &mRot);
 	return mul(mRot, _V(w*cos(lng), sin(lat), w*sin(lng)));
 }
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/ExportImport.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/ExportImport.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -305,3 +305,4 @@ void ToolKit::OpenImage(Layer::LayerType lr)
 		}
 	}
 }
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/Layer.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/Layer.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -241,3 +241,4 @@ void Layer::UpdateProps()
 	else pProp->OpenEntry(hISec, false);
 	pProp->Update();
 }
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/QTree.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/QTree.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -427,3 +427,4 @@ int QTree::SaveTile(int flags, SURFHANDLE hSurf, SURFHANDLE hTemp, DRECT bounds,
 }
 
 	
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/ToolKit.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/ToolKit.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -1221,3 +1221,4 @@ void ToolKit::clbkPreStep(double simt, double simdt, double mjd)
 {
 	if (!pCore) return;
 }
+

--- a/OVP/D3D9Client/samples/TerrainToolKit/gcTableView.cpp
+++ b/OVP/D3D9Client/samples/TerrainToolKit/gcTableView.cpp
@@ -1,5 +1,5 @@
 // ==================================================================
-// Copyright (c) 2021 Jarmo Nikkanen
+// Copyright (c) 2021-2026 Jarmo Nikkanen
 // Licensed under the MIT License
 // ==================================================================
 
@@ -928,3 +928,4 @@ int gcPropertyTree::AddComboBoxItem(HPROP hCombo, const char *label)
 	if (!hCombo->hCtrl) return -1;
 	return int(SendMessage(hCombo->hCtrl, CB_ADDSTRING, 0, (LPARAM)label));
 }
+

--- a/OVP/D3D9Client/shaders/CelSphere.hlsl
+++ b/OVP/D3D9Client/shaders/CelSphere.hlsl
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Licensed under LGPL v2
-// Copyright (C) 2021 Jarmo Nikkanen
+// Copyright (C) 2021-2026 Jarmo Nikkanen
 // ==============================================================
 
 #define BOOL bool
@@ -59,3 +59,4 @@ float4 CelPS(CelSphereVS frg) : COLOR
 	if (Flow.bBeta)  vColor += tex2D(tTexB, frg.tex0).rgb * Const.fBeta;
 	return float4(vColor, 1.0);
 }
+

--- a/OVP/D3D9Client/shaders/GDIOverlay.hlsl
+++ b/OVP/D3D9Client/shaders/GDIOverlay.hlsl
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2016 Jarmo Nikkanen
+// Copyright (C) 2016-2026 Jarmo Nikkanen
 // ==============================================================
 
 uniform extern float4  vColorKey;

--- a/OVP/D3D9Client/shaders/Glare.hlsl
+++ b/OVP/D3D9Client/shaders/Glare.hlsl
@@ -1,5 +1,5 @@
 // ===================================================
-// Copyright (C) 2022 Jarmo Nikkanen
+// Copyright (C) 2022-2026 Jarmo Nikkanen
 // licensed under MIT
 // ===================================================
 
@@ -244,5 +244,6 @@ float4 CreateSunTexPS(float u : TEXCOORD0, float v : TEXCOORD1) : COLOR
 	T = saturate(1.0f - exp(-T));
 	return float4(1, 1, 1, T);
 }
+
 
 

--- a/OVP/D3D9Client/shaders/LightBlur.hlsl
+++ b/OVP/D3D9Client/shaders/LightBlur.hlsl
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2016 Jarmo Nikkanen
+// Copyright (C) 2016-2026 Jarmo Nikkanen
 //				 2016 SolarLiner (Nathan Graule)
 // ==============================================================
 
@@ -178,4 +178,5 @@ float4 PSNormal(float tx : TEXCOORD0, float ty : TEXCOORD1) : COLOR
 	float2 xy = (q.xy + 1.0f) * 0.5f;
 	return float4(xy, abs(q.z), 1.0f);
 }
+
 

--- a/OVP/D3D9Client/shaders/NewMesh.hlsl
+++ b/OVP/D3D9Client/shaders/NewMesh.hlsl
@@ -1,7 +1,7 @@
 // ==============================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // Dual licensed under GPL v3 and LGPL v3
-// Copyright (C) 2022 Jarmo Nikkanen
+// Copyright (C) 2022-2026 Jarmo Nikkanen
 // ==============================================================
 
 #define BOOL bool
@@ -170,3 +170,4 @@ float4 NormalDepth_PS(NormalTexVS frg) : COLOR
 	float z = sqrt(saturate(1.0 - (x * x + y * y)));
 	return float4(x, y, z, D);
 }
+

--- a/OVP/D3D9Client/shaders/NewPlanet.hlsl
+++ b/OVP/D3D9Client/shaders/NewPlanet.hlsl
@@ -1,7 +1,7 @@
 // ============================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // licensed under LGPL v2
-// Copyright (C) 2022 Jarmo Nikkanen
+// Copyright (C) 2022-2026 Jarmo Nikkanen
 // ============================================================================
 
 #include "Scatter.hlsl"
@@ -965,3 +965,4 @@ float4 GiantCloudPS(CldVS frg) : COLOR
 
 	return float4(HDR(cTex.rgb), saturate(cTex.a));
 }
+

--- a/OVP/D3D9Client/shaders/Scatter.hlsl
+++ b/OVP/D3D9Client/shaders/Scatter.hlsl
@@ -2,7 +2,7 @@
 // ============================================================================
 // Part of the ORBITER VISUALISATION PROJECT (OVP)
 // licensed under MIT
-// Copyright (C) 2022 Jarmo Nikkanen
+// Copyright (C) 2022-2026 Jarmo Nikkanen
 // ============================================================================
 
 #if defined(_PERFORMANCE) // DO NOT CHANGE THESE, MUST MATCH WITH C++ CODE
@@ -769,3 +769,4 @@ float4 LandViewAtten(float u : TEXCOORD0, float v : TEXCOORD1) : COLOR
 
 	return float4(ret, 1.0);
 }
+

--- a/OVP/README.txt
+++ b/OVP/README.txt
@@ -1,6 +1,6 @@
 ORBITER VISUALISATION PROJECT
 Graphics Client Plugins for Orbiter Space Flight Simulator
-Copyright (C) 2006-2014  Martin Schweiger
+Copyright (C) 2006-2026  Martin Schweiger
 
 
 The aim of the Orbiter Visualisation Project (OVP) is to provide 3-D
@@ -67,4 +67,5 @@ instructions.
 - Launch orbiter_ng.exe from your Orbiter main directory, activate the D3D7Client
   module on the Modules tab, set the parameters on the Video tab, and launch a
   scenario.
+
 

--- a/Orbitersdk/doxygen/API_reference/mainpage.h
+++ b/Orbitersdk/doxygen/API_reference/mainpage.h
@@ -1,6 +1,6 @@
 /** \mainpage Orbiter API Reference Manual
   \image html banner.png
-  <center>Orbiter Software and documentation Copyright (C) 2016 Martin Schweiger</center>
+  <center>Orbiter Software and documentation Copyright (C) 2016-2026 Martin Schweiger</center>
 
   The Orbiter SDK Package contains this document in compiled HTML format (CHM) and in
   hyperlinked PDF format.

--- a/Orbitersdk/samples/Lua/Atlantis/Src/CameraMFD.lua
+++ b/Orbitersdk/samples/Lua/Atlantis/Src/CameraMFD.lua
@@ -1,4 +1,4 @@
--- Copyright (c) 2021 Jarmo Nikkanen
+-- Copyright (c) 2021-2026 Jarmo Nikkanen
 -- Copyright 2024 (c) Gondos
 -- Licensed under the MIT License
 
@@ -347,3 +347,4 @@ end
 -- Return a module created from CameraMFD
 -- ==============================================================
 return MFDModule(CameraMFD)
+

--- a/Sound/XRSound/assets/XRSound/ReadMe.txt
+++ b/Sound/XRSound/assets/XRSound/ReadMe.txt
@@ -3,7 +3,7 @@ XRSound 3.0
 
 Version Date: 31-Jul-2021
   
-Copyright (c) 2018-2021 Douglas Beachy
+Copyright (c) 2018-2026 Douglas Beachy
 Licensed under the MIT license
 
 https://www.alteaaerospace.com
@@ -19,7 +19,7 @@ LICENSE
 
 MIT License
 
-Copyright (c) 2018-2021 Douglas Beachy
+Copyright (c) 2018-2026 Douglas Beachy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -70,3 +70,4 @@ You are now ready to launch Orbiter, and you should hear default sounds playing 
 Happy orbiting!
 
 -- end --
+

--- a/Sound/XRSound/src/AnimationState.h
+++ b/Sound/XRSound/src/AnimationState.h
@@ -2,7 +2,7 @@
 // Defines the AnimationState class.
 // Tracks the state of a single vessel animation (or "door") across frames; used for default sounds.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -64,3 +64,4 @@ public:
         }
     }
 };
+

--- a/Sound/XRSound/src/DefaultSoundGroupPreSteps.cpp
+++ b/Sound/XRSound/src/DefaultSoundGroupPreSteps.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // Implements default group sound handlers for XRSound.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -669,4 +669,5 @@ void MusicDefaultSoundGroupPreStep::clbkPreStep(const double simt, const double 
         // else song is already playing, so nothing more to do
     }
 }
+
 

--- a/Sound/XRSound/src/DefaultSoundGroupPreSteps.h
+++ b/Sound/XRSound/src/DefaultSoundGroupPreSteps.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Defines the default group sound handlers for XRSound.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -153,3 +153,4 @@ public:
 protected:
     double m_startNextSongRealtime;  // -1 = "not set yet"
 };
+

--- a/Sound/XRSound/src/ModuleXRSoundEngine.cpp
+++ b/Sound/XRSound/src/ModuleXRSoundEngine.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound engine class bound to an Orbiter module (i.e., to a unique ID).
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -111,3 +111,4 @@ void ModuleXRSoundEngine::UpdateSoundState(WavContext &context)
         }
     }
 }
+

--- a/Sound/XRSound/src/ModuleXRSoundEngine.h
+++ b/Sound/XRSound/src/ModuleXRSoundEngine.h
@@ -2,7 +2,7 @@
 // XRSoundEngine class that is bound to an Orbiter module (i.e., to a unique ID); this file is not distributed with XRSound.
 // The code for this exists in XRSound.dll.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -35,3 +35,4 @@ private:
     ModuleXRSoundEngine(const char *pUniqueModuleName);
     virtual ~ModuleXRSoundEngine() override;
 };
+

--- a/Sound/XRSound/src/SoundPreSteps.cpp
+++ b/Sound/XRSound/src/SoundPreSteps.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // Implements default sounds handlers for XRSound.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -1109,3 +1109,4 @@ void DisableAutopilotsForTimeAccPreStep::clbkPreStep(const double simt, const do
         }
     }
 }
+

--- a/Sound/XRSound/src/SoundPreSteps.h
+++ b/Sound/XRSound/src/SoundPreSteps.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // Defines the default sounds for XRSound.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -293,3 +293,4 @@ public:
     DisableAutopilotsForTimeAccPreStep(VesselXRSoundEngine *pEngine);
     virtual void clbkPreStep(const double simt, const double simdt, const double mjd) override;
 };
+

--- a/Sound/XRSound/src/Utils/ConfigFileParser.cpp
+++ b/Sound/XRSound/src/Utils/ConfigFileParser.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // From the XR Vessel Framework
 // 
-// Copyright (c) 2006-2021 Douglas Beachy
+// Copyright (c) 2006-2026 Douglas Beachy
 // Licensed under the MIT License
 //
 // ConfigFileParser.cpp
@@ -360,4 +360,5 @@ bool ConfigFileParser::ValidateFloat(const float value, const float min, const f
 
     return retVal;
 }
+
 

--- a/Sound/XRSound/src/Utils/ConfigFileParser.h
+++ b/Sound/XRSound/src/Utils/ConfigFileParser.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // From the XR Vessel Framework
 //
-// Copyright (c) 2006-2021 Douglas Beachy
+// Copyright (c) 2006-2026 Douglas Beachy
 // Licensed under the MIT License
 //
 // ConfigFileParser.h
@@ -88,3 +88,4 @@ protected:
 private:
     std::string m_logPrefix;
 };
+

--- a/Sound/XRSound/src/Utils/ConfigFileParserMacros.h
+++ b/Sound/XRSound/src/Utils/ConfigFileParserMacros.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // From the XR Vessel Framework.
 //
-// Copyright (c) 2006-2021 Douglas Beachy
+// Copyright (c) 2006-2026 Douglas Beachy
 // Licensed under the MIT license
 //
 // ConfigFileParserMacros.h

--- a/Sound/XRSound/src/Utils/FileList.cpp
+++ b/Sound/XRSound/src/Utils/FileList.cpp
@@ -2,7 +2,7 @@
 // Parses a tree of files, optionally recursing subdirectories,
 // and invoking an abstract callback method for each file and folder.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -196,4 +196,5 @@ const std::string *FileList::FindFileWithBasename(const char *pBasename) const
 
     return nullptr;
 }
+
 

--- a/Sound/XRSound/src/Utils/FileList.h
+++ b/Sound/XRSound/src/Utils/FileList.h
@@ -2,7 +2,7 @@
 // Parses a tree of files, optionally recursing subdirectories,
 // and invoking an abstract callback method for each file and folder.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT license
 // ==============================================================
 
@@ -73,3 +73,4 @@ protected:
 
     vector<std::string> m_allFiles;     // full path of all files in the tree, starting with pRootPath.
 };
+

--- a/Sound/XRSound/src/VesselXRSoundEngine.cpp
+++ b/Sound/XRSound/src/VesselXRSoundEngine.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound engine class bound to a vessel.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -836,3 +836,4 @@ DefaultSoundGroupPreStep *VesselXRSoundEngine::FindDefaultSoundGroupPreStep(cons
 
     return pFound;
 }
+

--- a/Sound/XRSound/src/VesselXRSoundEngine.h
+++ b/Sound/XRSound/src/VesselXRSoundEngine.h
@@ -2,7 +2,7 @@
 // XRSoundEngine class that is bound to an Orbiter vessel; this file is not distributed with XRSound.
 // The code for this exists in XRSound.dll.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 

--- a/Sound/XRSound/src/XRSound.cpp
+++ b/Sound/XRSound/src/XRSound.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound source file with static methods.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 

--- a/Sound/XRSound/src/XRSound.h
+++ b/Sound/XRSound/src/XRSound.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound.h : Defines the XRSound 2.0 public API.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -239,3 +239,4 @@ protected:
     // this has protected access to prevent incorrect instantiation by vessel code: always use the static XRSound::CreateInstance method to create an instance of XRSound
     XRSound() { }
 };
+

--- a/Sound/XRSound/src/XRSoundConfigFileParser.cpp
+++ b/Sound/XRSound/src/XRSoundConfigFileParser.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundConfigFileParser.cpp : Parses XRSound.cfg
 //
-// Copyright (c) 2018 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 //
 // This software is FREEWARE and may not be sold!e
@@ -662,3 +662,4 @@ int AnimationSounds::GetSoundIDForAnimationState(AnimationState::StateType state
     }
     return animationID;
 }
+

--- a/Sound/XRSound/src/XRSoundConfigFileParser.h
+++ b/Sound/XRSound/src/XRSoundConfigFileParser.h
@@ -2,7 +2,7 @@
 // XRSoundConfigFileParser.h
 // Parses XRSound.cfg
 //
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -232,3 +232,4 @@ protected:
     // key = animation ID, value = AnimationSounds for that animation
     HASHMAP_ANIMATIONID_ANIMATIONSOUNDS m_animationSoundsMap;
 };
+

--- a/Sound/XRSound/src/XRSoundDLL.cpp
+++ b/Sound/XRSound/src/XRSoundDLL.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundDLL.cpp : Main class file for XRSound Orbiter module.
 //
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -455,3 +455,4 @@ void XRSoundDLL::WriteLog(const char *pMsg)
 {
     GetGlobalConfig().WriteLog(pMsg);
 }
+

--- a/Sound/XRSound/src/XRSoundDLL.h
+++ b/Sound/XRSound/src/XRSoundDLL.h
@@ -2,7 +2,7 @@
 // Defines the XRSound API engine implementation; this file is not distributed with XRSound.
 // The code for this exists in XRSound.dll.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -74,3 +74,4 @@ protected:
     double m_nextIrrKlangUpdateRealtime;
     double m_absoluteSimTime;   // replaces simt and oapiGetSimTime(), both of which are unreliable!  See note in XRSoundDLL::clbkPreStep.
 };
+

--- a/Sound/XRSound/src/XRSoundEngine.cpp
+++ b/Sound/XRSound/src/XRSoundEngine.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound engine implementation.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -606,3 +606,4 @@ bool XRSoundEngine::PauseOrReumseMusic(const bool bPause)
 
     return bRetVal;
 }
+

--- a/Sound/XRSound/src/XRSoundEngine.h
+++ b/Sound/XRSound/src/XRSoundEngine.h
@@ -2,7 +2,7 @@
 // Base class for the XRSound API engine implementation; this file is not distributed with XRSound.
 // The code for this exists in XRSound.dll.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -273,3 +273,4 @@ private:
 // calling convention, NOT the normal __stdcall that C++ uses.
 extern "C" typedef XRSoundEngine* (__cdecl* VesselXRSoundEngineInstanceFuncPtr)(OBJHANDLE hVessel);
 extern "C" typedef XRSoundEngine* (__cdecl* ModuleXRSoundEngineInstanceFuncPtr)(const char* pUniqueModuleName);
+

--- a/Sound/XRSound/src/XRSoundEngine10.h
+++ b/Sound/XRSound/src/XRSoundEngine10.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundEngine10.h : Defines the XRSoundEngine version 1.x interface.
 //
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -53,3 +53,4 @@ public:
 #else
 #define BUILD_TYPE "Release"
 #endif
+

--- a/Sound/XRSound/src/XRSoundEngine20.h
+++ b/Sound/XRSound/src/XRSoundEngine20.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundEngine20.h : Defines the XRSoundEngine version 2.x interface.
 //
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -21,3 +21,4 @@ public:
     virtual EngineType GetEngineType() = 0;
     virtual const char *GetLogID() = 0;  // e.g., vessel or module name
 };
+

--- a/Sound/XRSound/src/XRSoundEngine30.cpp
+++ b/Sound/XRSound/src/XRSoundEngine30.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound engine implementation.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -115,3 +115,4 @@ int XRSoundEngine::GetPlayPosition(const int soundID)
     }
     return retVal;
 }
+

--- a/Sound/XRSound/src/XRSoundEngine30.h
+++ b/Sound/XRSound/src/XRSoundEngine30.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundEngine30.h : Defines the XRSoundEngine version 2.x interface.
 //
-// Copyright (c) 2021 Douglas Beachy
+// Copyright (c) 2021-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 
@@ -24,3 +24,4 @@ public:
     virtual bool  SetPlayPosition(const int soundID, const unsigned int positionMillis) = 0;
     virtual int   GetPlayPosition(const int soundID) = 0;
 };
+

--- a/Sound/XRSound/src/XRSoundImpl.cpp
+++ b/Sound/XRSound/src/XRSoundImpl.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSound static library main source file.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 //
 // This software is FREEWARE and may not be sold!
@@ -392,3 +392,4 @@ bool XRSoundImpl::HaveMinDLLVersion(const float minimumVersionRequired) const
 {
     return (GetVersion() >= minimumVersionRequired);  // also checks IsPresent()
 }
+

--- a/Sound/XRSound/src/XRSoundImpl.h
+++ b/Sound/XRSound/src/XRSoundImpl.h
@@ -1,7 +1,7 @@
 // ==============================================================
 // XRSoundImpl.h : Defines the XRSound API implementation; this file is not distributed with XRSound.
 // 
-// Copyright (c) 2018-2021 Douglas Beachy
+// Copyright (c) 2018-2026 Douglas Beachy
 // Licensed under the MIT License
 // ==============================================================
 

--- a/Src/Module/LuaScript/LuaInline/LuaInline.cpp
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.cpp
@@ -4,7 +4,7 @@
 // ==============================================================
 //           ORBITER MODULE: LUA Inline Interpreter
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2007 Martin Schweiger
+//            Copyright (C) 2007-2026 Martin Schweiger
 //                   All rights reserved
 //
 // LuaInline.cpp
@@ -258,3 +258,4 @@ DLLCLBK lua_State *opcGetLua (INTERPRETERHANDLE hInterp)
 	InterpreterList::Environment *env = (InterpreterList::Environment*)hInterp;
 	return env->interp->GetState();
 }
+

--- a/Src/Module/LuaScript/LuaInline/LuaInline.h
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.h
@@ -4,7 +4,7 @@
 // ==============================================================
 //           ORBITER MODULE: LUA Inline Interpreter
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2007 Martin Schweiger
+//            Copyright (C) 2007-2026 Martin Schweiger
 //                   All rights reserved
 //
 // LuaInline.h

--- a/Src/Module/LuaScript/LuaInterpreter/lua_xrsound.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/lua_xrsound.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 TheGondos
+// Copyright (c) 2024-2026 TheGondos
 // Licensed under the MIT License
 
 #define INTERPRETER_IMPLEMENTATION
@@ -557,4 +557,5 @@ int Interpreter::xrsound_collect(lua_State *L)
 	delete snd;
 	return 0;
 }
+
 

--- a/Src/Orbiter/Disclaimer.txt
+++ b/Src/Orbiter/Disclaimer.txt
@@ -2,10 +2,11 @@ Orbiter Space Flight Simulator
 
 MIT License
 
-Copyright 2000-2021 Martin Schweiger
+Copyright 2000-2026 Martin Schweiger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/Src/Orbiter/DlgMgr.cpp
+++ b/Src/Orbiter/DlgMgr.cpp
@@ -647,7 +647,7 @@ Added:
 
 MIT License
 
-Copyright (c) 2021 Patrick
+Copyright (c) 2021-2026 Patrick
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1213,3 +1213,4 @@ namespace ImGui {
 		ImGui::EndChild();
 	}
 }
+

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -3,7 +3,7 @@
 
 // ==============================================================
 //              This file is part of ORBITER
-//          Copyright 2000-2007 Martin Schweiger
+//          Copyright 2000-2026 Martin Schweiger
 //
 // Vessel.cpp
 // Implementation of class Vessel
@@ -9021,3 +9021,4 @@ int VESSEL4::clbkNavProcess (int mode)
 {
 	return mode;
 }
+

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -3,7 +3,7 @@
 
 // ==============================================================
 //              This file is part of ORBITER
-//          Copyright 2000-2007 Martin Schweiger
+//          Copyright 2000-2026 Martin Schweiger
 //
 // Vessel.h
 // Interface of class Vessel
@@ -1860,4 +1860,5 @@ private:
 };
 
 #endif // !__VESSEL_H
+
 

--- a/Src/Orbiter/about.hpp.in
+++ b/Src/Orbiter/about.hpp.in
@@ -6,20 +6,20 @@
 
 #define NAME1 "ORBITER Space Flight Simulator"
 
-#define SIG1A "(c) 2000-2023 Martin Schweiger"
+#define SIG1A "(c) 2000-2026 Martin Schweiger"
 
-#define SIG1B "Copyright (c) 2000-2023 Martin Schweiger"
+#define SIG1B "Copyright (c) 2000-2026 Martin Schweiger"
 
-#define SIG1AA "(c) 2000-2023"
+#define SIG1AA "(c) 2000-2026"
 
 #define SIG1AB "Martin Schweiger"
 
-#define SIG2 "orbit.medphys.ucl.ac.uk"
+#define SIG2 "openorbiter.space"
 
 #ifdef ISBETA
-  #define SIG4 "Build @DATE@ [v.@VERSION@ BETA]"
+#define SIG4 "Build @DATE@ [v.@VERSION@ BETA]"
 #else
-  #define SIG4 "Build @DATE@ [v.@VERSION@]"
+#define SIG4 "Build @DATE@ [v.@VERSION@]"
 #endif
 
 #define SIG5 "orbiter-forum.com"

--- a/Src/Plugin/ExtMFD/ExtMFD.cpp
+++ b/Src/Plugin/ExtMFD/ExtMFD.cpp
@@ -4,7 +4,7 @@
 // ==============================================================
 //                  ORBITER MODULE: ExtMFD
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2006 Martin Schweiger
+//            Copyright (C) 2006-2026 Martin Schweiger
 //                   All rights reserved
 //
 // ExtMFD.cpp
@@ -90,3 +90,4 @@ void OpenDlgClbk (void *context)
 	MFDSPEC spec = {{0,0,100,100},6,6,10,10};
 	oapiRegisterExternMFD (new MFDWindow (spec), spec);
 }
+

--- a/Src/Plugin/ExtMFD/MFDWindow.cpp
+++ b/Src/Plugin/ExtMFD/MFDWindow.cpp
@@ -4,7 +4,7 @@
 // ==============================================================
 //                  ORBITER MODULE: ExtMFD
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2006 Martin Schweiger
+//            Copyright (C) 2006-2026 Martin Schweiger
 //                   All rights reserved
 //
 // MFDWindow.cpp
@@ -259,3 +259,4 @@ void MFDWindow::ToggleStickToVessel()
 		SetVessel(oapiGetFocusObject());
 	}
 }
+

--- a/Src/Plugin/ExtMFD/MFDWindow.h
+++ b/Src/Plugin/ExtMFD/MFDWindow.h
@@ -4,7 +4,7 @@
 // ==============================================================
 //                  ORBITER MODULE: ExtMFD
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2006 Martin Schweiger
+//            Copyright (C) 2006-2026 Martin Schweiger
 //                   All rights reserved
 //
 // MFDWindow.h

--- a/Src/Plugin/Notes/Notes.cpp
+++ b/Src/Plugin/Notes/Notes.cpp
@@ -4,7 +4,7 @@
 // ==============================================================
 //                  ORBITER MODULE: ExtMFD
 //                  Part of the ORBITER SDK
-//            Copyright (C) 2006 Martin Schweiger
+//            Copyright (C) 2006-2026 Martin Schweiger
 //                   All rights reserved
 //
 // ExtMFD.cpp
@@ -257,3 +257,4 @@ static void OpenDlgClbk (void *context)
 	ImGuiNote *note = new ImGuiNote();
 	oapiOpenDialog(note);
 }
+

--- a/Src/Vessel/Atlantis/Common.cpp
+++ b/Src/Vessel/Atlantis/Common.cpp
@@ -1,7 +1,7 @@
 // ==============================================================
 //                 ORBITER MODULE: Atlantis
 //                  Part of the ORBITER SDK
-//          Copyright (C) 2001-2003 Martin Schweiger
+//          Copyright (C) 2001-2026 Martin Schweiger
 //                   All rights reserved
 //
 // Common.cpp
@@ -88,4 +88,5 @@ void GetSRB_State (double met, double &thrust_level, double &prop_level)
 	thrust_level = SRB_ThrSCL[i] * (met-SRB_Seq[i]) + SRB_Thrust[i];
 	prop_level = SRB_PrpSCL[i] * (met-SRB_Seq[i]) + SRB_Prop[i];
 }
+
 

--- a/Utils/Pltex/Pltex.cpp
+++ b/Utils/Pltex/Pltex.cpp
@@ -251,7 +251,7 @@ int main (int argc, char *argv[])
 
 	cout << "+-----------------------------------------------------------------------+\n";
 	cout << "|             pltex: Planetary texture manager for ORBITER              |\n";
-	cout << "|        Build: " << __DATE__ << "      (c) 2001-2008 Martin Schweiger         |\n";
+	cout << "|        Build: " << __DATE__ << "      (c) 2001-2026 Martin Schweiger         |\n";
 	cout << "+-----------------------------------------------------------------------+\n\n";
 
 	for (;;) {
@@ -2827,3 +2827,4 @@ DWORD CopyDDS (FILE *ftgt, FILE *fsrc, DWORD idx, bool idx_is_ofs)
 
 	return tsize;
 }
+

--- a/Utils/meshc/meshc.cpp
+++ b/Utils/meshc/meshc.cpp
@@ -166,7 +166,7 @@ int main (int argc, char *argv[])
 
 	cout << "+-----------------------------------------------------------------------+\n";
 	cout << "|                   meshc: Mesh compiler for ORBITER                    |\n";
-	cout << "|        Build: " << __DATE__ << "      (c) 2001-2018 Martin Schweiger         |\n";
+	cout << "|        Build: " << __DATE__ << "      (c) 2001-2026 Martin Schweiger         |\n";
 	cout << "+-----------------------------------------------------------------------+\n\n";
 
 	ParseArgs(argc, argv, &param);


### PR DESCRIPTION
It was bugging me that the Launchpad showed both an incorrect copyright year *as well* as showing a since-sadly-defunct website. Fixed up both in this little PR.

Lots of files modified, all just copyright year updates. Figured I might as well regex everything while I'm there. The only file that actually matters is [‎Src/Orbiter/about.hpp.in](https://github.com/orbitersim/orbiter/pull/648/changes/027721863446f3b3bb1395327a06270debb18675#diff-3ca95745372a874a2d68006527690de5b842d567c53bc51488a1a4bbcb44338e).