### PR TITLE
[ExtMFD] Fix ExtMFD size amnesia

### DIFF
--- a/Src/Plugin/ExtMFD/MFDWindow.cpp
+++ b/Src/Plugin/ExtMFD/MFDWindow.cpp
@@ -20,6 +20,28 @@
 #include "imgui_extras.h"
 #include "IconsFontAwesome6.h"
 
+#include <vector>
+
+static std::vector<bool> g_usedWindowIds;
+
+int GetFreeWindowId() {
+	for (size_t i = 0; i < g_usedWindowIds.size(); ++i) {
+		if (!g_usedWindowIds[i]) {
+			g_usedWindowIds[i] = true;
+			return i + 1;
+		}
+	}
+	g_usedWindowIds.push_back(true);
+	return g_usedWindowIds.size();
+}
+
+void FreeWindowId(int id) {
+	int index = id - 1;
+	if (index >= 0 && index < (int)g_usedWindowIds.size()) {
+		g_usedWindowIds[index] = false;
+	}
+}
+
 // ==============================================================
 // class MFDWindow
 
@@ -72,7 +94,7 @@ void DlgExtMFD::Display() {
 	ImVec2 pos = mouse + offset;
 	ImGui::SetNextWindowPos(pos, ImGuiCond_FirstUseEver);
 
-	ImGui::SetNextWindowSize(ImVec2(defaultSize.width, defaultSize.height), ImGuiCond_Once);
+	ImGui::SetNextWindowSize(ImVec2(defaultSize.width, defaultSize.height), ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(382,366), ImVec2(FLT_MAX, FLT_MAX), AspectRatio, m_mfd);
 	
 	char cbuf[256] = ICON_FA_TABLET_SCREEN_BUTTON " MFD [";
@@ -207,16 +229,18 @@ void DlgExtMFD::OnDraw() {
 
 MFDWindow::MFDWindow(const MFDSPEC& spec) : ExternMFD(spec)
 {
+	m_windowId = GetFreeWindowId();
 	fnth = 0;
 	vstick = false;
 	char cbuf[128];
-	sprintf(cbuf, "ExtMFD%lld", (uint64_t)Id());
+	sprintf(cbuf, "ExtMFD_%d", m_windowId);
 	m_window = std::make_unique<DlgExtMFD>(cbuf, this);
 	oapiOpenDialog(m_window.get());
 }
 
 MFDWindow::~MFDWindow()
 {
+	FreeWindowId(m_windowId);
 }
 
 void MFDWindow::SetVessel(OBJHANDLE hV)

--- a/Src/Plugin/ExtMFD/MFDWindow.cpp
+++ b/Src/Plugin/ExtMFD/MFDWindow.cpp
@@ -24,7 +24,7 @@
 
 static std::vector<bool> g_usedWindowIds;
 
-int GetFreeWindowId() {
+static int GetFreeWindowId() {
 	for (size_t i = 0; i < g_usedWindowIds.size(); ++i) {
 		if (!g_usedWindowIds[i]) {
 			g_usedWindowIds[i] = true;
@@ -35,7 +35,7 @@ int GetFreeWindowId() {
 	return g_usedWindowIds.size();
 }
 
-void FreeWindowId(int id) {
+static void FreeWindowId(int id) {
 	int index = id - 1;
 	if (index >= 0 && index < (int)g_usedWindowIds.size()) {
 		g_usedWindowIds[index] = false;

--- a/Src/Plugin/ExtMFD/MFDWindow.h
+++ b/Src/Plugin/ExtMFD/MFDWindow.h
@@ -32,6 +32,7 @@ public:
 	float aspect_ratio = 382.0/366.0;
 
 private:
+	int m_windowId;
 	int BW, BH;       // button width and height
 	int fnth;         // button font height
 	bool vstick;      // stick to vessel


### PR DESCRIPTION
This PR fixes #355, an issue with ExtMFD from 3 years ago (sheesh). The core issues were actually two things:

While ImGuiCond_Once *sounds* like the correct flag, it just means something like "apply this rule the first time this code is executed per runtime session.". This obviously causes it to default out. The fix makes it so it only defaults if there's no saved size data for a specific window.

The second one was weird, basically the ImGui dialog's "name" was generated using the memory pointer of the MFDWindow instance - meaning that features like ASLR that are fairly standard these days force it to always think that it's a different window that needs a new name - so eventhough we save (after the first modification), we still are unable to retrieve the size info, so we default. I fixed this with a tiny and simple ID system for extmfd windows since that seemed like the easiest option.

