### PR TITLE
[Core] Fix 20-year old ephemeris interpolation bug

### DIFF
--- a/Src/Celbody/Galsat/Galsat.cpp
+++ b/Src/Celbody/Galsat/Galsat.cpp
@@ -107,6 +107,17 @@ inline double Radius (double *data)
 	return sqrt (data[0]*data[0] + data[1]*data[1] + data[2]*data[2]);
 }
 
+// ===========================================================
+// Name: Interpolate()
+// Desc: Interpolates position and velocity using a Cubic 
+//       Hermite Spline. Replaces the old linear interpolation 
+//       method that was causing the interpolated velocity to 
+//       deviate from the derivative.
+//       Values returned in 'data' are the interpolated
+//       position (data[0..2]) and velocity (data[3..5]).
+//       't' is the time to interpolate at, bounded by
+//       samples 's0' and 's1'.
+// ===========================================================
 void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 {
 	int i;
@@ -116,28 +127,37 @@ void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 		for (i = 0; i < 6; i++) data[i] = s0->param[i];
 		return;
 	}
-
+	
+	// Step 1: Calculate the normalized time 'u' between the two sample points (range 0.0 to 1.0)
 	double u = (t - s0->t) / dt;
 	double u2 = u * u;
 	double u3 = u2 * u;
 
+	// Step 2: Compute the Hermite basis functions for position interpolation
 	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
 	double h10 = u3 - 2.0 * u2 + u;
 	double h01 = -2.0 * u3 + 3.0 * u2;
 	double h11 = u3 - u2;
 
+	// Step 3: Compute the derivatives of the Hermite basis functions for velocity interpolation
 	double dh00 = 6.0 * u2 - 6.0 * u;
 	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
 	double dh01 = -6.0 * u2 + 6.0 * u;
 	double dh11 = 3.0 * u2 - 2.0 * u;
 
+	// Step 4: Apply the basis functions to the position and velocity vectors
 	for (i = 0; i < 3; i++) {
 		double p0 = s0->param[i];
 		double p1 = s1->param[i];
+		
+		// Scale the endpoint velocities by the time interval (dt)
 		double v0 = s0->param[i+3] * dt;
 		double v1 = s1->param[i+3] * dt;
 
+		// Calculate final interpolated position
 		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		
+		// Calculate final interpolated velocity (un-scaled by dt)
 		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
 	}
 }

--- a/Src/Celbody/Galsat/Galsat.cpp
+++ b/Src/Celbody/Galsat/Galsat.cpp
@@ -112,16 +112,34 @@ void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 	int i;
 	double dt = s1->t - s0->t;
 
-	// step 1: linear interpolation
-	double fac = (t - s0->t) / dt;
-	for (i = 0; i < 6; i++)
-		data[i] = fac * (s1->param[i] - s0->param[i]) + s0->param[i];
+	if (dt == 0.0) {
+		for (i = 0; i < 6; i++) data[i] = s0->param[i];
+		return;
+	}
 
-	// step 2: radius interpolation
-	fac = ((t - s0->t)/dt * s1->rad + (s1->t - t)/dt * s0->rad)/Radius(data);
-	for (i = 0; i < 3; i++)
-		data[i] *= fac;
-	// Warning: velocities are not corrected here!
+	double u = (t - s0->t) / dt;
+	double u2 = u * u;
+	double u3 = u2 * u;
+
+	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
+	double h10 = u3 - 2.0 * u2 + u;
+	double h01 = -2.0 * u3 + 3.0 * u2;
+	double h11 = u3 - u2;
+
+	double dh00 = 6.0 * u2 - 6.0 * u;
+	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
+	double dh01 = -6.0 * u2 + 6.0 * u;
+	double dh11 = 3.0 * u2 - 2.0 * u;
+
+	for (i = 0; i < 3; i++) {
+		double p0 = s0->param[i];
+		double p1 = s1->param[i];
+		double v0 = s0->param[i+3] * dt;
+		double v1 = s1->param[i+3] * dt;
+
+		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
+	}
 }
 
 void SampleEphem (int ksat, double simt, double interval, double *ret, Sample *sp)

--- a/Src/Celbody/Moon/Moon.cpp
+++ b/Src/Celbody/Moon/Moon.cpp
@@ -114,6 +114,17 @@ int Moon::clbkFastEphemeris (double simt, int req, double *ret)
 	return req | (EPHEM_TRUEPOS | EPHEM_TRUEVEL | EPHEM_BARYISTRUE);
 }
 
+// ===========================================================
+// Name: Interpolate()
+// Desc: Interpolates position and velocity using a Cubic 
+//       Hermite Spline. Replaces the old linear interpolation 
+//       method that was causing the interpolated velocity to 
+//       deviate from the derivative.
+//       Values returned in 'data' are the interpolated
+//       position (data[0..2]) and velocity (data[3..5]).
+//       't' is the time to interpolate at, bounded by
+//       samples 's0' and 's1'.
+// ===========================================================
 void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 {
 	int i;
@@ -123,28 +134,37 @@ void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 		for (i = 0; i < 6; i++) data[i] = s0->param[i];
 		return;
 	}
-
+	
+	// Step 1: Calculate the normalized time 'u' between the two sample points (range 0.0 to 1.0)
 	double u = (t - s0->t) / dt;
 	double u2 = u * u;
 	double u3 = u2 * u;
 
+	// Step 2: Compute the Hermite basis functions for position interpolation
 	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
 	double h10 = u3 - 2.0 * u2 + u;
 	double h01 = -2.0 * u3 + 3.0 * u2;
 	double h11 = u3 - u2;
 
+	// Step 3: Compute the derivatives of the Hermite basis functions for velocity interpolation
 	double dh00 = 6.0 * u2 - 6.0 * u;
 	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
 	double dh01 = -6.0 * u2 + 6.0 * u;
 	double dh11 = 3.0 * u2 - 2.0 * u;
 
+	// Step 4: Apply the basis functions to the position and velocity vectors
 	for (i = 0; i < 3; i++) {
 		double p0 = s0->param[i];
 		double p1 = s1->param[i];
+		
+		// Scale the endpoint velocities by the time interval (dt)
 		double v0 = s0->param[i+3] * dt;
 		double v1 = s1->param[i+3] * dt;
 
+		// Calculate final interpolated position
 		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		
+		// Calculate final interpolated velocity (un-scaled by dt)
 		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
 	}
 }

--- a/Src/Celbody/Moon/Moon.cpp
+++ b/Src/Celbody/Moon/Moon.cpp
@@ -119,16 +119,34 @@ void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 	int i;
 	double dt = s1->t - s0->t;
 
-	// step 1: linear interpolation
-	double fac = (t - s0->t) / dt;
-	for (i = 0; i < 6; i++)
-		data[i] = fac * (s1->param[i] - s0->param[i]) + s0->param[i];
+	if (dt == 0.0) {
+		for (i = 0; i < 6; i++) data[i] = s0->param[i];
+		return;
+	}
 
-	// step 2: radius interpolation
-	fac = ((t - s0->t)/dt * s1->rad + (s1->t - t)/dt * s0->rad)/Radius(data);
-	for (i = 0; i < 3; i++)
-		data[i] *= fac;
-	// Warning: velocities are not corrected here!
+	double u = (t - s0->t) / dt;
+	double u2 = u * u;
+	double u3 = u2 * u;
+
+	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
+	double h10 = u3 - 2.0 * u2 + u;
+	double h01 = -2.0 * u3 + 3.0 * u2;
+	double h11 = u3 - u2;
+
+	double dh00 = 6.0 * u2 - 6.0 * u;
+	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
+	double dh01 = -6.0 * u2 + 6.0 * u;
+	double dh11 = 3.0 * u2 - 2.0 * u;
+
+	for (i = 0; i < 3; i++) {
+		double p0 = s0->param[i];
+		double p1 = s1->param[i];
+		double v0 = s0->param[i+3] * dt;
+		double v1 = s1->param[i+3] * dt;
+
+		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
+	}
 }
 
 

--- a/Src/Celbody/Satsat/Satsat.cpp
+++ b/Src/Celbody/Satsat/Satsat.cpp
@@ -128,16 +128,34 @@ static void Interpolate (double t, double *data, const Sample *s0, const Sample 
 	int i;
 	double dt = s1->t - s0->t;
 
-	// step 1: linear interpolation
-	double fac = (t - s0->t) / dt;
-	for (i = 0; i < 6; i++)
-		data[i] = fac * (s1->param[i] - s0->param[i]) + s0->param[i];
+	if (dt == 0.0) {
+		for (i = 0; i < 6; i++) data[i] = s0->param[i];
+		return;
+	}
 
-	// step 2: radius interpolation
-	fac = ((t - s0->t)/dt * s1->rad + (s1->t - t)/dt * s0->rad)/Radius(data);
-	for (i = 0; i < 3; i++)
-		data[i] *= fac;
-	// Warning: velocities are not corrected here!
+	double u = (t - s0->t) / dt;
+	double u2 = u * u;
+	double u3 = u2 * u;
+
+	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
+	double h10 = u3 - 2.0 * u2 + u;
+	double h01 = -2.0 * u3 + 3.0 * u2;
+	double h11 = u3 - u2;
+
+	double dh00 = 6.0 * u2 - 6.0 * u;
+	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
+	double dh01 = -6.0 * u2 + 6.0 * u;
+	double dh11 = 3.0 * u2 - 2.0 * u;
+
+	for (i = 0; i < 3; i++) {
+		double p0 = s0->param[i];
+		double p1 = s1->param[i];
+		double v0 = s0->param[i+3] * dt;
+		double v1 = s1->param[i+3] * dt;
+
+		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
+	}
 }
 
 void SampleEphem (int ksat, double simt, double *ret)

--- a/Src/Celbody/Satsat/Satsat.cpp
+++ b/Src/Celbody/Satsat/Satsat.cpp
@@ -123,6 +123,17 @@ inline double Radius (double *data)
 	return sqrt (data[0]*data[0] + data[1]*data[1] + data[2]*data[2]);
 }
 
+// ===========================================================
+// Name: Interpolate()
+// Desc: Interpolates position and velocity using a Cubic 
+//       Hermite Spline. Replaces the old linear interpolation 
+//       method that was causing the interpolated velocity to 
+//       deviate from the derivative.
+//       Values returned in 'data' are the interpolated
+//       position (data[0..2]) and velocity (data[3..5]).
+//       't' is the time to interpolate at, bounded by
+//       samples 's0' and 's1'.
+// ===========================================================
 static void Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 {
 	int i;
@@ -132,28 +143,37 @@ static void Interpolate (double t, double *data, const Sample *s0, const Sample 
 		for (i = 0; i < 6; i++) data[i] = s0->param[i];
 		return;
 	}
-
+	
+	// Step 1: Calculate the normalized time 'u' between the two sample points (range 0.0 to 1.0)
 	double u = (t - s0->t) / dt;
 	double u2 = u * u;
 	double u3 = u2 * u;
 
+	// Step 2: Compute the Hermite basis functions for position interpolation
 	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
 	double h10 = u3 - 2.0 * u2 + u;
 	double h01 = -2.0 * u3 + 3.0 * u2;
 	double h11 = u3 - u2;
 
+	// Step 3: Compute the derivatives of the Hermite basis functions for velocity interpolation
 	double dh00 = 6.0 * u2 - 6.0 * u;
 	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
 	double dh01 = -6.0 * u2 + 6.0 * u;
 	double dh11 = 3.0 * u2 - 2.0 * u;
 
+	// Step 4: Apply the basis functions to the position and velocity vectors
 	for (i = 0; i < 3; i++) {
 		double p0 = s0->param[i];
 		double p1 = s1->param[i];
+		
+		// Scale the endpoint velocities by the time interval (dt)
 		double v0 = s0->param[i+3] * dt;
 		double v1 = s1->param[i+3] * dt;
 
+		// Calculate final interpolated position
 		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		
+		// Calculate final interpolated velocity (un-scaled by dt)
 		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
 	}
 }

--- a/Src/Celbody/Vsop87/Vsop87.cpp
+++ b/Src/Celbody/Vsop87/Vsop87.cpp
@@ -273,17 +273,33 @@ void VSOPOBJ::Interpolate (double t, double *data, const Sample *s0, const Sampl
 	int i;
 	double dt = s1->t - s0->t;
 
-	// step 1: linear interpolation
-	double fac = (t - s0->t) / dt;
-	for (i = 0; i < 6; i++)
-		data[i] = fac * (s1->param[i] - s0->param[i]) + s0->param[i];
+	if (dt == 0.0) {
+		for (i = 0; i < 6; i++) data[i] = s0->param[i];
+		return;
+	}
 
-	if (!(fmtflag & EPHEM_POLAR)) {
-		// step 2: radius interpolation
-		fac = ((t - s0->t)/dt * s1->rad + (s1->t - t)/dt * s0->rad)/Radius(data);
-		for (i = 0; i < 3; i++)
-			data[i] *= fac;
-		// Warning: velocities are not corrected here!
+	double u = (t - s0->t) / dt;
+	double u2 = u * u;
+	double u3 = u2 * u;
+
+	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
+	double h10 = u3 - 2.0 * u2 + u;
+	double h01 = -2.0 * u3 + 3.0 * u2;
+	double h11 = u3 - u2;
+
+	double dh00 = 6.0 * u2 - 6.0 * u;
+	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
+	double dh01 = -6.0 * u2 + 6.0 * u;
+	double dh11 = 3.0 * u2 - 2.0 * u;
+
+	for (i = 0; i < 3; i++) {
+		double p0 = s0->param[i];
+		double p1 = s1->param[i];
+		double v0 = s0->param[i+3] * dt;
+		double v1 = s1->param[i+3] * dt;
+
+		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
 	}
 }
 

--- a/Src/Celbody/Vsop87/Vsop87.cpp
+++ b/Src/Celbody/Vsop87/Vsop87.cpp
@@ -268,6 +268,17 @@ void VSOPOBJ::VsopFastEphem (double simt, double *ret)
 	}
 }
 
+// ===========================================================
+// Name: Interpolate()
+// Desc: Interpolates position and velocity using a Cubic 
+//       Hermite Spline. Replaces the old linear interpolation 
+//       method that was causing the interpolated velocity to 
+//       deviate from the derivative.
+//       Values returned in 'data' are the interpolated
+//       position (data[0..2]) and velocity (data[3..5]).
+//       't' is the time to interpolate at, bounded by
+//       samples 's0' and 's1'.
+// ===========================================================
 void VSOPOBJ::Interpolate (double t, double *data, const Sample *s0, const Sample *s1)
 {
 	int i;
@@ -277,28 +288,37 @@ void VSOPOBJ::Interpolate (double t, double *data, const Sample *s0, const Sampl
 		for (i = 0; i < 6; i++) data[i] = s0->param[i];
 		return;
 	}
-
+	
+	// Step 1: Calculate the normalized time 'u' between the two sample points (range 0.0 to 1.0)
 	double u = (t - s0->t) / dt;
 	double u2 = u * u;
 	double u3 = u2 * u;
 
+	// Step 2: Compute the Hermite basis functions for position interpolation
 	double h00 = 2.0 * u3 - 3.0 * u2 + 1.0;
 	double h10 = u3 - 2.0 * u2 + u;
 	double h01 = -2.0 * u3 + 3.0 * u2;
 	double h11 = u3 - u2;
 
+	// Step 3: Compute the derivatives of the Hermite basis functions for velocity interpolation
 	double dh00 = 6.0 * u2 - 6.0 * u;
 	double dh10 = 3.0 * u2 - 4.0 * u + 1.0;
 	double dh01 = -6.0 * u2 + 6.0 * u;
 	double dh11 = 3.0 * u2 - 2.0 * u;
 
+	// Step 4: Apply the basis functions to the position and velocity vectors
 	for (i = 0; i < 3; i++) {
 		double p0 = s0->param[i];
 		double p1 = s1->param[i];
+		
+		// Scale the endpoint velocities by the time interval (dt)
 		double v0 = s0->param[i+3] * dt;
 		double v1 = s1->param[i+3] * dt;
 
+		// Calculate final interpolated position
 		data[i] = h00 * p0 + h10 * v0 + h01 * p1 + h11 * v1;
+		
+		// Calculate final interpolated velocity (un-scaled by dt)
 		data[i+3] = (dh00 * p0 + dh10 * v0 + dh01 * p1 + dh11 * v1) / dt;
 	}
 }


### PR DESCRIPTION
This small commit implements a Cubic Hermite Spline ephemeris method. The old method failed to correct for the velocity vector after adjusting the planet's path. It basically drew a straight line from point A to point B on a ellipse (which itself was done to save performance), cutting the corner, and after pushing the position of the body outwards to create the curved path it needed, it just left the velocity pointing along the original straight path. The CHS fixes this by taking into account all four pieces of information and "bending a smooth curve" between them. This mathematically guarantees that any attempts to calculate speed along any point of our curve will perfectly match the interpolated velocity variable.

Why is this important?

Because, while "high gravity" bodies naturally hide the consequences of this bug by essentially shrinking the size of the velocity error by having "close enough to a straight line" paths through space between interpolation points. Even on certain bodies where we would expect this behavior to kick in, the friction capacity of most vessels still hid this bug due to the bodies' inherently greater gravity, giving the ship massive grip that allowed fullstop landings anyway. So this bug really only showed up on *very* low gravity bodies with tight orbits, like Mimas.

Without this fix, full-stop landings on these bodies are simply impossible, because you will always be sliding along the surface through no fault of your own. For Mimas, this value comes out at exactly 0.17m/s. That's not insignificant and looks really jarring. Especially once we reach another interpolation point, the sliding vessel appears to "bounce" off of nothing in a completely random direction at the same velocity.