### PR TITLE
[Launchpad] Proper quicksave deletion confirmation

### DIFF
--- a/Src/Orbiter/TabScenario.cpp
+++ b/Src/Orbiter/TabScenario.cpp
@@ -666,9 +666,38 @@ INT_PTR CALLBACK orbiter::ScenarioTab::SaveProc (HWND hWnd, UINT uMsg, WPARAM wP
 //-----------------------------------------------------------------------------
 void orbiter::ScenarioTab::ClearQSFolder()
 {
+	fs::path scnpath{ fs::absolute(pLp->App()->ScnPath("Quicksave")) };
+	scnpath.replace_extension(); // remove ".scn"
+
+	std::string msg = "Are you sure you want to delete all quicksaves? This affects:\n";
+	int qsCount = 0;
+	
+	if (fs::exists(scnpath) && fs::is_directory(scnpath)) {
+		for (auto& entry : fs::directory_iterator(scnpath)) {
+			if (entry.is_regular_file() && entry.path().extension().string() == ".scn") {
+				qsCount++;
+				if (qsCount <= 10) {
+					msg += "- " + entry.path().stem().string() + "\n";
+				}
+			}
+		}
+	}
+	
+	if (qsCount == 0) {
+		MessageBox(LaunchpadWnd(), "There are no quicksaves to delete.", "Clear Quicksaves", MB_OK | MB_ICONINFORMATION);
+		return;
+	}
+	
+	if (qsCount > 10) {
+		msg += "... and " + std::to_string(qsCount - 10) + " more.\n";
+	}
+	
+	if (MessageBox(LaunchpadWnd(), msg.c_str(), "Clear Quicksaves", MB_YESNO | MB_ICONWARNING) != IDYES) {
+		return;
+	}
+
 #ifdef _WIN32
 	// SHFileOperation needs an absolute path
-	fs::path scnpath{ fs::absolute(pLp->App()->ScnPath("Quicksave")) };
 	scnpath.replace_extension(); // remove ".scn"
 	// pFrom needs to be null terminated twice
 	std::string strpath = scnpath.string() + '\0';
@@ -682,7 +711,6 @@ void orbiter::ScenarioTab::ClearQSFolder()
 		fs::create_directory(scnpath);
 	}
 #else
-	fs::path scnpath{ pLp->App()->ScnPath("Quicksave") };
 	scnpath.replace_extension(); // remove ".scn"
 
 	std::error_code ec;

--- a/Src/Orbiter/TabScenario.cpp
+++ b/Src/Orbiter/TabScenario.cpp
@@ -666,7 +666,7 @@ INT_PTR CALLBACK orbiter::ScenarioTab::SaveProc (HWND hWnd, UINT uMsg, WPARAM wP
 //-----------------------------------------------------------------------------
 void orbiter::ScenarioTab::ClearQSFolder()
 {
-	fs::path scnpath{ fs::absolute(pLp->App()->ScnPath("Quicksave")) };
+	fs::path scnpath{ pLp->App()->ScnPath("Quicksave") };
 	scnpath.replace_extension(); // remove ".scn"
 
 	std::string msg = "Are you sure you want to delete all quicksaves? This affects:\n";
@@ -696,29 +696,11 @@ void orbiter::ScenarioTab::ClearQSFolder()
 		return;
 	}
 
-#ifdef _WIN32
-	// SHFileOperation needs an absolute path
-	scnpath.replace_extension(); // remove ".scn"
-	// pFrom needs to be null terminated twice
-	std::string strpath = scnpath.string() + '\0';
-	SHFILEOPSTRUCT op;
-	op.hwnd = LaunchpadWnd();
-	op.wFunc = FO_DELETE;
-	op.pFrom = strpath.c_str();
-	op.pTo = NULL;
-	op.fFlags = FOF_ALLOWUNDO;
-	if(!SHFileOperation(&op)) {
-		fs::create_directory(scnpath);
-	}
-#else
-	scnpath.replace_extension(); // remove ".scn"
-
 	std::error_code ec;
 	fs::remove_all(scnpath, ec);
 	if (!ec) {
 		fs::create_directory(scnpath);
 	}
-#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
(Hopefully) sufficently fixes #600. The dialogs now look like this:
<img width="268" height="152" alt="Orbiter_XTzaRZXzDd" src="https://github.com/user-attachments/assets/e4f1a724-246f-452a-9644-9fdcc53ad8ac" />
<img width="300" height="200" alt="Orbiter_iObMCMtnQ1" src="https://github.com/user-attachments/assets/0a7b2fb9-d137-4b36-bb98-e50d5e483b12" />
<img width="400" height="152" alt="image" src="https://github.com/user-attachments/assets/e2da311d-8594-423c-bf47-18bcdea35a4b" />

If something else should be done about this I'd be happy to do it.
