### PR TITLE
Fix phantom vessel drag

### DIFF
--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -350,6 +350,7 @@ void Vessel::DefaultGenericCaps ()
 	CWz[1]             = 0.3;
 	CWx                = 0.3;
 	CWy                = 0.3;
+	bCWexplicit        = false;
 	wingaspect         = 1.0;
 	wingeff            = 2.8;
 	trim_scale         = 0.0;
@@ -517,8 +518,10 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 	} else 
 		GetItemReal (ifs, "COG_OverGround", cog_elev);  // obsolete
 
-	if (GetItemString (ifs, "CW", cbuf))
+	if (GetItemString (ifs, "CW", cbuf)) {
 		sscanf (cbuf, "%lf%lf%lf%lf", CWz, CWz+1, &CWx, &CWy);
+		bCWexplicit = true;
+	}
 	GetItemReal   (ifs, "WingAspect", wingaspect);
 	GetItemReal   (ifs, "WingEffectiveness", wingeff);
 	GetItemVector (ifs, "CrossSections", cs);
@@ -4227,6 +4230,8 @@ void Vessel::UpdateAerodynamicForces ()
 
 void Vessel::UpdateAerodynamicForces_OLD ()
 {
+	if (!bCWexplicit) return; // no explicit drag definition = no legacy drag (issue #573)
+
 	const double eps = 1e-8;
 
 	if (sp.airspd < eps) return; // nothing to do
@@ -7168,6 +7173,7 @@ void VESSEL::SetCW (double cw_z_pos, double cw_z_neg, double cw_x, double cw_y) 
 	vessel->CWz[1] = cw_z_neg;
 	vessel->CWx    = cw_x;
 	vessel->CWy    = cw_y;
+	vessel->bCWexplicit = true;
 
 	vessel->vd_forw = vessel->cs.z * 0.5*vessel->CWz[0];
 	vessel->vd_back = vessel->cs.z * 0.5*vessel->CWz[1];

--- a/Src/Orbiter/Vessel.h
+++ b/Src/Orbiter/Vessel.h
@@ -1594,6 +1594,7 @@ private:
 	double emass, fmass, pfmass; // empty mass, current total fuel mass, previous total fuel mass
 	double cog_elev;             // elevation of centre of gravity over ground when landed
 	double CWz[2], CWx, CWy;     // wind resistance form factors (forward/backward,vert,side)
+	bool bCWexplicit;             // true if CW coefficients were explicitly set (via API or config)
 	double wingfactor;           // aspect ratio * effectiveness factor // OBSOLETE
 	double wingaspect, wingeff;  // wing form factors
 	double pitch_moment_scale;   // scale factor for pitch moment


### PR DESCRIPTION
Fixes #573 by adding a bCWexplicit flag to Vessel.h to track intentional definition of drag coefficients (initialized to false to fix the bug). The flag toggles true if any CW coefficients are parsed from a vessel's .cfg or if SetCW() is called from the API (ergo the Lua scripts that were originally tested). It's done this way instead of something like zero-defaulting CW values because doing it this way isn't a breaking change. Zeroing everything out would change physics behavior of all existing vessels that might rely on the legacy aero model without any explicit calls to the API. Many older addons would wind up unaffected obviously, but some might rely on the defaults.