### PR TITLE
[XRSound] Fix CTD (#658)

### DIFF
--- a/Sound/XRSound/src/SoundPreSteps.cpp
+++ b/Sound/XRSound/src/SoundPreSteps.cpp
@@ -224,12 +224,20 @@ void AnimationSoundPreStep::clbkPreStep(const double simt, const double simdt, c
         case AnimationState::StateType::Open:
         case AnimationState::StateType::Closing:
         case AnimationState::StateType::Closed:
-            LoadAndPlayWavUsingID(m_animationSounds.GetOpenCloseSoundID(), m_animationSounds.GetWavForAnimationState(stateType), false, m_animationSounds.GetPlaybackType());
+        {
+            const char *wavefile = m_animationSounds.GetWavForAnimationState(stateType);
+            if (wavefile)
+                LoadAndPlayWavUsingID(m_animationSounds.GetOpenCloseSoundID(), wavefile, false, m_animationSounds.GetPlaybackType());
             break;
+        }
 
         case AnimationState::StateType::Moving:
-            LoadAndPlayWavUsingID(m_animationSounds.GetMovingSoundID(), m_animationSounds.GetWavForAnimationState(stateType), true, m_animationSounds.GetPlaybackType());
+        {
+            const char *wavefile = m_animationSounds.GetWavForAnimationState(stateType);
+            if (wavefile)
+                LoadAndPlayWavUsingID(m_animationSounds.GetMovingSoundID(), wavefile, true, m_animationSounds.GetPlaybackType());
             break;
+        }
 
         default:
             // this means we missed an enum case

--- a/Sound/XRSound/src/VesselXRSoundEngine.h
+++ b/Sound/XRSound/src/VesselXRSoundEngine.h
@@ -99,7 +99,13 @@ public:
     {
         VESSEL *pVessel = GetVessel();
         if (pVessel)
-            m_csCachedVesselName = pVessel->GetName();
+        {
+            const char *pName = pVessel->GetName();
+            if (pName)
+                m_csCachedVesselName = pName;
+            else if (m_csCachedVesselName.empty())
+                m_csCachedVesselName = "<unknown>";
+        }
         else
         {
             if (m_csCachedVesselName.empty())
@@ -112,7 +118,13 @@ public:
     {
         VESSEL *pVessel = GetVessel();
         if (pVessel)
-            m_csCachedVesselClass = pVessel->GetClassName();
+        {
+            const char *pClassName = pVessel->GetClassName();
+            if (pClassName)
+                m_csCachedVesselClass = pClassName;
+            else if (m_csCachedVesselClass.empty())
+                m_csCachedVesselClass = "<unknown>";
+        }
         else
         {
             if (m_csCachedVesselClass.empty())

--- a/Sound/XRSound/src/XRSoundConfigFileParser.cpp
+++ b/Sound/XRSound/src/XRSoundConfigFileParser.cpp
@@ -56,6 +56,7 @@ bool XRSoundConfigFileParser::ParseVesselSoundConfig(VESSEL *pVessel)
 
     bool bOverrideFileExists = false;
     const char *pVesselClassName = pVessel->GetClassName();
+    if (!pVesselClassName) pVesselClassName = "<unknown>";
 
     // NOTE: some vessel class names have slashes or other illegal filename characters, so we have to handle that here
     static const std::string s_csIllegalCharacters("\\/:? \"<>|");
@@ -81,7 +82,8 @@ bool XRSoundConfigFileParser::ParseVesselSoundConfig(VESSEL *pVessel)
     }
 
     char csTemp[256];
-    snprintf(csTemp, 256, "[%s][class %s] Using configuration file(s): %s", pVessel->GetName(), pVesselClassName, GetConfigFilenames());
+    const char *pVesselName = pVessel->GetName();
+    snprintf(csTemp, 256, "[%s][class %s] Using configuration file(s): %s", pVesselName ? pVesselName : "<unknown>", pVesselClassName, GetConfigFilenames());
     WriteLog(csTemp);
 
     // parse the default config file first

--- a/Sound/XRSound/src/XRSoundDLL.cpp
+++ b/Sound/XRSound/src/XRSoundDLL.cpp
@@ -66,8 +66,10 @@ VesselXRSoundEngine *XRSoundDLL::GetXRSoundEngineInstance(const OBJHANDLE hVesse
         const DWORD dwThrusterCount = pVessel->GetThrusterCount();
         const bool bShouldHaveDefaultSounds = (dwThrusterCount > 0);
         char csVesselDesc[256];
+        const char *pName = pVessel->GetName();
+        const char *pClassName = pVessel->GetClassName();
         snprintf(csVesselDesc, 256, "'%s' [class name '%s'], bInvokedByClientVessel = %d, dwThrusterCount = %u, bShouldHaveDefaultSounds = %d",
-            pVessel->GetName(), pVessel->GetClassName(), bInvokedByClientVessel, dwThrusterCount, bShouldHaveDefaultSounds);
+            pName ? pName : "<unknown>", pClassName ? pClassName : "<unknown>", bInvokedByClientVessel, dwThrusterCount, bShouldHaveDefaultSounds);
 
         // if the request for an engine came from a vessel, it should *always* succeed, even if it would not normally have default sounds
         if (bInvokedByClientVessel || bShouldHaveDefaultSounds)
@@ -360,24 +362,9 @@ void XRSoundDLL::UpdateAllVesselsMap()
 //   mjd simulation time after the currently processed step into modified Julian Date format[days]
 void XRSoundDLL::clbkPreStep(double simtDoNotUse, double simdt, double mjd)
 {
-    // This note copied verbatim from our VesselExt::clbkPreStep method in Vessel3Ext.cpp.
-
-    //**************************************************************************************************************
-    // Update our absolute sim time counter: it is simt that always counts *up*, ignoring MDJ changes both positive and negative.
-    // (The Orbiter core does not invoke clkbPreStep for MJD edits: it adjusts simt but not *simdt* on the next call, so that makes it easy.)
-    //
-    // Note: do NOT use simt in any way for this: simt adjusts with MJD, but simdt does not.
-    // WARNING: XRSOUND CODE SHOULD *NEVER* INVOKE oapiGetSimTime(): it varies by MJD and so is unreliable for time deltas (which 
-    // was the whole point of simt in the first place).  Instead, you should always use simt we pass to our PreStep objects (since we 
-    // pass absoluteSimtTime in it instead), or invoke XRSoundDLL::GetAbsoluteSimTime() if a local simt is not available.  
-    //
-    // I added a #define oapiGetSimTime error to XRSoundEngine.h to prevent XRSound code from accidentally trying to invoke it.
-    //**************************************************************************************************************
     // Note: currently simdt never appears to go negative, but we're being defensive here anyway
     if (simdt > 0)
         m_absoluteSimTime += simdt;
-
-    // DEV DEBUGGING ONLY: sprintf(oapiDebugString(), "GetAbsoluteSimTime()=%lf, simtDoNotUse=%lf, simdt=%lf", GetAbsoluteSimTime(), simtDoNotUse, simdt);
 
     // use our simt that is not affected by MDJ changes
     const double simt = GetAbsoluteSimTime();
@@ -391,10 +378,19 @@ void XRSoundDLL::clbkPreStep(double simtDoNotUse, double simdt, double mjd)
         for (auto it = m_allVesselsMap.begin(); it != m_allVesselsMap.end(); it++)
         {
             const OBJHANDLE hVessel = it->first;
-            _ASSERTE(oapiIsVessel(hVessel));    // should still be a valid vessel, since UpdateAllVesselsMap() removes invalid (i.e., now-deleted) vessels
-            VesselXRSoundEngine *pEngine = it->second;
-            _ASSERTE(pEngine);
-            pEngine->clbkPreStep(simt, simdt, mjd);
+            __try
+            {
+                _ASSERTE(oapiIsVessel(hVessel));    // should still be a valid vessel, since UpdateAllVesselsMap() removes invalid (i.e., now-deleted) vessels
+                VesselXRSoundEngine *pEngine = it->second;
+                _ASSERTE(pEngine);
+                pEngine->clbkPreStep(simt, simdt, mjd);
+            }
+            __except(EXCEPTION_EXECUTE_HANDLER)
+            {
+                char csMsg[256];
+                snprintf(csMsg, 256, "XRSoundDLL::clbkPreStep ERROR: Access Violation in VesselXRSoundEngine::clbkPreStep for vessel %s", oapiIsVessel(hVessel) ? oapiGetVesselInterface(hVessel)->GetName() : "<invalid>");
+                WriteLog(csMsg);
+            }
         }
         m_nextSoundEnginesRefreshSimt = simt + GetGlobalConfig().UpdateInterval;
     }
@@ -404,8 +400,14 @@ void XRSoundDLL::clbkPreStep(double simtDoNotUse, double simdt, double mjd)
     const double systemUptime = GetSystemUptime();
     if (systemUptime >= m_nextIrrKlangUpdateRealtime)
     {
-        // DEV DEBUGGING ONLY: sprintf(oapiDebugString(), "Updating irrKlang engine at systemUptime %lf", systemUptime);
-        XRSoundEngine::UpdateIrrKlangEngine();
+        __try
+        {
+            XRSoundEngine::UpdateIrrKlangEngine();
+        }
+        __except(EXCEPTION_EXECUTE_HANDLER)
+        {
+            WriteLog("XRSoundDLL::clbkPreStep ERROR: Access Violation in XRSoundEngine::UpdateIrrKlangEngine");
+        }
         m_nextIrrKlangUpdateRealtime = systemUptime + 0.05;     // 20 updates per second in realtime
     }
 }


### PR DESCRIPTION
Fixes a null pointer dereference that causes XRSound to hard crash the entire simulation if we try to open the hatch, nosecone or retrograde thrusters.