### PR TITLE
Bump D3D9 CXX standard to get std::clamp

### DIFF
--- a/OVP/D3D9Client/CMakeLists.txt
+++ b/OVP/D3D9Client/CMakeLists.txt
@@ -5,8 +5,8 @@ configure_file(D3D9ClientConfig.h.in D3D9ClientConfig.h)
 FetchContent_MakeAvailable(imgui)
 
 # specify the C++ standard
-# set(CMAKE_CXX_STANDARD 11)
-# set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(DXSDK_LIB_DIR ${DXSDK_DIR}/lib/${ARCH})
 set(DXSDK_LIB_DIR2 "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/${ARCH}")  #Must acquire d3d9.lib from here

--- a/OVP/D3D9Client/Scene.cpp
+++ b/OVP/D3D9Client/Scene.cpp
@@ -22,6 +22,7 @@
 #include "DebugControls.h"
 #include "IProcess.h"
 #include "VectorHelpers.h"
+#include <algorithm>
 #include <sstream>
 #include <vector>
 


### PR DESCRIPTION
In an effort to resolve the compile error on current main