### PR TITLE
Add support to render surface labels to custom cameras

### DIFF
--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -3145,10 +3145,6 @@ void Scene::ExitGDIResources ()
 	oapiReleaseFont(pAxisFont);
 	oapiReleaseFont(pLabelFont);
 	oapiReleaseFont(pDebugFont);
-
-	for (int i = 0; i < 4; ++i) {
-		gc->clbkReleaseFont(label_font[i]);
-	}
 	
 	// Only delete the cache. The label_font are just weak refs!
 	for(auto &[size, font] : labelFontCache) {
@@ -3705,7 +3701,7 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 	RenderSecondaryScene(List, Lights, 0xFF);
 
 	// Render surface labels
-	if(/*cCur->dwFlags & CUSTOMCAM_SURFACE_LABELS*/ true)
+	if(cCur->dwFlags & CUSTOMCAM_SURFACE_LABELS)
 	{
 		RenderLabelsForCustomCamera();
 	}

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -120,6 +120,7 @@ Scene::Scene(D3D9Client *_gc, DWORD w, DWORD h)
 
 	SetCameraAperture(float(RAD*50.0), float(viewH)/float(viewW));
 	SetCameraFrustumLimits(2.5f, 5e6f); // initial limits
+	Camera.labelScale = 1.0f;
 
 	m_celSphere = new D3D9CelestialSphere(gc, this);
 	Lights = new D3D9Light[MAX_SCENE_LIGHTS];
@@ -3597,6 +3598,30 @@ void Scene::CustomCameraOnOff(CAMERAHANDLE hCamera, bool bOn)
 
 // ===========================================================================================
 //
+void Scene::RenderLabelsForCustomCamera()
+{
+	if(!surfLabelsActive)
+		return;
+	
+	vPlanet *planet = GetCameraProxyVisual();
+
+	if(!planet)
+		return;
+
+	D3D9Pad *skp = GetPooledSketchpad(SKETCHPAD_LABELS);
+
+	if(!skp)
+		return;
+
+	int fontidx = -1;
+	planet->RenderLabels(pDevice, skp, label_font, &fontidx);
+
+	skp->EndDrawing();
+
+}
+
+// ===========================================================================================
+//
 void Scene::RenderCustomCameraView(CAMREC *cCur)
 {
 	VESSEL *pVes = oapiGetVesselInterface(cCur->hVessel);
@@ -3631,6 +3656,10 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 	SetCameraFrustumLimits(0.1, 2e7);
 	SetupInternalCamera(&mEnv, &gpos, cCur->dAperture, double(h)/double(w));
 
+	// Copy target surface dimensions. This is needed so the surface label render path can correctly compute the projection
+	Camera.viewportW = w;
+	Camera.viewportH = h;
+	Camera.labelScale = max(1.0f, min(2.0f, (float)h / (float)viewH));
 	
 	VOBJREC *pv = NULL;
 	std::set<vVessel*> List;
@@ -3643,6 +3672,12 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 	gc->PushRenderTarget(pSrf, pDSs, RENDERPASS_CUSTOMCAM);
 
 	RenderSecondaryScene(List, Lights, 0xFF);
+
+	// Render surface labels
+	if(/*cCur->dwFlags & CUSTOMCAM_SURFACE_LABELS*/ true)
+	{
+		RenderLabelsForCustomCamera();
+	}
 
 	gc->PopRenderTargets();
 
@@ -3768,11 +3803,19 @@ bool Scene::CameraDirection2Viewport(const VECTOR3 &dir, int &x, int &y)
 	D3DXVECTOR3 idir = D3DXVECTOR3( -float(dir.x), -float(dir.y), -float(dir.z) );
 	D3DMAT_VectorMatrixMultiply(&homog, &idir, &Camera.mProjView);
 	if (homog.x >= -1.0f && homog.y <= 1.0f && homog.z >= 0.0) {
+		const DWORD width = Camera.viewportW != 0 ? Camera.viewportW : viewW;
+		const DWORD height = Camera.viewportH != 0 ? Camera.viewportH : viewH;
+
+		if(width == 0 || height == 0)
+		{
+			return false;
+		}
+
 		if (std::hypot(homog.x, homog.y) < 1e-6) {
-			x = viewW / 2, y = viewH / 2;
+			x = width / 2, y = height / 2;
 		} else {
-			x = (int)(viewW*0.5f*(1.0f + homog.x));
-			y = (int)(viewH*0.5f*(1.0f - homog.y));
+			x = (int)(width*0.5f*(1.0f + homog.x));
+			y = (int)(height*0.5f*(1.0f - homog.y));
 		}
 		return true;
 	}

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -3590,6 +3590,7 @@ CAMERAHANDLE Scene::SetupCustomCamera(CAMERAHANDLE hCamera, OBJHANDLE hVessel, M
 	pv->vPosition = pos;
 	pv->hVessel = hVessel;
 	pv->iError = 0;
+	pv->fSurfLabelScale = 1.0f;
 
 	return (CAMERAHANDLE)pv;
 }
@@ -3689,7 +3690,7 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 	// Copy target surface dimensions. This is needed so the surface label render path can correctly compute the projection
 	Camera.viewportW = w;
 	Camera.viewportH = h;
-	Camera.labelScale = max(1.0f, (float)h / (float)viewH) * 1.5f;
+	Camera.labelScale = cCur->fSurfLabelScale;
 	
 	VOBJREC *pv = NULL;
 	std::set<vVessel*> List;
@@ -3713,6 +3714,23 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 
 	PopPass();
 	PopCamera();
+}
+
+void Scene::SetCustomCameraSurfaceLabelScale(CAMERAHANDLE hCamera, float scale)
+{
+	if(!hCamera) {
+		return;
+	}
+
+	if(scale <= 0.0f || !std::isfinite(scale)) {
+		return;
+	}
+
+	CAMREC* camera = CAMERA(hCamera);
+
+	camera->fSurfLabelScale = std::clamp(scale, 0.25f, 8.0f);
+
+	return;
 }
 
 

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -51,6 +51,8 @@ D3DXHANDLE Scene::eTex0 = 0;
 
 D3DXVECTOR4 IKernel[IKernelSize];
 
+static const int FONT_SIZES[4] = { 12, 16, 20, 26 };
+
 bool sort_vessels(const vVessel *a, const vVessel *b)
 {
 	return a->CameraTgtDist() < b->CameraTgtDist();
@@ -3130,10 +3132,11 @@ void Scene::InitGDIResources ()
 	pLabelFont = oapiCreateFont(15, false, "Arial", FONT_NORMAL, 0);
 	pDebugFont = oapiCreateFont(Config->DebugFontSize, true, dbgfnt, FONT_NORMAL, 0);
 
-	const int fsize[4] = { 12, 16, 20, 26 };
 	for (int i = 0; i < 4; ++i) {
-		label_font[i] = gc->clbkCreateFont(fsize[i], true, "Arial", FONT_BOLD);
+		label_font[i] = CreateLabelFont(FONT_SIZES[i]);
+		label_font_scaled[i] = NULL;
 	}
+	labelScaleCached = 0.0f;
 	//@todo: different pens for different fonts?
 }
 
@@ -3147,6 +3150,7 @@ void Scene::ExitGDIResources ()
 
 	for (int i = 0; i < 4; ++i) {
 		gc->clbkReleaseFont(label_font[i]);
+		if (label_font_scaled[i]) gc->clbkReleaseFont(label_font_scaled[i]);
 	}
 }
 
@@ -3598,6 +3602,13 @@ void Scene::CustomCameraOnOff(CAMERAHANDLE hCamera, bool bOn)
 
 // ===========================================================================================
 //
+Font* Scene::CreateLabelFont(int size)
+{
+	return gc->clbkCreateFont(size, true, "Arial", FONT_BOLD);
+}
+
+// ===========================================================================================
+//
 void Scene::RenderLabelsForCustomCamera()
 {
 	if(!surfLabelsActive)
@@ -3613,8 +3624,20 @@ void Scene::RenderLabelsForCustomCamera()
 	if(!skp)
 		return;
 
+	const float labelScale = Camera.labelScale;
+
+	if (labelScale != labelScaleCached) {
+		for (int i = 0; i < 4; ++i) {
+			if (label_font_scaled[i]) gc->clbkReleaseFont(label_font_scaled[i]);
+			label_font_scaled[i] = CreateLabelFont((int)(FONT_SIZES[i] * labelScale));
+		}
+		labelScaleCached = labelScale;
+	}
+
+	skp->QuickPen(RGB(255, 255, 255), labelScale);
+
 	int fontidx = -1;
-	planet->RenderLabels(pDevice, skp, label_font, &fontidx);
+	planet->RenderLabels(pDevice, skp, label_font_scaled, &fontidx);
 
 	skp->EndDrawing();
 
@@ -3659,7 +3682,7 @@ void Scene::RenderCustomCameraView(CAMREC *cCur)
 	// Copy target surface dimensions. This is needed so the surface label render path can correctly compute the projection
 	Camera.viewportW = w;
 	Camera.viewportH = h;
-	Camera.labelScale = max(1.0f, min(2.0f, (float)h / (float)viewH));
+	Camera.labelScale = max(1.0f, (float)h / (float)viewH) * 1.5f;
 	
 	VOBJREC *pv = NULL;
 	std::set<vVessel*> List;

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -3133,10 +3133,8 @@ void Scene::InitGDIResources ()
 	pDebugFont = oapiCreateFont(Config->DebugFontSize, true, dbgfnt, FONT_NORMAL, 0);
 
 	for (int i = 0; i < 4; ++i) {
-		label_font[i] = CreateLabelFont(FONT_SIZES[i]);
-		label_font_scaled[i] = NULL;
+		label_font[i] = GetOrCreateLabelFont(FONT_SIZES[i]);
 	}
-	labelScaleCached = 0.0f;
 	//@todo: different pens for different fonts?
 }
 
@@ -3150,7 +3148,11 @@ void Scene::ExitGDIResources ()
 
 	for (int i = 0; i < 4; ++i) {
 		gc->clbkReleaseFont(label_font[i]);
-		if (label_font_scaled[i]) gc->clbkReleaseFont(label_font_scaled[i]);
+	}
+	
+	// Only delete the cache. The label_font are just weak refs!
+	for(auto &[size, font] : labelFontCache) {
+		gc->clbkReleaseFont(font);
 	}
 }
 
@@ -3602,9 +3604,16 @@ void Scene::CustomCameraOnOff(CAMERAHANDLE hCamera, bool bOn)
 
 // ===========================================================================================
 //
-Font* Scene::CreateLabelFont(int size)
+Font* Scene::GetOrCreateLabelFont(int size)
 {
-	return gc->clbkCreateFont(size, true, "Arial", FONT_BOLD);
+	auto it = labelFontCache.find(size);
+	if(it == labelFontCache.end())
+	{
+		Font* newFont = gc->clbkCreateFont(size, true, "Arial", FONT_BOLD);
+		it = labelFontCache.emplace(size, newFont).first;
+	}
+
+	return it->second;
 }
 
 // ===========================================================================================
@@ -3626,21 +3635,19 @@ void Scene::RenderLabelsForCustomCamera()
 
 	const float labelScale = Camera.labelScale;
 
-	if (labelScale != labelScaleCached) {
-		for (int i = 0; i < 4; ++i) {
-			if (label_font_scaled[i]) gc->clbkReleaseFont(label_font_scaled[i]);
-			label_font_scaled[i] = CreateLabelFont((int)(FONT_SIZES[i] * labelScale));
-		}
-		labelScaleCached = labelScale;
-	}
-
+	// Set-up pen before calling Label rendering logic. Otherwise the marks were not visible
 	skp->QuickPen(RGB(255, 255, 255), labelScale);
 
+	Font* fonts[4];
+	for (int i = 0; i < 4; i++) {
+		// Retrieve cached fonts or create them new. This prevents recreating fonts when having different custom cameras at the cost of O(log n) access
+		fonts[i] = GetOrCreateLabelFont((int)(FONT_SIZES[i] * labelScale));
+	}
+
 	int fontidx = -1;
-	planet->RenderLabels(pDevice, skp, label_font_scaled, &fontidx);
+	planet->RenderLabels(pDevice, skp, fonts, &fontidx);
 
 	skp->EndDrawing();
-
 }
 
 // ===========================================================================================

--- a/OVP/D3D9Client/Scene.h
+++ b/OVP/D3D9Client/Scene.h
@@ -445,6 +445,7 @@ private:
 	void FreePooledSketchpads();      ///< Release pooled Sketchpad instances
 
 	void RenderLabelsForCustomCamera();
+	Font* CreateLabelFont(int size);
 
 
 
@@ -470,6 +471,8 @@ private:
 	// GDI resources ====================================================================
 	//
 	oapi::Font *label_font[4];
+	oapi::Font *label_font_scaled[4];
+	float labelScaleCached;
 
 	std::list<vVessel *> RenderList;
 	std::list<vVessel *> SmapRenderList;

--- a/OVP/D3D9Client/Scene.h
+++ b/OVP/D3D9Client/Scene.h
@@ -445,7 +445,7 @@ private:
 	void FreePooledSketchpads();      ///< Release pooled Sketchpad instances
 
 	void RenderLabelsForCustomCamera();
-	Font* CreateLabelFont(int size);
+	Font* GetOrCreateLabelFont(int size);
 
 
 
@@ -471,8 +471,7 @@ private:
 	// GDI resources ====================================================================
 	//
 	oapi::Font *label_font[4];
-	oapi::Font *label_font_scaled[4];
-	float labelScaleCached;
+	std::map<int, oapi::Font*> labelFontCache;
 
 	std::list<vVessel *> RenderList;
 	std::list<vVessel *> SmapRenderList;

--- a/OVP/D3D9Client/Scene.h
+++ b/OVP/D3D9Client/Scene.h
@@ -148,6 +148,13 @@ public:
 
 		double		alt_near;
 		double		lng, lat, elev;
+
+		// Pixel viewport associated with the current camera.
+		// Uses main scene viewport when zero
+		DWORD viewportW;
+		DWORD viewportH;
+		// Scale for 2D Labels
+		float labelScale;
 	};
 
 	// Screen space sun visual parameters ==================================================
@@ -436,6 +443,8 @@ private:
 	void ExitGDIResources();
 
 	void FreePooledSketchpads();      ///< Release pooled Sketchpad instances
+
+	void RenderLabelsForCustomCamera();
 
 
 

--- a/OVP/D3D9Client/Scene.h
+++ b/OVP/D3D9Client/Scene.h
@@ -106,6 +106,7 @@ public:
 		bool		bActive;
 		__gcRenderProc pRenderProc;
 		void*		pUser;
+		float       fSurfLabelScale;
 	};
 
 	std::set<CAMREC*> CustomCams;
@@ -325,6 +326,7 @@ public:
 	int				DeleteCustomCamera(CAMERAHANDLE hCamera);
 	void			DeleteAllCustomCameras();
 	void			CustomCameraOnOff(CAMERAHANDLE hCamera, bool bOn);
+	void 			SetCustomCameraSurfaceLabelScale(CAMERAHANDLE hCamera, float scale);
 	void			RenderCustomCameraView(CAMREC *cCur);
 
 

--- a/OVP/D3D9Client/TileLabel.cpp
+++ b/OVP/D3D9Client/TileLabel.cpp
@@ -279,6 +279,8 @@ void TileLabel::Render (D3D9Pad *skp, oapi::Font **labelfont, int *fontidx)
 	MATRIX3 Rpl;
 	oapiGetRotationMatrix(hPlanet, &Rpl);            // planet rotation matrix
 	VECTOR3 campos = tmul(Rpl, *Pcam - Ppl);         // camera pos in planet frame
+	
+	const float labelScale = pScene->GetCamera()->labelScale;
 
 	Tick();
 

--- a/OVP/D3D9Client/TileLabel.cpp
+++ b/OVP/D3D9Client/TileLabel.cpp
@@ -293,7 +293,7 @@ void TileLabel::Render (D3D9Pad *skp, oapi::Font **labelfont, int *fontidx)
 				skp->SetFont(labelfont[idx]);
 				*fontidx = idx;
 			}
-			scale = symscale[idx];
+			scale = max(1, int(symscale[idx] * labelScale));
 			sp = mul(Rpl, renderlabel[i]->pos) + Ppl - *Pcam;
 			dir = unit(sp);
 			if (pScene->CameraDirection2Viewport(dir, x, y)) {

--- a/OVP/D3D9Client/gcCore.cpp
+++ b/OVP/D3D9Client/gcCore.cpp
@@ -46,6 +46,7 @@ DLLCLBK void gcBindCoreMethod(void** ppFnc, const char* name)
 	if (strcmp(name,"DeleteCustomCamera")==0) *ppFnc = &gcCore2::DeleteCustomCamera;
 	if (strcmp(name,"CustomCameraOnOff")==0) *ppFnc = &gcCore2::CustomCameraOnOff;
 	if (strcmp(name,"CustomCameraOverlay")==0) *ppFnc = &gcCore2::CustomCameraOverlay;
+	if (strcmp(name,"SetCustomCameraSurfaceLabelScale")==0) *ppFnc = &gcCore2::SetCustomCameraSurfaceLabelScale;
 	if (strcmp(name,"SetupCustomCamera")==0) *ppFnc = &gcCore2::SetupCustomCamera;
 	if (strcmp(name,"SketchpadVersion")==0) *ppFnc = &gcCore2::SketchpadVersion;
 	if (strcmp(name,"CreatePoly")==0) *ppFnc = &gcCore2::CreatePoly;
@@ -220,6 +221,16 @@ int gcCore::DeleteCustomCamera(CAMERAHANDLE hCam)
 	return pScene ? pScene->DeleteCustomCamera(hCam) : 0;
 }
 
+// ===============================================================================================
+//
+void gcCore::SetCustomCameraSurfaceLabelScale(CAMERAHANDLE hCam, float scale)
+{
+	Scene* pScene = g_client->GetScene();
+
+	if(pScene) {
+		pScene->SetCustomCameraSurfaceLabelScale(hCam, scale);
+	}
+}
 
 
 

--- a/OVP/D3D9Client/gcCore.h
+++ b/OVP/D3D9Client/gcCore.h
@@ -95,6 +95,7 @@ static class gcCore2 *pCoreInterface = NULL;
 /// \defgroup dwFlags for gcSetupCustomCamera() API function
 ///@{
 #define CUSTOMCAM_DEFAULTS				0x00FF
+#define CUSTOMCAM_SURFACE_LABELS        0x0100
 ///@}
 
 /// \defgroup Polyline Polyline object creation and update flags

--- a/OVP/D3D9Client/gcCore.h
+++ b/OVP/D3D9Client/gcCore.h
@@ -426,6 +426,13 @@ public:
 	gc_interface void CustomCameraOverlay(CAMERAHANDLE hCam, __gcRenderProc clbk, void* pUser);
 
 	/**
+	 * \brief Sets the scale at which the surface labels are to be rendered for this camera. Can be used to adapt it to the real screen size of the target surface
+	 * \param hCam camera handle to modify the surface label scale
+	 * \param scale scale factor to apply
+	 */
+	gc_interface void SetCustomCameraSurfaceLabelScale(CAMERAHANDLE hCam, float scale);
+
+	/**
 	* \brief Create a new custom camera that can be used to render views into a surfaces and textures
 	* \param hCam camera handle to modify an existing camera or, NULL
 	* \param hVessel handle to a vessel where the camera is attached to.


### PR DESCRIPTION
This changes the Custom Camera render path to support rendering surface labels when a respective flag is set at camera creation.
Additionally, a scale can be set from the gcCore API. This is needed because we don't know how the target surface will be scaled on the actual screen later on, so the client of the custom camera needs to scale up the surface labels so they are readable.
The scale is applied to the symbols as well as on the fonts. For the fonts a cache of bigger fonts is created and used.
While there are other solutions that work and might take less resources, e.g. I did a small change to render the text to a sprite before rendering it to the sketchpad. This makes it sensitive to the sketchpads transform matrix and the font is upscaled too.
 
But this is a more invasive approach into the general text render path, while my requested approach only changes Custom Camera and Label Rendering logic, on the cost of keeping bigger fonts in memory and rendering them.

Additionally the Camera structures need to carry that scale information and also the dimensions of the render target.
This is because the projection logic of the Label Renderer needs to know the viewport dimensions.

In general I tried to minimize invasiveness and kept it backwards compatible, so no interface should break.

The reason for this change is that in the NASSP Apollo Project the superimposition technique on the optics sextant uses a custom camera. The user cannot spot landmarks then anymore. This allows to still render them, and resize them according to the size of the custom camera rendered texture on the screen.