### PR TITLE
Fix for a missing normal in mesh processing

### DIFF
--- a/Src/Orbiter/Mesh.cpp
+++ b/Src/Orbiter/Mesh.cpp
@@ -894,7 +894,16 @@ istream &operator>> (istream &is, Mesh &mesh)
 					if (bnormal) {
 						j = sscanf (cbuf, "%f%f%f%f%f%f%f%f",
 							&v.x, &v.y, &v.z, &v.nx, &v.ny, &v.nz, &v.tu, &v.tv);
-						if (j < 6) calcnml = true;
+						if (j < 6) {
+							calcnml = true;
+							// sscanf wrote UV coords into normal fields - relocate them
+							v.tu = v.nx;
+							v.tv = v.ny;
+							// Zero the normal so CalcNormals() will recalculate this vertex
+							v.nx = 0.0f;
+							v.ny = 0.0f;
+							v.nz = 0.0f;
+						}
 					} else {
 						j = sscanf (cbuf, "%f%f%f%f%f",
 							&v.x, &v.y, &v.z, &v.tu, &v.tv);


### PR DESCRIPTION
Fixes #605.
The issue is as described originally - while parsing mesh vertices, if we have any normals in the group header, but a specific vertex line is missing normal values, sscanf just blindly writes whatever it finds into the struct fields in order. This causes incorrect UV values and zeroes out v.nz, v.tu and v.tv. This then causes a downstream consequence in CalcNormals() when it runs with missingonly = true. I took the originally proposed fix and just fixed the mistake where the vars were t.nx/ny/nz instead of v.nx/ny/nz.